### PR TITLE
GameWindow: MULTISAMPLE specific recreate of SDL_Window

### DIFF
--- a/src/GameWindow.cpp
+++ b/src/GameWindow.cpp
@@ -74,7 +74,7 @@ GameWindow::GameWindow(const std::string& title, int width, int height, DisplayM
 	// Get SDL Window requirements from Renderer
 	flags |= Renderer::GetRequiredFlags();
 	for (auto& attr: Renderer::GetRequiredWindowingAttributes()) {
-		if (attr.api == Renderer::Api::OpenGl) {;
+		if (attr.api == Renderer::Api::OpenGl) {
 			SDL_GL_SetAttribute(static_cast<SDL_GLattr>(attr.name), attr.value);
 		}
 	}

--- a/src/GameWindow.cpp
+++ b/src/GameWindow.cpp
@@ -85,7 +85,17 @@ GameWindow::GameWindow(const std::string& title, int width, int height, DisplayM
 
 	if (window == nullptr)
 	{
-		throw std::runtime_error("Failed creating window: " + std::string(SDL_GetError()));
+		// try again, maybe on wayland
+		spdlog::debug("Could not create SLDWindow, try again without MULTISAMPLEBUFFERS");
+		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 0);
+		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 0);
+		window = std::unique_ptr<SDL_Window, SDLDestroyer>(SDL_CreateWindow(
+			title.c_str(), SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
+			width, height, flags));
+		if (window == nullptr)
+		{
+			throw std::runtime_error("Failed creating window: " + std::string(SDL_GetError()));
+		}
 	}
 	_window = std::move(window);
 }


### PR DESCRIPTION
Once again on Wayland the SDL_Window can't be created when
SDL_GL_MULTISAMPLEBUFFERS and SDL_GL_MULTISAMPLESAMPLES are set. On error
reset those values and try to one again create the SDL_Window without
those variables set.