### PR TITLE
Renderer: disable MULTISAMPLE to fix OpenGL on wayland

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -81,6 +81,7 @@ Game::Game(int argc, char** argv):
 		args.Get("g", gamePath);
 		SetGamePath(gamePath);
 	}
+
 	_window = std::make_unique<GameWindow>(kWindowTitle + " [" + kBuildStr + "]", windowWidth, windowHeight, displayMode);
 	_window->SetSwapInterval(1);
 

--- a/src/GameWindow.cpp
+++ b/src/GameWindow.cpp
@@ -228,6 +228,7 @@ void GameWindow::SetSwapInterval(int interval)
 	SDL_GL_SetSwapInterval(interval);
 }
 
+
 float GameWindow::GetAspectRatio() const
 {
 	int width, height;


### PR DESCRIPTION
- disable SDL_GL_MULTISAMPLEBUFFERS
- disable SDL_GL_MULTISAMPLESAMPLES

seems the previous PR fell out with the rebase
https://github.com/openblack/openblack/pull/70/commits/6195fd7bee34fba52aa896b1bf708eeda618634f