### PR TITLE
Add Renderer Class

### DIFF
--- a/ci/Dockerfile.ubuntu.template
+++ b/ci/Dockerfile.ubuntu.template
@@ -10,7 +10,8 @@ RUN apt-get update && \
   libglew-dev \
   libsdl2-dev \
   libglm-dev \
-  libspdlog-dev
+  libspdlog-dev \
+  libwayland-dev
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/src/3D/Camera.cpp
+++ b/src/3D/Camera.cpp
@@ -149,9 +149,9 @@ void Camera::handleMouseInput(const SDL_Event& e)
 	}
 }
 
-void Camera::Update(double dt)
+void Camera::Update(std::chrono::microseconds dt)
 {
-	_position += GetForward() * (float)(_velocity.z * _movementSpeed * dt);
-	_position += GetUp() * (float)(_velocity.y * _movementSpeed * dt);
-	_position += GetRight() * (float)(_velocity.x * _movementSpeed * dt);
+	_position += GetForward() * (float)(_velocity.z * _movementSpeed * dt.count());
+	_position += GetUp() * (float)(_velocity.y * _movementSpeed * dt.count());
+	_position += GetRight() * (float)(_velocity.x * _movementSpeed * dt.count());
 }

--- a/src/3D/Camera.h
+++ b/src/3D/Camera.h
@@ -24,6 +24,7 @@
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/quaternion.hpp>
+#include <chrono>
 
 namespace OpenBlack
 {
@@ -34,7 +35,7 @@ class Camera
   public:
 	Camera(glm::vec3 position, glm::vec3 rotation):
 	    _position(position), _rotation(glm::radians(rotation)), _projectionMatrix(1.0f),
-	    _movementSpeed(0.5f), _freeLookSensitivity(1.0f),
+	    _movementSpeed(0.0005f), _freeLookSensitivity(1.0f),
 	    _velocity(0.0f, 0.0f, 0.0f) {}
 	Camera():
 	    Camera(glm::vec3(0.0f), glm::vec3(0.0f)) {}
@@ -57,7 +58,7 @@ class Camera
 
 	void DeprojectScreenToWorld(const glm::ivec2 screenPosition, const glm::ivec2 screenSize, glm::vec3& out_worldOrigin, glm::vec3& out_worldDirection);
 
-	void Update(double dt);
+	void Update(std::chrono::microseconds dt);
 	void ProcessSDLEvent(const SDL_Event&);
 
 	void handleKeyboardInput(const SDL_Event&);

--- a/src/3D/Sky.cpp
+++ b/src/3D/Sky.cpp
@@ -41,7 +41,7 @@ Sky::Sky()
 	delete bitmap;
 }
 
-void Sky::Draw(const Camera& camera)
+void Sky::Draw(const Camera& camera) const
 {
 	_shader->Bind();
 	_shader->SetUniformValue("viewProj", camera.GetViewProjectionMatrix());

--- a/src/3D/Sky.h
+++ b/src/3D/Sky.h
@@ -38,7 +38,7 @@ class Sky
 	Sky();
 	~Sky() = default;
 
-	void Draw(const Camera&);
+	void Draw(const Camera&) const;
 
   private:
 	std::unique_ptr<ShaderProgram> _shader;

--- a/src/3D/Water.cpp
+++ b/src/3D/Water.cpp
@@ -98,7 +98,7 @@ void Water::createMesh()
 	_mesh = std::make_unique<Mesh>(vertexBuffer, indexBuffer, decl, GL_TRIANGLES);
 }
 
