### PR TITLE
use std::filesystem if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,15 @@ function(check_submodules_present)
 endfunction()
 # check_submodules_present()
 
+# check compiler for various features
+include(CheckIncludeFileCXX)
+CHECK_INCLUDE_FILE_CXX(filesystem HAS_FILESYSTEM)
+if(HAS_FILESYSTEM)
+	message("compiler has CXX header <filesystem>")
+else()
+	message("compiler has no CXX header <filesystem>, need to use <experimental/filesystem>")
+endif()
+
 # Dependencies
 find_package(OpenGL REQUIRED)
 find_package(SDL2 REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,8 +41,10 @@ set_target_properties(openblack PROPERTIES LINKER_LANGUAGE CXX)
 target_include_directories(openblack PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 target_link_libraries(openblack PRIVATE ScriptLibrary SDL2::Main ${OPENGL_LIBRARIES} ${GLEW_LIBRARY})
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND NOT HAS_FILESYSTEM)
 	target_link_libraries(openblack PRIVATE stdc++fs)
+else()
+	target_compile_definitions(openblack PRIVATE HAS_FILESYSTEM)
 endif()
 
 if (WIN32)

--- a/src/Common/File.h
+++ b/src/Common/File.h
@@ -20,13 +20,21 @@
 
 #pragma once
 
+#ifdef HAS_FILESYSTEM
+#include <filesystem>
+#else
 #include <experimental/filesystem>
+#endif // HAS_FILESYSTEM
 #include <string>
 #include <cstdio>
 #include <cassert>
 #include <unordered_map>
 
+#ifdef HAS_FILESYSTEM
+namespace fs = std::filesystem;
+#else
 namespace fs = std::experimental::filesystem;
+#endif // HAS_FILESYSTEM
 
 namespace OpenBlack
 {

--- a/src/Common/FileSystem.h
+++ b/src/Common/FileSystem.h
@@ -21,14 +21,11 @@
 #pragma once
 
 #include <Common/File.h>
-#include <experimental/filesystem>
 #include <cstddef>
 #include <list>
 #include <memory>
 #include <string>
 #include <vector>
-
-namespace fs = std::experimental::filesystem;
 
 namespace OpenBlack
 {


### PR DESCRIPTION
test if <filesystem> header is available and use it. If not fall back to
use <experimental/filesystem>. This fixes clang builds