### PR TITLE
Fixed glew on wayland

### DIFF
--- a/src/GameWindow.cpp
+++ b/src/GameWindow.cpp
@@ -114,6 +114,13 @@ GameWindow::GameWindow(const std::string& title, int width, int height, DisplayM
 	// initalize glew
 	glewExperimental = GL_TRUE;
 	GLenum err = glewInit();
+	#ifdef GLEW_ERROR_NO_GLX_DISPLAY
+	if (GLEW_ERROR_NO_GLX_DISPLAY == err)
+	{
+		std::clog << "GLEW couldn't open GLX display" << std::endl;
+	}
+	else
+	#endif
 	if (GLEW_OK != err)
 	{
 		std::stringstream error;


### PR DESCRIPTION
Glew can't open glx display when it's running on wayland session and thus
returns an error. But glXGetProcAddress is fully usable on wayland, so we
can just ignore the "no glx display" error.

Note that GLEW_ERROR_NO_GLX_DISPLAY needs glew >= 2.1. Older versions assume
that glx display is always available and will just crash.

source: https://github.com/SuperTux/supertux/commit/06976f8ed70c7137807b7b312c07f5698832be9a