-void Water::Draw(ShaderProgram& program)
+void Water::Draw(ShaderProgram& program) const
 {
 	program.SetUniformValue("sReflection", 0);
 	glActiveTexture(GL_TEXTURE0);

--- a/src/3D/Water.h
+++ b/src/3D/Water.h
@@ -49,7 +49,7 @@ class Water
 	Water();
 	~Water() = default;
 
-	void Draw(ShaderProgram& program);
+	void Draw(ShaderProgram& program) const;
 
 	void BeginReflection(const Camera& sceneCamera);
 	void EndReflection();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,7 @@ target_link_libraries(openblack PRIVATE
 	spdlog::spdlog
 	EnTT
 )
+target_compile_definitions(openblack PRIVATE GLEW_STATIC)
 if (UNIX)
 	find_library(WAYLAND wayland-egl)
 	if (WAYLAND)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,12 @@ target_link_libraries(openblack PRIVATE
 	spdlog::spdlog
 	EnTT
 )
+if (UNIX)
+	find_library(WAYLAND wayland-egl)
+	if (WAYLAND)
+		target_link_libraries(openblack PRIVATE ${WAYLAND})
+	endif()
+endif()
 
 if (HAS_FILESYSTEM)
 	message(STATUS "Got <filesystem>: add compiler definition HAS_FILESYSTEM")

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -47,6 +47,7 @@
 #include <Graphics/VertexBuffer.h>
 #include <LHScriptX/Script.h>
 #include <LHVMViewer.h>
+#include <Renderer.h>
 #include <glm/gtx/intersect.hpp>
 #include <iostream>
 #include <sstream>
@@ -101,6 +102,8 @@ Game::Game(int argc, char** argv):
 	}
 	_window = std::make_unique<GameWindow>(kWindowTitle + " [" + kBuildStr + "]", windowWidth, windowHeight, displayMode);
 	_window->SetSwapInterval(1);
+
+	_renderer = std::make_unique<Renderer>(_window);
 
 	_fileSystem->SetGamePath(GetGamePath());
 	spdlog::debug("The GamePath is \"{}\".", _fileSystem->GetGamePath().generic_string());

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -72,13 +72,6 @@ const std::string kWindowTitle = "OpenBlack";
 
 Game* Game::sInstance = nullptr;
 
-void GLAPIENTRY MessageCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam)
-{
-	spdlog::debug("GL CALLBACK: {} type = {0:x}, severity = {0:x}, message = {}\n",
-	        (type == GL_DEBUG_TYPE_ERROR ? "** GL ERROR **" : ""),
-	        type, severity, message);
-}
-
 Game::Game(int argc, char** argv):
     _running(true), _wireframe(false), _waterDebug(false), _timeOfDay(1.0f), _bumpmapStrength(1.0f), _smallBumpmapStrength(1.0f),
     _fileSystem(std::make_unique<FileSystem>()),
@@ -107,10 +100,6 @@ Game::Game(int argc, char** argv):
 
 	_fileSystem->SetGamePath(GetGamePath());
 	spdlog::debug("The GamePath is \"{}\".", _fileSystem->GetGamePath().generic_string());
-
-	glEnable(GL_DEBUG_OUTPUT);
-	glDebugMessageCallback(MessageCallback, 0);
-	glDebugMessageControl(GL_DEBUG_SOURCE_API, GL_DONT_CARE, GL_DEBUG_SEVERITY_NOTIFICATION, 0, 0, GL_FALSE);
 
 	IMGUI_CHECKVERSION();
 	ImGui::CreateContext();

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -159,9 +159,10 @@ void Game::Run()
 	// _lhvm->LoadBinary(GetGamePath() + "/Scripts/Quests/challenge.chl");
 
 	// measure our delta time
+	using namespace std::chrono_literals;
 	uint64_t now     = SDL_GetPerformanceCounter();
 	uint64_t last    = 0;
-	double deltaTime = 0.0;
+	std::chrono::microseconds deltaTime = 0us;
 
 	_running = true;
 	SDL_Event e;
@@ -170,7 +171,7 @@ void Game::Run()
 		last = now;
 		now  = SDL_GetPerformanceCounter();
 
