### PR TITLE
Graphics: don't redefine GLEW_STATIC if already defined

### DIFF
--- a/src/Graphics/OpenGL.h
+++ b/src/Graphics/OpenGL.h
@@ -20,5 +20,7 @@
 
 #pragma once
 
+#ifndef GLEW_STATIC
 #define GLEW_STATIC
+#endif
 #include <GL/glew.h>


### PR DESCRIPTION
throws some errors on my mingw toolchain