### PR TITLE
Fix include guards

### DIFF
--- a/components/ScriptLibrary/include/LHVM/LHVM.h
+++ b/components/ScriptLibrary/include/LHVM/LHVM.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_SCRIPTLIBRARY_LHVM_LHVMH
-#define OPENBLACK_SCRIPTLIBRARY_LHVM_LHVMH
 
 #include <string>
 #include <vector>
@@ -67,5 +65,3 @@ private:
 
 }
 }
-
-#endif

--- a/components/ScriptLibrary/include/LHVM/OpcodeNames.h
+++ b/components/ScriptLibrary/include/LHVM/OpcodeNames.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_SCRIPTLIBRARY_LHVM_OPCODENAMESH
-#define OPENBLACK_SCRIPTLIBRARY_LHVM_OPCODENAMESH
 
 #include <array>
 
@@ -63,5 +61,3 @@ static const std::array<std::string, 31> Opcode_Names = {
 
 }
 }
-
-#endif

--- a/components/ScriptLibrary/include/LHVM/VMInstruction.h
+++ b/components/ScriptLibrary/include/LHVM/VMInstruction.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_SCRIPTLIBRARY_LHVM_VMINSTRUCTIONH
-#define OPENBLACK_SCRIPTLIBRARY_LHVM_VMINSTRUCTIONH
 
 #include <stdint.h>
 #include <string>
@@ -60,5 +58,3 @@ private:
 
 }
 }
-
-#endif

--- a/components/ScriptLibrary/include/LHVM/VMScript.h
+++ b/components/ScriptLibrary/include/LHVM/VMScript.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_SCRIPTLIBRARY_LHVM_VMSCRIPTH
-#define OPENBLACK_SCRIPTLIBRARY_LHVM_VMSCRIPTH
 
 #include <string>
 #include <vector>
@@ -58,5 +56,3 @@ private:
 
 }
 }
-
-#endif

--- a/components/ScriptLibrary/include/LHVM/VMTask.h
+++ b/components/ScriptLibrary/include/LHVM/VMTask.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_SCRIPTLIBRARY_LHVM_TASKH
-#define OPENBLACK_SCRIPTLIBRARY_LHVM_TASKH
 
 namespace OpenBlack {
 namespace LHVM {
@@ -31,5 +29,3 @@ class VMTask {
 
 }
 }
-
-#endif

--- a/src/3D/Camera.h
+++ b/src/3D/Camera.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_CAMERA_H
-#define OPENBLACK_CAMERA_H
 
 #include <SDL_events.h>
 #include <glm/glm.hpp>
@@ -78,5 +76,3 @@ class Camera
 	float _freeLookSensitivity;
 };
 } // namespace OpenBlack
-
-#endif

--- a/src/3D/Hand.h
+++ b/src/3D/Hand.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_3D_HAND_H
-#define OPENBLACK_3D_HAND_H
 
 #include <3D/SkinnedModel.h>
 #include <Graphics/Mesh.h>
@@ -42,5 +40,3 @@ class Hand
 	std::unique_ptr<SkinnedModel> m_HandModel;
 };
 } // namespace OpenBlack
-
-#endif

--- a/src/3D/LandCell.h
+++ b/src/3D/LandCell.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_LANDCELL_H
-#define OPENBLACK_LANDCELL_H
 
 #include <Common/Types.h>
 
@@ -63,5 +61,3 @@ class LandCell
 };
 #pragma pack(pop)
 } // namespace OpenBlack
-
-#endif

--- a/src/3D/SkinnedModel.h
+++ b/src/3D/SkinnedModel.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_SKINNEDMODEL_H
-#define OPENBLACK_SKINNEDMODEL_H
 
 #include <Graphics/Mesh.h>
 #include <Graphics/ShaderProgram.h>
@@ -84,5 +82,3 @@ class SkinnedModel
 	std::vector<SkinnedModel_Bone>& GetBones() { return _bones; }
 };
 } // namespace OpenBlack
-
-#endif

--- a/src/3D/Sky.h
+++ b/src/3D/Sky.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_3D_SKY_H
-#define OPENBLACK_3D_SKY_H
 
 #include <3D/Camera.h>
 #include <3D/SkinnedModel.h>
@@ -49,5 +47,3 @@ class Sky
 };
 
 } // namespace OpenBlack