-		deltaTime = ((now - last) * 1000 / (double)SDL_GetPerformanceFrequency());
+		deltaTime = std::chrono::microseconds((now - last) * 1000000 / SDL_GetPerformanceFrequency());
 
 		while (SDL_PollEvent(&e))
 		{
@@ -214,7 +215,7 @@ void Game::Run()
 		DebugDraw::Cross(_intersection, 50.0f);
 
 		_camera->Update(deltaTime);
-		_modelRotation.y = fmod(_modelRotation.y + float(deltaTime) * .1f, 360.f);
+		_modelRotation.y = fmod(_modelRotation.y + float(deltaTime.count()) * .0001f, 360.f);
 
 		this->guiLoop();
 
@@ -222,16 +223,15 @@ void Game::Run()
 		_renderer->ClearScene((int)io.DisplaySize.x, (int)io.DisplaySize.y);
 
 		_water->BeginReflection(*_camera);
-		_renderer->DrawScene(0, *this, _water->GetReflectionCamera(), false);
+		_renderer->DrawScene(deltaTime, *this, _water->GetReflectionCamera(), false);
 		_water->EndReflection();
 
 		// reset viewport here, should be done in EndReflection
 		glViewport(0, 0, (int)io.DisplaySize.x, (int)io.DisplaySize.y);
 
-		_renderer->DrawScene(0, *this, *_camera, true);
+		_renderer->DrawScene(deltaTime, *this, *_camera, true);
 
-		// TODO(bwrsandman): Get delta time
-		_renderer->DebugDraw(0, *this);
+		_renderer->DebugDraw(deltaTime, *this);
 
 		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -122,7 +122,7 @@ Game::Game(int argc, char** argv):
 	ImGuiStyle& style     = ImGui::GetStyle();
 	style.FrameBorderSize = 1.0f;
 
-	ImGui_ImplSDL2_InitForOpenGL(_window->GetHandle(), _window->GetGLContext());
+	ImGui_ImplSDL2_InitForOpenGL(_window->GetHandle(), _renderer->GetGLContext());
 	ImGui_ImplOpenGL3_Init("#version 130");
 
 	_shaderManager->LoadShader("DebugLine", "shaders/line.vert", "shaders/line.frag");

--- a/src/Game.h
+++ b/src/Game.h
@@ -35,6 +35,7 @@ class MeshPack;
 class MeshViewer;
 class LandIsland;
 class L3DModel;
+class Renderer;
 class SkinnedModel;
 class Sky;
 class Water;
@@ -97,6 +98,7 @@ class Game
 	std::unique_ptr<Graphics::ShaderManager> _shaderManager;
 
 	std::unique_ptr<GameWindow> _window;
+	std::unique_ptr<Renderer> _renderer;
 	std::unique_ptr<Camera> _camera;
 
 	std::unique_ptr<FileSystem> _fileSystem;

--- a/src/Game.h
+++ b/src/Game.h
@@ -40,12 +40,6 @@ class SkinnedModel;
 class Sky;
 class Water;
 
-namespace Graphics
-{
-class ShaderProgram;
-class ShaderManager;
-} // namespace Graphics
-
 namespace LHScriptX
 {
 class Script;
@@ -77,11 +71,21 @@ class Game
 
 	GameWindow& GetWindow() { return *_window; }
 	Camera& GetCamera() { return *_camera; }
+	[[nodiscard]] Camera& GetCamera() const { return *_camera; }
+	[[nodiscard]] Sky& GetSky() const { return *_sky; }
+	[[nodiscard]] Water& GetWater() const { return *_water; }
+	LandIsland& GetLandIsland() { return *_landIsland; }
+	[[nodiscard]] LandIsland& GetLandIsland() const { return *_landIsland; }
+	[[nodiscard]] SkinnedModel& GetTestModel() const { return *_testModel; }
 	MeshPack& GetMeshPack() { return *_meshPack; }
 	FileSystem& GetFileSystem() { return *_fileSystem; }
-	Graphics::ShaderManager& GetShaderManager() { return *_shaderManager; }
 	Entities::Registry& GetEntityRegistry() { return *_entityRegistry; }
-	LandIsland& GetLandIsland() { return *_landIsland; }
+	[[nodiscard]] Entities::Registry& GetEntityRegistry() const { return *_entityRegistry; }
+	[[nodiscard]] float GetTimeOfDay() const { return _timeOfDay; }
+	[[nodiscard]] float GetBumpmapStrength() const { return _bumpmapStrength; }
+	[[nodiscard]] float GetSmallBumpmapStrength() const { return _smallBumpmapStrength; }
+	[[nodiscard]] glm::mat4 GetModelMatrix() const;
+	[[nodiscard]] bool GetIsWireframe() const { return _wireframe; }
 
 	static Game* instance()
 	{
@@ -89,13 +93,9 @@ class Game
 	}
 
   private:
-	void drawScene(const Camera& camera, bool drawWater);
-
 	static Game* sInstance;
 
 	std::string sGamePath; // path to Lionhead Studios Ltd/Black & White folder
-
-	std::unique_ptr<Graphics::ShaderManager> _shaderManager;
 
 	std::unique_ptr<GameWindow> _window;
 	std::unique_ptr<Renderer> _renderer;

--- a/src/GameWindow.cpp
+++ b/src/GameWindow.cpp
@@ -21,11 +21,6 @@
 #include "GameWindow.h"
 
 #include <iostream>
-#include <sstream>
-#ifndef GLEW_STATIC
-#define GLEW_STATIC
-#endif
-#include <GL/glew.h>
 #include <spdlog/spdlog.h>
 #include <SDL_syswm.h>
 #if defined(SDL_VIDEO_DRIVER_WAYLAND)
@@ -93,58 +88,11 @@ GameWindow::GameWindow(const std::string& title, int width, int height, DisplayM
 		throw std::runtime_error("Failed creating window: " + std::string(SDL_GetError()));
 	}
 	_window = std::move(window);
-
-	// Create a debug context?
-	bool useDebug = true;
-	SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, useDebug ? SDL_GL_CONTEXT_DEBUG_FLAG : 0);
-
-	auto context = SDL_GL_CreateContext(_window.get());
-
-	if (context == nullptr)
-	{
-		throw std::runtime_error("Could not create OpenGL context: " + std::string(SDL_GetError()));
-	}
-	else
-	{
-		_glcontext = std::unique_ptr<SDL_GLContext, SDLDestroyer>(&context);
-	}
-
-	spdlog::info("OpenGL context successfully created.");
-	
-	int majorVersion, minorVersion;
-	SDL_GL_GetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, &majorVersion);
-	SDL_GL_GetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, &minorVersion);
-
-	spdlog::info("OpenGL version: {}.{}", majorVersion, minorVersion);
-
-	// initalize glew
-	glewExperimental = GL_TRUE;
-	GLenum err = glewInit();
-	#ifdef GLEW_ERROR_NO_GLX_DISPLAY
-	if (GLEW_ERROR_NO_GLX_DISPLAY == err)
-	{
-		spdlog::warn("GLEW couldn't open GLX display");
-	}
-	else
-	#endif
-	if (GLEW_OK != err)
-	{
-		std::stringstream error;
-		error << "glewInit failed: " << glewGetErrorString(err) << std::endl;
-		throw std::runtime_error(error.str());
-	}
-
-	spdlog::info("Using GLEW {0}", glewGetString(GLEW_VERSION));
 }
 
 SDL_Window* GameWindow::GetHandle() const
 {
 	return _window.get();
-}
-
-SDL_GLContext* GameWindow::GetGLContext() const
-{
-	return _glcontext.get();
 }
 
 void GameWindow::GetNativeHandles(void*& native_window, void*& native_display) const
