### PR TITLE
use snprintf because iota is not ansi C

### DIFF
--- a/src/3D/MeshPack.cpp
+++ b/src/3D/MeshPack.cpp
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <stdexcept>
 #include <stdint.h>
+#include <stdlib.h> // snprintf
 
 namespace OpenBlack
 {
@@ -158,7 +159,7 @@ void MeshPack::loadTextures(File& file)
 	char sBlockID[4];
 	for (auto const& tex : textureTypeMap)
 	{
-		itoa(tex.first, sBlockID, 16);
+		snprintf(sBlockID, sizeof(sBlockID), "%x", tex.first);
 
 		auto const& textureBlock = _blocks.find(sBlockID);
 		if (textureBlock == _blocks.end())


### PR DESCRIPTION
got error
```
/home/nero/repos/openblack/src/3D/MeshPack.cpp: In member function ‘void OpenBlack::MeshPack::loadTextures(OpenBlack::File&)’:
/home/nero/repos/openblack/src/3D/MeshPack.cpp:162:3: error: ‘itoa’ was not declared in this scope
  162 |   itoa(tex.first, sBlockID, 16);
      |   ^~~~
```

```
g++ --version
gcc (GCC) 9.1.0
```

alternative (and info that iota is not ansi C from here:
https://stackoverflow.com/a/6462973

Edit: got a CI job with the error, exciting :)
https://travis-ci.org/NeroBurner/openblack/jobs/579247589