-
-#endif

--- a/src/3D/Water.h
+++ b/src/3D/Water.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_3D_WATER_H
-#define OPENBLACK_3D_WATER_H
 
 #include <3D/Camera.h>
 #include <Graphics/Mesh.h>
@@ -78,5 +76,3 @@ class Water
 };
 
 } // namespace OpenBlack
-
-#endif

--- a/src/AllMeshes.h
+++ b/src/AllMeshes.h
@@ -18,8 +18,7 @@
  * along with OpenBlack. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _ALL_MESHES_AND_ANIMS_H_
-#define _ALL_MESHES_AND_ANIMS_H_
+#pragma once
 
 //  626 Meshes.
 //  441 Anims.

--- a/src/Common/Bitmap16B.h
+++ b/src/Common/Bitmap16B.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_BITMAP16_H
-#define OPENBLACK_BITMAP16_H
 
 #include <stdint.h>
 #include <string>
@@ -50,5 +48,3 @@ class Bitmap16B
 };
 
 } // namespace OpenBlack
-
-#endif

--- a/src/Common/CmdLineArgs.h
+++ b/src/Common/CmdLineArgs.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_COMMON_CMDLINEARGS_H
-#define OPENBLACK_COMMON_CMDLINEARGS_H
 
 #include <sstream>
 #include <string>
@@ -110,5 +108,3 @@ inline bool CmdLineArgs::ArgValue::ValueAs<bool>() const
 	return AsBool();
 }
 } // namespace OpenBlack
-
-#endif

--- a/src/Common/Types.h
+++ b/src/Common/Types.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_TYPES_H
-#define OPENBLACK_TYPES_H
 
 #include <glm/glm.hpp>
 #include <stdint.h>
@@ -40,5 +38,3 @@ typedef struct rgba
 	uint8_t b;
 	uint8_t a;
 } rgba_t;
-
-#endif

--- a/src/Game.h
+++ b/src/Game.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_GAME_H
-#define OPENBLACK_GAME_H
 
 #include "GameWindow.h"
 
@@ -121,5 +119,3 @@ class Game
 	void guiLoop();
 };
 } // namespace OpenBlack
-
-#endif

--- a/src/GameWindow.h
+++ b/src/GameWindow.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_GAMEWINDOW_H
-#define OPENBLACK_GAMEWINDOW_H
 
 #include <SDL.h>
 #include <cstdint>
@@ -94,5 +92,3 @@ class GameWindow
 	std::unique_ptr<SDL_GLContext, SDLDestroyer> _glcontext;
 };
 } // namespace OpenBlack
-
-#endif

--- a/src/GitSHA1.h
+++ b/src/GitSHA1.h
@@ -18,4 +18,5 @@
  * along with OpenBlack. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
 extern const char* kGitSHA1Hash;

--- a/src/Graphics/DebugDraw.h
+++ b/src/Graphics/DebugDraw.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_DEBUGDRAW_H
-#define OPENBLACK_DEBUGDRAW_H
 
 #include <Graphics/VertexBuffer.h>
 #include <glm/glm.hpp>
@@ -60,5 +58,3 @@ class DebugDraw
 
 } // namespace Graphics
 } // namespace OpenBlack
-
-#endif // OPENBLACK_DEBUGDRAW_H

--- a/src/Graphics/IndexBuffer.h
+++ b/src/Graphics/IndexBuffer.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_INDEXBUFFER_H
-#define OPENBLACK_INDEXBUFFER_H
 
 #include "OpenGL.h"
 
@@ -59,5 +57,3 @@ class IndexBuffer
 
 } // namespace Graphics
 } // namespace OpenBlack
-
-#endif // OPENBLACK_INDEXBUFFER_H

--- a/src/Graphics/Mesh.h
+++ b/src/Graphics/Mesh.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_GRAPHICS_MESH_H
-#define OPENBLACK_GRAPHICS_MESH_H
 
 #include <Graphics/IndexBuffer.h>
 #include <Graphics/VertexBuffer.h>
@@ -81,5 +79,3 @@ class Mesh
 
 } // namespace Graphics
 } // namespace OpenBlack
-
-#endif

--- a/src/Graphics/OpenGL.h
+++ b/src/Graphics/OpenGL.h
@@ -19,10 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_OPENGL_H
-#define OPENBLACK_OPENGL_H
 
 #define GLEW_STATIC
 #include <GL/glew.h>