@@ -384,7 +332,6 @@ void GameWindow::SetFullscreen(bool b)
 
 void GameWindow::Close()
 {
-	_glcontext.reset(nullptr);
 	_window.reset(nullptr);
 }
 

--- a/src/GameWindow.cpp
+++ b/src/GameWindow.cpp
@@ -73,7 +73,7 @@ GameWindow::GameWindow(const std::string& title, int width, int height, DisplayM
 
 	// Get SDL Window requirements from Renderer
 	flags |= Renderer::GetRequiredFlags();
-	for (auto& attr: Renderer::GetRequiredAttributes()) {
+	for (auto& attr: Renderer::GetRequiredWindowingAttributes()) {
 		if (attr.api == Renderer::Api::OpenGl) {;
 			SDL_GL_SetAttribute(static_cast<SDL_GLattr>(attr.name), attr.value);
 		}

--- a/src/GameWindow.cpp
+++ b/src/GameWindow.cpp
@@ -35,6 +35,8 @@
 #include <SDL_vulkan.h>
 #endif  // USE_VULKAN
 
+#include "Renderer.h"
+
 using namespace OpenBlack;
 
 GameWindow::GameWindow(const std::string& title, const SDL_DisplayMode& display, DisplayMode displaymode):
@@ -68,25 +70,19 @@ GameWindow::GameWindow(const std::string& title, int width, int height, DisplayM
 
 	SDL_ShowCursor(SDL_DISABLE);
 
-	SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8);
-	SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
-	SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8);
-	SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
-	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
-
-	SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
-	SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 4);
-
-	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
-	SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
-
-	uint32_t flags = SDL_WINDOW_OPENGL | SDL_WINDOW_INPUT_FOCUS | SDL_WINDOW_ALLOW_HIGHDPI;
-
+	uint32_t flags = SDL_WINDOW_INPUT_FOCUS | SDL_WINDOW_ALLOW_HIGHDPI;
 	if (displaymode == DisplayMode::Fullscreen)
 		flags |= SDL_WINDOW_FULLSCREEN;
 	else if (displaymode == DisplayMode::Borderless)
 		flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+
+	// Get SDL Window requirements from Renderer
+	flags |= Renderer::GetRequiredFlags();
+	for (auto& attr: Renderer::GetRequiredAttributes()) {
+		if (attr.api == Renderer::Api::OpenGl) {;
+			SDL_GL_SetAttribute(static_cast<SDL_GLattr>(attr.name), attr.value);
+		}
+	}
 
 	auto window = std::unique_ptr<SDL_Window, SDLDestroyer>(SDL_CreateWindow(
 	    title.c_str(), SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,

--- a/src/GameWindow.cpp
+++ b/src/GameWindow.cpp
@@ -27,6 +27,9 @@
 #endif
 #include <GL/glew.h>
 #include <spdlog/spdlog.h>
+#if USE_VULKAN
+#include <SDL_vulkan.h>
+#endif  // USE_VULKAN
 
 using namespace OpenBlack;
 
@@ -254,6 +257,16 @@ void GameWindow::SetSize(int width, int height)
 void GameWindow::GetSize(int& width, int& height)
 {
 	SDL_GetWindowSize(_window.get(), &width, &height);
+}
+
+void GameWindow::GetDrawableSize(int &width, int &height)
+{
+	// TODO(bwrsandman): Make this a runtime branch
+#if USE_VULKAN
+	SDL_Vulkan_GetDrawableSize(_window.get(), &drawable_width, &drawable_height);
+#else
+	SDL_GL_GetDrawableSize(_window.get(), &width, &height);
+#endif  // USE_VULKAN
 }
 
 void GameWindow::Show()

--- a/src/GameWindow.h
+++ b/src/GameWindow.h
@@ -48,6 +48,7 @@ class GameWindow
 
 	SDL_Window* GetHandle() const;
 	SDL_GLContext* GetGLContext() const;
+	void GetNativeHandles(void*& native_window, void*& native_display) const;
 
 	bool IsOpen() const;
 	float GetBrightness() const;

--- a/src/GameWindow.h
+++ b/src/GameWindow.h
@@ -76,6 +76,7 @@ class GameWindow
 	void GetMinimumSize(int& width, int& height);
 	void SetMaximumSize(int width, int height);
 	void GetMaximumSize(int& width, int& height);
+	void GetDrawableSize(int& width, int& height);
 
 	void Minimise();
 	void Maximise();

--- a/src/GameWindow.h
+++ b/src/GameWindow.h
@@ -25,12 +25,6 @@
 #include <memory>
 #include <string>
 
-struct SDLDestroyer
-{
-	void operator()(SDL_Window* window) const { SDL_DestroyWindow(window); }
-	void operator()(SDL_GLContext* glcontext) const { SDL_GL_DeleteContext(*glcontext); }
-};
-
 namespace OpenBlack
 {
 enum DisplayMode
@@ -42,12 +36,16 @@ enum DisplayMode
 
 class GameWindow
 {
+  struct SDLDestroyer
+  {
+	void operator()(SDL_Window* window) const { SDL_DestroyWindow(window); }
+  };
+
   public:
 	GameWindow(const std::string& title, const SDL_DisplayMode& display, DisplayMode displaymode);
 	GameWindow(const std::string& title, int width, int height, DisplayMode displaymode);
 
 	SDL_Window* GetHandle() const;
-	SDL_GLContext* GetGLContext() const;
 	void GetNativeHandles(void*& native_window, void*& native_display) const;
 
 	bool IsOpen() const;
@@ -91,6 +89,5 @@ class GameWindow
 
   private:
 	std::unique_ptr<SDL_Window, SDLDestroyer> _window;
-	std::unique_ptr<SDL_GLContext, SDLDestroyer> _glcontext;
 };
 } // namespace OpenBlack

--- a/src/Graphics/OpenGL.h
+++ b/src/Graphics/OpenGL.h
@@ -20,7 +20,4 @@
 
 #pragma once
 
-#ifndef GLEW_STATIC
-#define GLEW_STATIC
-#endif
 #include <GL/glew.h>

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -1,0 +1,53 @@
+/* OpenBlack - A reimplementation of Lionhead's Black & White.
+ *
+ * OpenBlack is the legal property of its developers, whose names
+ * can be found in the AUTHORS.md file distributed with this source
+ * distribution.
+ *
+ * OpenBlack is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * OpenBlack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenBlack. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Renderer.h"
+
+#include <SDL_video.h>
+
+#include <GameWindow.h>
+
+using namespace OpenBlack;
+
+std::vector<Renderer::RequiredAttribute> Renderer::GetRequiredAttributes() {
+	return std::vector<RequiredAttribute> {
+		{Api::OpenGl, SDL_GL_RED_SIZE, 8},
+		{Api::OpenGl, SDL_GL_GREEN_SIZE, 8},
+		{Api::OpenGl, SDL_GL_BLUE_SIZE, 8},
+		{Api::OpenGl, SDL_GL_ALPHA_SIZE, 8},
+		{Api::OpenGl, SDL_GL_DOUBLEBUFFER, 1},
+
+		{Api::OpenGl, SDL_GL_MULTISAMPLEBUFFERS, 1},
+		{Api::OpenGl, SDL_GL_MULTISAMPLESAMPLES, 4},
+
+		{Api::OpenGl, SDL_GL_CONTEXT_MAJOR_VERSION, 3},
+		{Api::OpenGl, SDL_GL_CONTEXT_MINOR_VERSION, 3},
+		{Api::OpenGl, SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE},
+	};
+}
+
+uint32_t Renderer::GetRequiredFlags()
+{
+	return SDL_WINDOW_OPENGL;
+}
+
+Renderer::Renderer(std::unique_ptr<GameWindow>& window)
+{
+}

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -30,12 +30,19 @@
 
 using namespace OpenBlack;
 
-std::vector<Renderer::RequiredAttribute> Renderer::GetRequiredAttributes() {
+std::vector<Renderer::RequiredAttribute> Renderer::GetRequiredWindowingAttributes() {
 	return std::vector<RequiredAttribute> {
 		{Api::OpenGl, SDL_GL_RED_SIZE, 8},
 		{Api::OpenGl, SDL_GL_GREEN_SIZE, 8},
 		{Api::OpenGl, SDL_GL_BLUE_SIZE, 8},
 		{Api::OpenGl, SDL_GL_ALPHA_SIZE, 8},
+	};
+}
+
+std::vector<Renderer::RequiredAttribute> Renderer::GetRequiredContextAttributes() {
+	// Create a debug context?
+	bool useDebug = true;
+	return std::vector<RequiredAttribute> {
 		{Api::OpenGl, SDL_GL_DOUBLEBUFFER, 1},
 
 		{Api::OpenGl, SDL_GL_MULTISAMPLEBUFFERS, 1},
@@ -44,6 +51,8 @@ std::vector<Renderer::RequiredAttribute> Renderer::GetRequiredAttributes() {
 		{Api::OpenGl, SDL_GL_CONTEXT_MAJOR_VERSION, 3},
 		{Api::OpenGl, SDL_GL_CONTEXT_MINOR_VERSION, 3},
 		{Api::OpenGl, SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE},
+
+		{Api::OpenGl, SDL_GL_CONTEXT_FLAGS, useDebug ? SDL_GL_CONTEXT_DEBUG_FLAG : 0},
 	};
 }
 
@@ -54,9 +63,11 @@ uint32_t Renderer::GetRequiredFlags()
 
 Renderer::Renderer(std::unique_ptr<GameWindow>& window)
 {
-	// Create a debug context?
-	bool useDebug = true;
-	SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, useDebug ? SDL_GL_CONTEXT_DEBUG_FLAG : 0);
+	for (auto& attr: GetRequiredContextAttributes()) {
+		if (attr.api == Renderer::Api::OpenGl) {;
+			SDL_GL_SetAttribute(static_cast<SDL_GLattr>(attr.name), attr.value);
+		}
+	}
 
 	auto context = SDL_GL_CreateContext(window->GetHandle());
 

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -170,7 +170,7 @@ void Renderer::ClearScene(int width, int height)
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 }
 
-void Renderer::DebugDraw(uint32_t dt, const Game &game)
+void Renderer::DebugDraw(std::chrono::microseconds dt, const Game &game)
 {
 	glDisable(GL_DEPTH_TEST);
 	glDisable(GL_BLEND);
@@ -181,7 +181,7 @@ void Renderer::DebugDraw(uint32_t dt, const Game &game)
 	DebugDraw::DrawDebugLines();
 }
 
-void Renderer::DrawScene(uint32_t dt, const Game &game, const Camera& camera, bool drawWater)
+void Renderer::DrawScene(std::chrono::microseconds dt, const Game &game, const Camera& camera, bool drawWater)
 {
 	glEnable(GL_DEPTH_TEST);
 	glEnable(GL_BLEND);

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -22,6 +22,7 @@
 
 #include <cstdint>
 #include <array>
+#include <chrono>
 #include <memory>
 #include <vector>
 
@@ -83,9 +84,8 @@ class Renderer {
 	void MessageCallback(uint32_t source, uint32_t type, uint32_t id, uint32_t severity, int32_t length, const std::string& message) const;
 
 	void ClearScene(int width, int height);
-	// TODO(bwrsandman): Use std duration or ms
-	void DebugDraw(uint32_t dt, const Game& game);
-	void DrawScene(uint32_t dt, const Game& game, const Camera& camera, bool drawWater);
+	void DebugDraw(std::chrono::microseconds dt, const Game& game);
+	void DrawScene(std::chrono::microseconds dt, const Game& game, const Camera& camera, bool drawWater);
 
   private:
   static std::vector<RequiredAttribute> GetRequiredContextAttributes();

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -1,0 +1,49 @@
+/* OpenBlack - A reimplementation of Lionhead's Black & White.
+ *
+ * OpenBlack is the legal property of its developers, whose names
+ * can be found in the AUTHORS.md file distributed with this source
+ * distribution.
+ *
+ * OpenBlack is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * OpenBlack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenBlack. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace OpenBlack
+{
+class GameWindow;
+
+class Renderer {
+  public:
+	enum class Api {
+		OpenGl,
+	};
+	struct RequiredAttribute {
+		Api api;
+		uint32_t name;
+		int value;
+	};
+	static std::vector<RequiredAttribute> GetRequiredAttributes();
+	static uint32_t GetRequiredFlags();
+
+	Renderer() = delete;
+	explicit Renderer(std::unique_ptr<GameWindow>& window);
+
+	~Renderer() = default;
+};
+} // namespace OpenBlack

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -21,14 +21,37 @@
 #pragma once
 
 #include <cstdint>
+#include <array>
 #include <memory>
 #include <vector>
 
 #include <SDL.h>
+#include <3D/Camera.h>
 
 namespace OpenBlack
 {
 class GameWindow;
+class Game;
+
+namespace Graphics
+{
+class ShaderProgram;
+class ShaderManager;
+} // namespace Graphics
+
+
+struct ShaderDefinition {
+  const std::string name;
+  const std::string vertexShaderFile;
+  const std::string fragmentShaderFile;
+};
+
+static const std::array Shaders {
+	ShaderDefinition{"DebugLine", "shaders/line.vert", "shaders/line.frag"},
+	ShaderDefinition{"Terrain", "shaders/terrain.vert", "shaders/terrain.frag"},
+	ShaderDefinition{"SkinnedMesh", "shaders/skin.vert", "shaders/skin.frag"},
+	ShaderDefinition{"Water", "shaders/water.vert", "shaders/water.frag"},
+};
 
 class Renderer {
   struct SDLDestroyer
@@ -45,20 +68,29 @@ class Renderer {
 		uint32_t name;
 		int value;
 	};
+
 	static std::vector<RequiredAttribute> GetRequiredWindowingAttributes();
 	static uint32_t GetRequiredFlags();
 
 	Renderer() = delete;
 	explicit Renderer(std::unique_ptr<GameWindow>& window);
 
-	~Renderer() = default;
+	virtual ~Renderer();
 
+	void LoadShaders();
 	[[nodiscard]] SDL_GLContext& GetGLContext() const;
+	[[nodiscard]] Graphics::ShaderManager& GetShaderManager() const;
 	void MessageCallback(uint32_t source, uint32_t type, uint32_t id, uint32_t severity, int32_t length, const std::string& message) const;
+
+	void ClearScene(int width, int height);
+	// TODO(bwrsandman): Use std duration or ms
+	void DebugDraw(uint32_t dt, const Game& game);
+	void DrawScene(uint32_t dt, const Game& game, const Camera& camera, bool drawWater);
 
   private:
   static std::vector<RequiredAttribute> GetRequiredContextAttributes();
 
   std::unique_ptr<SDL_GLContext, SDLDestroyer> _glcontext;
+  std::unique_ptr<Graphics::ShaderManager> _shaderManager;
 };
 } // namespace OpenBlack

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -45,7 +45,7 @@ class Renderer {
 		uint32_t name;
 		int value;
 	};
-	static std::vector<RequiredAttribute> GetRequiredAttributes();
+	static std::vector<RequiredAttribute> GetRequiredWindowingAttributes();
 	static uint32_t GetRequiredFlags();
 
 	Renderer() = delete;
@@ -56,6 +56,8 @@ class Renderer {
 	[[nodiscard]] SDL_GLContext& GetGLContext() const;
 
   private:
+  static std::vector<RequiredAttribute> GetRequiredContextAttributes();
+
   std::unique_ptr<SDL_GLContext, SDLDestroyer> _glcontext;
 };
 } // namespace OpenBlack

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -54,6 +54,7 @@ class Renderer {
 	~Renderer() = default;
 
 	[[nodiscard]] SDL_GLContext& GetGLContext() const;
+	void MessageCallback(uint32_t source, uint32_t type, uint32_t id, uint32_t severity, int32_t length, const std::string& message) const;
 
   private:
   static std::vector<RequiredAttribute> GetRequiredContextAttributes();

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -24,11 +24,18 @@
 #include <memory>
 #include <vector>
 
+#include <SDL.h>
+
 namespace OpenBlack
 {
 class GameWindow;
 
 class Renderer {
+  struct SDLDestroyer
+  {
+	void operator()(SDL_GLContext* glcontext) const { SDL_GL_DeleteContext(*glcontext); }
+  };
+
   public:
 	enum class Api {
 		OpenGl,
@@ -45,5 +52,10 @@ class Renderer {
 	explicit Renderer(std::unique_ptr<GameWindow>& window);
 
 	~Renderer() = default;
+
+	[[nodiscard]] SDL_GLContext& GetGLContext() const;
+
+  private:
+  std::unique_ptr<SDL_GLContext, SDLDestroyer> _glcontext;
 };
 } // namespace OpenBlack


### PR DESCRIPTION
This change decouples some of the rendering logic from the Game and Window Class and puts them in a Rendering Class on its own.

This class will grow into a proper renderer, adding abstractions to the engine, maintaining a rendering thread, its own settings and acceleration structures.

This change was also done in a future-proofing way to allow changes of rendering api and different windowing apis.

* Moved context from game window to Renderer.
* Moved the message callback to the renderer with itself as the user param.
* Moved most of the rendering logic from Game into Renderer.

Bonus: Moved the `GLEW_STATIC` define to CMake so it is now a project-wide define and doesn't need define guards.