### PR TITLE
readme: use more modern cmake command for linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,8 @@ sudo apt install cmake libglew-dev libsdl2-dev libglm-dev
 Then to build run CMake in a build directory:
 
 ```bash
-mkdir build && cd build
-cmake ../
-make
+cmake -S . -B build
+cmake --build build
 ```
 
 **Mesa drivers on Linux:** if you are trying to run with Mesa drivers and are getting issues with OpenGL context try messing with `MESA_GL_VERSION_OVERRIDE` when running like so: `MESA_GL_VERSION_OVERRIDE=4.3FC MESA_GLSL_VERSION_OVERRIDE=430 bin/donut`


### PR DESCRIPTION
the more modern cmake command can also be used on Windows with MSVC
toolchain, only the generator must be specified

```
cmake -S . -B build -G "Visual Studio 16 2019" -A x64
cmake --build build
```