-
-#endif

--- a/src/Graphics/ShaderManager.h
+++ b/src/Graphics/ShaderManager.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_GRAPHICS_SHADERMANAGER_H
-#define OPENBLACK_GRAPHICS_SHADERMANAGER_H
 
 #include <Graphics/ShaderProgram.h>
 #include <map>
@@ -48,5 +46,3 @@ class ShaderManager
 
 } // namespace Graphics
 } // namespace OpenBlack
-
-#endif

--- a/src/Graphics/ShaderProgram.h
+++ b/src/Graphics/ShaderProgram.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_GRAPHICS_SHADERPROGRAM_H
-#define OPENBLACK_GRAPHICS_SHADERPROGRAM_H
 
 #include <Graphics/OpenGL.h>
 #include <glm/glm.hpp>
@@ -61,5 +59,3 @@ class ShaderProgram
 
 } // namespace Graphics
 } // namespace OpenBlack
-
-#endif

--- a/src/Graphics/Texture2D.h
+++ b/src/Graphics/Texture2D.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_GRAPHICS_TEXTURE_H
-#define OPENBLACK_GRAPHICS_TEXTURE_H
 
 #include <Graphics/OpenGL.h>
 
@@ -181,5 +179,3 @@ class Texture2D
 
 } // namespace Graphics
 } // namespace OpenBlack
-
-#endif

--- a/src/Graphics/Texture2DArray.h
+++ b/src/Graphics/Texture2DArray.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_GRAPHICS_TEXTURE2DARRAY_H
-#define OPENBLACK_GRAPHICS_TEXTURE2DARRAY_H
 
 #include <Graphics/Texture2D.h>
 
@@ -54,5 +52,3 @@ class Texture2DArray
 
 } // namespace Graphics
 } // namespace OpenBlack
-
-#endif

--- a/src/Graphics/VertexBuffer.h
+++ b/src/Graphics/VertexBuffer.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_VERTEXBUFFER_H
-#define OPENBLACK_VERTEXBUFFER_H
 
 #include <Graphics/OpenGL.h>
 #include <memory>
@@ -62,5 +60,3 @@ class VertexBuffer
 
 } // namespace Graphics
 } // namespace OpenBlack
-
-#endif // OPENBLACK_VERTEXBUFFER_H

--- a/src/LHVMViewer.h
+++ b/src/LHVMViewer.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_LHVMVIEWER_H
-#define OPENBLACK_LHVMVIEWER_H
 
 #include <LHVM/LHVM.h>
 #include <imgui/imgui.h>
@@ -41,5 +39,3 @@ class LHVMViewer
 	static void SelectScript(int idx);
 };
 } // namespace OpenBlack
-
-#endif

--- a/src/Video/Bink/GetBitContext.h
+++ b/src/Video/Bink/GetBitContext.h
@@ -21,10 +21,12 @@
 //code derived from FFMPEG
 //using code from get_bits.h, bitstream.c
 
+#pragma once
+
 #include "common.h"
 
 #define INIT_VLC_LE         2
-#define INIT_VLC_USE_NEW_STATIC 4 
+#define INIT_VLC_USE_NEW_STATIC 4
 
 class VLC
 {
@@ -83,7 +85,7 @@ private:
 	((((const uint8_t*)(x))[3] << 24) |  \
 	(((const uint8_t*)(x))[2] << 16) |   \
 	(((const uint8_t*)(x))[1] <<  8) |   \
-	((const uint8_t*)(x))[0]) 
+	((const uint8_t*)(x))[0])
 
 class GetBitContext
 {

--- a/src/Video/VideoPlayer.h
+++ b/src/Video/VideoPlayer.h
@@ -19,8 +19,6 @@
  */
 
 #pragma once
-#ifndef OPENBLACK_VIDEO_VIDEOPLAYER_H
-#define OPENBLACK_VIDEO_VIDEOPLAYER_H
 
 #include <Common/File.h>
 #include <Graphics/Texture2D.h>
@@ -68,5 +66,3 @@ class VideoPlayer
 
 } // namespace Video
 } // namespace OpenBlack
-
-#endif


### PR DESCRIPTION
A large portion of the project used double include guards. There were
more `#pragma`s than the traditional ones, so I guessed that was the
original intention.