### PR TITLE
Fixes for building with GCC and working on Linux

### DIFF
--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -172,10 +172,10 @@ std::vector<LandVertex> LandIsland::getVerticies()
 				glm::vec2 uvBL(x / 16.0f, (y+1) / 16.0f);
 				glm::vec2 uvBR((x+1) / 16.0f, (y+1) / 16.0f);
 
-				auto tlMat = _countries[tl.Country()].MapMaterial[tl.Altitude()];
-				auto trMat = _countries[tr.Country()].MapMaterial[tr.Altitude()];
-				auto blMat = _countries[bl.Country()].MapMaterial[bl.Altitude()];
-				auto brMat = _countries[br.Country()].MapMaterial[br.Altitude()];
+				auto tlMat = _countries[tl.Country()].MapMaterials[tl.Altitude()];
+				auto trMat = _countries[tr.Country()].MapMaterials[tr.Altitude()];
+				auto blMat = _countries[bl.Country()].MapMaterials[bl.Altitude()];
+				auto brMat = _countries[br.Country()].MapMaterials[br.Altitude()];
 
 				// triangle one: TL -> TR -> BR
 				verts.push_back(LandVertex(pTL, uvTL, glm::vec3(1.0f, 0.0f, 0.0f),

--- a/src/3D/LandIsland.h
+++ b/src/3D/LandIsland.h
@@ -28,7 +28,7 @@ namespace OpenBlack
 	struct Country
 	{
 		uint32_t TerrainType;
-		MapMaterial MapMaterial[256]; // altitude 0-255
+		MapMaterial MapMaterials[256]; // altitude 0-255
 	};
 
 	#pragma pack(push, 1)

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -93,7 +93,11 @@ void Game::Run()
 	_camera->SetPosition(glm::vec3(2458.0f, 169.0f, 1743.0f));
 	_camera->SetRotation(glm::vec3(104.0f, 15.0f, 0.0f));
 
+#ifdef _WIN32
 	LoadMap(GetGamePath() + "\\Data\\Landscape\\Land1.lnd");
+#else
+	LoadMap(GetGamePath() + "/Data/Landscape/Land1.lnd");
+#endif // _WIN32
 	//LoadMap("Land1.lnd");
 
 	/* we pass the unique_ptr straight to the Script, so do not reuse this */
@@ -111,7 +115,11 @@ void Game::Run()
 	_scriptx->SetCommands(commands);
 
 	//_scriptx->ScanLine("VERSION(\"LOL\")");
+#ifdef _WIN32
 	_scriptx->LoadFile(GetGamePath() + "\\Scripts\\Land1.txt");
+#else
+	_scriptx->LoadFile(GetGamePath() + "/Scripts/Land1.txt");
+#endif // _WIN32
 
 	//LHScriptX* script = new LHScriptX();
 	//script->LoadFile(GetGamePath() + "\\Scripts\\Land1.txt");

--- a/src/GameWindow.h
+++ b/src/GameWindow.h
@@ -2,6 +2,7 @@
 #ifndef OPENBLACK_GAMEWINDOW_H
 #define OPENBLACK_GAMEWINDOW_H
 
+#include <memory>
 #include <string>
 #include <cstdint>
 #include <SDL.h>

--- a/src/Graphics/Shader.cpp
+++ b/src/Graphics/Shader.cpp
@@ -1,3 +1,7 @@
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+
 #include <Graphics/Shader.h>
 
 using namespace OpenBlack::Graphics;

--- a/src/LHScriptX/Script.h
+++ b/src/LHScriptX/Script.h
@@ -4,6 +4,7 @@
 
 #include <LHScriptX/Command.h>
 
+#include <memory>
 #include <list>
 
 namespace OpenBlack {


### PR DESCRIPTION
- MapMaterial refers both to a type (struct) and a variable (member of struct Country). I had to rename it to compile with gcc. It is probably a good practice to do so.
- Some c functions were used without proper includes
- The use of backslash in paths is only compatible with windows, so I added an `#ifdef` for Unices