### PR TITLE
Vertex attribs refact

### DIFF
--- a/src/3D/L3DSubMesh.cpp
+++ b/src/3D/L3DSubMesh.cpp
@@ -121,10 +121,11 @@ void L3DSubMesh::Load(IStream& stream)
 		primIndexOffset += primitive.numTriangles * 3;
 	}
 
-	VertexDecl decl(3);
-	decl[0] = VertexAttrib(0, 3, GL_FLOAT, false, false, sizeof(L3DVertex), offsetof(L3DVertex, pos));
-	decl[1] = VertexAttrib(1, 3, GL_FLOAT, false, false, sizeof(L3DVertex), offsetof(L3DVertex, uv));
-	decl[2] = VertexAttrib(2, 3, GL_FLOAT, false, false, sizeof(L3DVertex), offsetof(L3DVertex, norm));
+	VertexDecl decl;
+	decl.reserve(3);
+	decl.emplace_back(0, 3, GL_FLOAT, false, false, sizeof(L3DVertex), offsetof(L3DVertex, pos));
+	decl.emplace_back(1, 3, GL_FLOAT, false, false, sizeof(L3DVertex), offsetof(L3DVertex, uv));
+	decl.emplace_back(2, 3, GL_FLOAT, false, false, sizeof(L3DVertex), offsetof(L3DVertex, norm));
 
 	// build our buffers
 	auto vertexBuffer = new VertexBuffer(reinterpret_cast<const void*>(verticies.data()), verticies.size(), sizeof(L3DVertex));

--- a/src/3D/L3DSubMesh.cpp
+++ b/src/3D/L3DSubMesh.cpp
@@ -123,9 +123,9 @@ void L3DSubMesh::Load(IStream& stream)
 
 	VertexDecl decl;
 	decl.reserve(3);
-	decl.emplace_back(0, 3, GL_FLOAT, false, false, sizeof(L3DVertex), offsetof(L3DVertex, pos));
-	decl.emplace_back(1, 3, GL_FLOAT, false, false, sizeof(L3DVertex), offsetof(L3DVertex, uv));
-	decl.emplace_back(2, 3, GL_FLOAT, false, false, sizeof(L3DVertex), offsetof(L3DVertex, norm));
+	decl.emplace_back(3, GL_FLOAT, false, false, sizeof(L3DVertex), offsetof(L3DVertex, pos));
+	decl.emplace_back(3, GL_FLOAT, false, false, sizeof(L3DVertex), offsetof(L3DVertex, uv));
+	decl.emplace_back(3, GL_FLOAT, false, false, sizeof(L3DVertex), offsetof(L3DVertex, norm));
 
 	// build our buffers
 	auto vertexBuffer = new VertexBuffer(reinterpret_cast<const void*>(verticies.data()), verticies.size(), decl);

--- a/src/3D/L3DSubMesh.cpp
+++ b/src/3D/L3DSubMesh.cpp
@@ -123,9 +123,9 @@ void L3DSubMesh::Load(IStream& stream)
 
 	VertexDecl decl;
 	decl.reserve(3);
-	decl.emplace_back(3, GL_FLOAT, false, false, sizeof(L3DVertex), offsetof(L3DVertex, pos));
-	decl.emplace_back(3, GL_FLOAT, false, false, sizeof(L3DVertex), offsetof(L3DVertex, uv));
-	decl.emplace_back(3, GL_FLOAT, false, false, sizeof(L3DVertex), offsetof(L3DVertex, norm));
+	decl.emplace_back(3, VertexAttrib::Type::Float);  // position
+	decl.emplace_back(2, VertexAttrib::Type::Float);  // texture coordinate
+	decl.emplace_back(3, VertexAttrib::Type::Float);  // normals
 
 	// build our buffers
 	auto vertexBuffer = new VertexBuffer(reinterpret_cast<const void*>(verticies.data()), verticies.size(), decl);

--- a/src/3D/L3DSubMesh.cpp
+++ b/src/3D/L3DSubMesh.cpp
@@ -128,9 +128,9 @@ void L3DSubMesh::Load(IStream& stream)
 	decl.emplace_back(2, 3, GL_FLOAT, false, false, sizeof(L3DVertex), offsetof(L3DVertex, norm));
 
 	// build our buffers
-	auto vertexBuffer = new VertexBuffer(reinterpret_cast<const void*>(verticies.data()), verticies.size(), sizeof(L3DVertex));
+	auto vertexBuffer = new VertexBuffer(reinterpret_cast<const void*>(verticies.data()), verticies.size(), decl);
 	auto indexBuffer  = new IndexBuffer(indices.data(), indices.size(), GL_UNSIGNED_SHORT);
-	_mesh = std::make_unique<Mesh>(vertexBuffer, indexBuffer, decl, GL_TRIANGLES);
+	_mesh = std::make_unique<Mesh>(vertexBuffer, indexBuffer, GL_TRIANGLES);
 
 
 	// uint32_t lod = (header.flags & 0xE0000000) >> 30;

--- a/src/3D/L3DSubMesh.h
+++ b/src/3D/L3DSubMesh.h
@@ -53,9 +53,7 @@ class L3DSubMesh
   private:
 	L3DSubMeshFlags _flags;
 
-	GLuint _vertexArray;
-	std::unique_ptr<VertexBuffer> _vertexBuffer;
-	std::unique_ptr<IndexBuffer> _indexBuffer;
+	std::unique_ptr<Mesh> _mesh;
 	std::vector<Primitive> _primitives;
 };
 } // namespace openblack

--- a/src/3D/LandBlock.cpp
+++ b/src/3D/LandBlock.cpp
@@ -108,8 +108,8 @@ void LandBlock::BuildMesh(LandIsland& island)
 
 	auto verts = buildVertexList(island);
 
-	VertexBuffer* vertexBuffer = new VertexBuffer(verts.data(), verts.size(), sizeof(LandVertex));
-	_mesh                      = std::make_unique<Mesh>(vertexBuffer, decl, GL_TRIANGLES);
+	VertexBuffer* vertexBuffer = new VertexBuffer(verts.data(), verts.size(), decl);
+	_mesh                      = std::make_unique<Mesh>(vertexBuffer, GL_TRIANGLES);
 }
 
 std::vector<LandVertex> LandBlock::buildVertexList(LandIsland& island)

--- a/src/3D/LandBlock.cpp
+++ b/src/3D/LandBlock.cpp
@@ -98,13 +98,13 @@ void LandBlock::BuildMesh(LandIsland& island)
 
 	VertexDecl decl;
 	decl.reserve(7);
-	decl.emplace_back(0, 3, GL_FLOAT, false, false, sizeof(LandVertex), offsetof(LandVertex, position));
-	decl.emplace_back(1, 3, GL_FLOAT, false, false, sizeof(LandVertex), offsetof(LandVertex, weight));
-	decl.emplace_back(2, 3, GL_UNSIGNED_BYTE, true, false, sizeof(LandVertex), offsetof(LandVertex, firstMaterialID));
-	decl.emplace_back(3, 3, GL_UNSIGNED_BYTE, true, false, sizeof(LandVertex), offsetof(LandVertex, secondMaterialID));
-	decl.emplace_back(4, 3, GL_UNSIGNED_BYTE, false, true, sizeof(LandVertex), offsetof(LandVertex, materialBlendCoefficient));
-	decl.emplace_back(5, 1, GL_UNSIGNED_BYTE, false, true, sizeof(LandVertex), offsetof(LandVertex, lightLevel));
-	decl.emplace_back(6, 1, GL_FLOAT, false, true, sizeof(LandVertex), offsetof(LandVertex, waterAlpha));
+	decl.emplace_back(3, GL_FLOAT, false, false, sizeof(LandVertex), offsetof(LandVertex, position));
+	decl.emplace_back(3, GL_FLOAT, false, false, sizeof(LandVertex), offsetof(LandVertex, weight));
+	decl.emplace_back(3, GL_UNSIGNED_BYTE, true, false, sizeof(LandVertex), offsetof(LandVertex, firstMaterialID));
+	decl.emplace_back(3, GL_UNSIGNED_BYTE, true, false, sizeof(LandVertex), offsetof(LandVertex, secondMaterialID));
+	decl.emplace_back(3, GL_UNSIGNED_BYTE, false, true, sizeof(LandVertex), offsetof(LandVertex, materialBlendCoefficient));
+	decl.emplace_back(1, GL_UNSIGNED_BYTE, false, true, sizeof(LandVertex), offsetof(LandVertex, lightLevel));
+	decl.emplace_back(1, GL_FLOAT, false, true, sizeof(LandVertex), offsetof(LandVertex, waterAlpha));
 
 	auto verts = buildVertexList(island);
 

--- a/src/3D/LandBlock.cpp
+++ b/src/3D/LandBlock.cpp
@@ -96,14 +96,15 @@ void LandBlock::BuildMesh(LandIsland& island)
 	if (_mesh != nullptr)
 		_mesh.reset();
 
-	VertexDecl decl(7);
-	decl[0] = VertexAttrib(0, 3, GL_FLOAT, false, false, sizeof(LandVertex), offsetof(LandVertex, position));
-	decl[1] = VertexAttrib(1, 3, GL_FLOAT, false, false, sizeof(LandVertex), offsetof(LandVertex, weight));
-	decl[2] = VertexAttrib(2, 3, GL_UNSIGNED_BYTE, true, false, sizeof(LandVertex), offsetof(LandVertex, firstMaterialID));
-	decl[3] = VertexAttrib(3, 3, GL_UNSIGNED_BYTE, true, false, sizeof(LandVertex), offsetof(LandVertex, secondMaterialID));
-	decl[4] = VertexAttrib(4, 3, GL_UNSIGNED_BYTE, false, true, sizeof(LandVertex), offsetof(LandVertex, materialBlendCoefficient));
-	decl[5] = VertexAttrib(5, 1, GL_UNSIGNED_BYTE, false, true, sizeof(LandVertex), offsetof(LandVertex, lightLevel));
-	decl[6] = VertexAttrib(6, 1, GL_FLOAT, false, true, sizeof(LandVertex), offsetof(LandVertex, waterAlpha));
+	VertexDecl decl;
+	decl.reserve(7);
+	decl.emplace_back(0, 3, GL_FLOAT, false, false, sizeof(LandVertex), offsetof(LandVertex, position));
+	decl.emplace_back(1, 3, GL_FLOAT, false, false, sizeof(LandVertex), offsetof(LandVertex, weight));
+	decl.emplace_back(2, 3, GL_UNSIGNED_BYTE, true, false, sizeof(LandVertex), offsetof(LandVertex, firstMaterialID));
+	decl.emplace_back(3, 3, GL_UNSIGNED_BYTE, true, false, sizeof(LandVertex), offsetof(LandVertex, secondMaterialID));
+	decl.emplace_back(4, 3, GL_UNSIGNED_BYTE, false, true, sizeof(LandVertex), offsetof(LandVertex, materialBlendCoefficient));
+	decl.emplace_back(5, 1, GL_UNSIGNED_BYTE, false, true, sizeof(LandVertex), offsetof(LandVertex, lightLevel));
+	decl.emplace_back(6, 1, GL_FLOAT, false, true, sizeof(LandVertex), offsetof(LandVertex, waterAlpha));
 
 	auto verts = buildVertexList(island);
 

--- a/src/3D/LandBlock.cpp
+++ b/src/3D/LandBlock.cpp
@@ -98,13 +98,13 @@ void LandBlock::BuildMesh(LandIsland& island)
 
 	VertexDecl decl;
 	decl.reserve(7);
-	decl.emplace_back(3, GL_FLOAT, false, false, sizeof(LandVertex), offsetof(LandVertex, position));
-	decl.emplace_back(3, GL_FLOAT, false, false, sizeof(LandVertex), offsetof(LandVertex, weight));
-	decl.emplace_back(3, GL_UNSIGNED_BYTE, true, false, sizeof(LandVertex), offsetof(LandVertex, firstMaterialID));
-	decl.emplace_back(3, GL_UNSIGNED_BYTE, true, false, sizeof(LandVertex), offsetof(LandVertex, secondMaterialID));
-	decl.emplace_back(3, GL_UNSIGNED_BYTE, false, true, sizeof(LandVertex), offsetof(LandVertex, materialBlendCoefficient));
-	decl.emplace_back(1, GL_UNSIGNED_BYTE, false, true, sizeof(LandVertex), offsetof(LandVertex, lightLevel));
-	decl.emplace_back(1, GL_FLOAT, false, true, sizeof(LandVertex), offsetof(LandVertex, waterAlpha));
+	decl.emplace_back(3, VertexAttrib::Type::Float);  // position
+	decl.emplace_back(3, VertexAttrib::Type::Float);  // weight
+	decl.emplace_back(3, VertexAttrib::Type::Uint8, false, true);  // first material id
+	decl.emplace_back(3, VertexAttrib::Type::Uint8, false, true);  // second material id
+	decl.emplace_back(3, VertexAttrib::Type::Uint8, true);  // material blend coefficient
+	decl.emplace_back(1, VertexAttrib::Type::Uint8, true);  // light level
+	decl.emplace_back(1, VertexAttrib::Type::Float, true);  // water alpha
 
 	auto verts = buildVertexList(island);
 

--- a/src/3D/LandBlock.h
+++ b/src/3D/LandBlock.h
@@ -33,14 +33,15 @@
 namespace openblack
 {
 
+
 struct LandVertex
 {
 	GLfloat position[3];
 	GLfloat weight[3]; // interpolated
-	GLubyte firstMaterialID[3];
-	GLubyte secondMaterialID[3];
-	GLubyte materialBlendCoefficient[3];
-	GLubyte lightLevel;
+	GLubyte firstMaterialID[4];  // force alignment 4 bytes to prevent packing
+	GLubyte secondMaterialID[4];  // force alignment 4 bytes to prevent packing
+	GLubyte materialBlendCoefficient[4];  // force alignment 4 bytes to prevent packing
+	GLubyte lightLevel;  // aligned to 4 bytes
 	GLfloat waterAlpha;
 
 	LandVertex() { }

--- a/src/3D/Water.cpp
+++ b/src/3D/Water.cpp
@@ -82,7 +82,7 @@ void Water::createMesh()
 {
 	VertexDecl decl;
 	decl.reserve(1);
-	decl.emplace_back(0, 2, GL_FLOAT, false, false, sizeof(glm::vec2), 0); // position
+	decl.emplace_back(2, GL_FLOAT, false, false, sizeof(glm::vec2), 0); // position
 
 	static const glm::vec2 points[] = {
 		glm::vec2(-1.0f, 1.0f),

--- a/src/3D/Water.cpp
+++ b/src/3D/Water.cpp
@@ -80,8 +80,9 @@ Water::Water()
 
 void Water::createMesh()
 {
-	VertexDecl decl(1);
-	decl[0] = VertexAttrib(0, 2, GL_FLOAT, false, false, sizeof(glm::vec2), 0); // position
+	VertexDecl decl;
+	decl.reserve(1);
+	decl.emplace_back(0, 2, GL_FLOAT, false, false, sizeof(glm::vec2), 0); // position
 
 	static const glm::vec2 points[] = {
 		glm::vec2(-1.0f, 1.0f),

--- a/src/3D/Water.cpp
+++ b/src/3D/Water.cpp
@@ -82,7 +82,7 @@ void Water::createMesh()
 {
 	VertexDecl decl;
 	decl.reserve(1);
-	decl.emplace_back(2, GL_FLOAT, false, false, sizeof(glm::vec2), 0); // position
+	decl.emplace_back(2, VertexAttrib::Type::Float); // position
 
 	static const glm::vec2 points[] = {
 		glm::vec2(-1.0f, 1.0f),

--- a/src/3D/Water.cpp
+++ b/src/3D/Water.cpp
@@ -93,10 +93,10 @@ void Water::createMesh()
 
 	static const unsigned short indices[6] = { 2, 1, 0, 0, 3, 2 };
 
-	VertexBuffer* vertexBuffer = new VertexBuffer(points, 4, sizeof(glm::vec2));
+	VertexBuffer* vertexBuffer = new VertexBuffer(points, 4, decl);
 	IndexBuffer* indexBuffer   = new IndexBuffer(indices, 6, GL_UNSIGNED_SHORT);
 
-	_mesh = std::make_unique<Mesh>(vertexBuffer, indexBuffer, decl, GL_TRIANGLES);
+	_mesh = std::make_unique<Mesh>(vertexBuffer, indexBuffer, GL_TRIANGLES);
 }
 
 void Water::Draw(ShaderProgram& program) const

--- a/src/Graphics/DebugLines.cpp
+++ b/src/Graphics/DebugLines.cpp
@@ -43,8 +43,8 @@ std::unique_ptr<DebugLines> DebugLines::CreateDebugLines(uint32_t size, const vo
 {
 	VertexDecl decl;
 	decl.reserve(2);
-	decl.emplace_back(0, 3, GL_FLOAT, false, false, sizeof(Vertex), offsetof(Vertex, pos)); // position
-	decl.emplace_back(1, 3, GL_FLOAT, false, false, sizeof(Vertex), offsetof(Vertex, col)); // color
+	decl.emplace_back(3, GL_FLOAT, false, false, sizeof(Vertex), offsetof(Vertex, pos)); // position
+	decl.emplace_back(3, GL_FLOAT, false, false, sizeof(Vertex), offsetof(Vertex, col)); // color
 
 	auto vertexBuffer = new VertexBuffer(data, vertexCount, decl);
 	auto mesh = std::make_unique<Mesh>(vertexBuffer, GL_LINES);

--- a/src/Graphics/DebugLines.cpp
+++ b/src/Graphics/DebugLines.cpp
@@ -43,9 +43,10 @@ std::unique_ptr<DebugLines> DebugLines::CreateDebugLines(uint32_t size, const vo
 {
 	auto vertexBuffer = new VertexBuffer(data, vertexCount, sizeof(Vertex));
 
-	VertexDecl decl(2);
-	decl[0] = VertexAttrib(0, 3, GL_FLOAT, false, false, sizeof(Vertex), offsetof(Vertex, pos)); // position
-	decl[1] = VertexAttrib(1, 3, GL_FLOAT, false, false, sizeof(Vertex), offsetof(Vertex, col)); // color
+	VertexDecl decl;
+	decl.reserve(2);
+	decl.emplace_back(0, 3, GL_FLOAT, false, false, sizeof(Vertex), offsetof(Vertex, pos)); // position
+	decl.emplace_back(1, 3, GL_FLOAT, false, false, sizeof(Vertex), offsetof(Vertex, col)); // color
 
 	auto mesh = std::make_unique<Mesh>(vertexBuffer, decl, GL_LINES);
 

--- a/src/Graphics/DebugLines.cpp
+++ b/src/Graphics/DebugLines.cpp
@@ -45,9 +45,9 @@ std::unique_ptr<DebugLines> DebugLines::CreateDebugLines(uint32_t size, const vo
 
 	VertexDecl decl(2);
 	decl[0] = VertexAttrib(0, 3, GL_FLOAT, false, false, sizeof(Vertex), offsetof(Vertex, pos)); // position
-	decl[1] = VertexAttrib(0, 3, GL_FLOAT, false, false, sizeof(Vertex), offsetof(Vertex, col)); // color
+	decl[1] = VertexAttrib(1, 3, GL_FLOAT, false, false, sizeof(Vertex), offsetof(Vertex, col)); // color
 
-	auto mesh = std::make_unique<Mesh>(vertexBuffer, decl, GL_TRIANGLES);
+	auto mesh = std::make_unique<Mesh>(vertexBuffer, decl, GL_LINES);
 
 	return std::unique_ptr<DebugLines>(new DebugLines(std::move(mesh)));
 }

--- a/src/Graphics/DebugLines.cpp
+++ b/src/Graphics/DebugLines.cpp
@@ -41,14 +41,13 @@ struct Vertex
 
 std::unique_ptr<DebugLines> DebugLines::CreateDebugLines(uint32_t size, const void* data, uint32_t vertexCount)
 {
-	auto vertexBuffer = new VertexBuffer(data, vertexCount, sizeof(Vertex));
-
 	VertexDecl decl;
 	decl.reserve(2);
 	decl.emplace_back(0, 3, GL_FLOAT, false, false, sizeof(Vertex), offsetof(Vertex, pos)); // position
 	decl.emplace_back(1, 3, GL_FLOAT, false, false, sizeof(Vertex), offsetof(Vertex, col)); // color
 
-	auto mesh = std::make_unique<Mesh>(vertexBuffer, decl, GL_LINES);
+	auto vertexBuffer = new VertexBuffer(data, vertexCount, decl);
+	auto mesh = std::make_unique<Mesh>(vertexBuffer, GL_LINES);
 
 	return std::unique_ptr<DebugLines>(new DebugLines(std::move(mesh)));
 }

--- a/src/Graphics/DebugLines.cpp
+++ b/src/Graphics/DebugLines.cpp
@@ -43,8 +43,8 @@ std::unique_ptr<DebugLines> DebugLines::CreateDebugLines(uint32_t size, const vo
 {
 	VertexDecl decl;
 	decl.reserve(2);
-	decl.emplace_back(3, GL_FLOAT, false, false, sizeof(Vertex), offsetof(Vertex, pos)); // position
-	decl.emplace_back(3, GL_FLOAT, false, false, sizeof(Vertex), offsetof(Vertex, col)); // color
+	decl.emplace_back(3, VertexAttrib::Type::Float); // position
+	decl.emplace_back(3, VertexAttrib::Type::Float); // color
 
 	auto vertexBuffer = new VertexBuffer(data, vertexCount, decl);
 	auto mesh = std::make_unique<Mesh>(vertexBuffer, GL_LINES);

--- a/src/Graphics/IndexBuffer.cpp
+++ b/src/Graphics/IndexBuffer.cpp
@@ -51,7 +51,12 @@ std::size_t IndexBuffer::GetCount() const
 
 std::size_t IndexBuffer::GetSize() const
 {
-	return _count * GetTypeSize(_type);
+	return _count * GetStride();
+}
+
+std::size_t IndexBuffer::GetStride() const
+{
+	return GetTypeSize(_type);
 }
 
 GLenum IndexBuffer::GetType() const

--- a/src/Graphics/IndexBuffer.h
+++ b/src/Graphics/IndexBuffer.h
@@ -42,6 +42,7 @@ class IndexBuffer
 
 	std::size_t GetCount() const;
 	std::size_t GetSize() const;
+	std::size_t GetStride() const;
 	GLenum GetType() const;
 	GLuint GetIBO() const;
 

--- a/src/Graphics/Mesh.cpp
+++ b/src/Graphics/Mesh.cpp
@@ -26,31 +26,29 @@
 
 using namespace openblack::graphics;
 
-Mesh::Mesh(VertexBuffer* vertexBuffer, const VertexDecl& decl, GLuint type):
+Mesh::Mesh(VertexBuffer* vertexBuffer, GLuint type):
     _vertexBuffer(std::move(vertexBuffer)),
-    _vertexDecl(decl),
     _type(type)
 {
 	glGenVertexArrays(1, &_vao);
 	glBindVertexArray(_vao);
 
 	_vertexBuffer->Bind();
-	bindVertexDecl();
+	_vertexBuffer->bindVertexDecl();
 
 	glBindVertexArray(0);
 }
 
-Mesh::Mesh(VertexBuffer* vertexBuffer, IndexBuffer* indexBuffer, const VertexDecl& decl, GLuint type):
+Mesh::Mesh(VertexBuffer* vertexBuffer, IndexBuffer* indexBuffer, GLuint type):
     _vertexBuffer(std::move(vertexBuffer)),
     _indexBuffer(std::move(indexBuffer)),
-    _vertexDecl(decl),
     _type(type)
 {
 	glGenVertexArrays(1, &_vao);
 	glBindVertexArray(_vao);
 
 	_vertexBuffer->Bind();
-	bindVertexDecl();
+	_vertexBuffer->bindVertexDecl();
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, _indexBuffer->GetIBO());
 
 	glBindVertexArray(0);
@@ -100,31 +98,5 @@ void Mesh::Draw(uint32_t count, uint32_t startIndex)
 	else
 	{
 		glDrawArrays(_type, 0, count);
-	}
-}
-
-void Mesh::bindVertexDecl()
-{
-	for (auto& d : _vertexDecl)
-	{
-		if (d._asInt)
-		{
-			glVertexAttribIPointer(d._index,
-			                       d._size,
-			                       d._type,
-			                       d._stride,
-			                       reinterpret_cast<const void*>(d._offset));
-		}
-		else
-		{
-			glVertexAttribPointer(d._index,
-			                      d._size,
-			                      d._type,
-			                      d._normalized ? GL_TRUE : GL_FALSE,
-			                      d._stride,
-			                      reinterpret_cast<const void*>(d._offset));
-		}
-
-		glEnableVertexAttribArray(d._index);
 	}
 }

--- a/src/Graphics/Mesh.cpp
+++ b/src/Graphics/Mesh.cpp
@@ -79,11 +79,28 @@ GLuint Mesh::GetType() const noexcept
 
 void Mesh::Draw()
 {
+	if (_indexBuffer != nullptr && _indexBuffer->GetCount() > 0)
+	{
+		Draw(_indexBuffer->GetCount(), 0);
+	}
+	else
+	{
+		Draw(_vertexBuffer->GetVertexCount(), 0);
+	}
+}
+
+void Mesh::Draw(uint32_t count, uint32_t startIndex)
+{
 	glBindVertexArray(_vao);
 	if (_indexBuffer != nullptr && _indexBuffer->GetCount() > 0)
-		glDrawElements(_type, _indexBuffer->GetCount(), _indexBuffer->GetType(), 0);
+	{
+		auto indexBufferOffset = startIndex * _indexBuffer->GetStride();
+		glDrawElements(_type, count, _indexBuffer->GetType(), reinterpret_cast<void*>(indexBufferOffset));
+	}
 	else
-		glDrawArrays(_type, 0, _vertexBuffer->GetVertexCount());
+	{
+		glDrawArrays(_type, 0, count);
+	}
 }
 
 void Mesh::bindVertexDecl()

--- a/src/Graphics/Mesh.cpp
+++ b/src/Graphics/Mesh.cpp
@@ -107,24 +107,24 @@ void Mesh::bindVertexDecl()
 {
 	for (auto& d : _vertexDecl)
 	{
-		if (d.integer)
+		if (d._asInt)
 		{
-			glVertexAttribIPointer(d.index,
-			                       d.size,
-			                       d.type,
-			                       d.stride,
-			                       reinterpret_cast<const void*>(d.offset));
+			glVertexAttribIPointer(d._index,
+			                       d._size,
+			                       d._type,
+			                       d._stride,
+			                       reinterpret_cast<const void*>(d._offset));
 		}
 		else
 		{
-			glVertexAttribPointer(d.index,
-			                      d.size,
-			                      d.type,
-			                      d.normalized ? GL_TRUE : GL_FALSE,
-			                      d.stride,
-			                      reinterpret_cast<const void*>(d.offset));
+			glVertexAttribPointer(d._index,
+			                      d._size,
+			                      d._type,
+			                      d._normalized ? GL_TRUE : GL_FALSE,
+			                      d._stride,
+			                      reinterpret_cast<const void*>(d._offset));
 		}
 
-		glEnableVertexAttribArray(d.index);
+		glEnableVertexAttribArray(d._index);
 	}
 }

--- a/src/Graphics/Mesh.h
+++ b/src/Graphics/Mesh.h
@@ -63,6 +63,7 @@ class Mesh
 	GLuint GetType() const noexcept;
 
 	void Draw();
+	void Draw(uint32_t count, uint32_t startIndex);
 
   protected:
 	std::shared_ptr<VertexBuffer> _vertexBuffer;

--- a/src/Graphics/Mesh.h
+++ b/src/Graphics/Mesh.h
@@ -33,8 +33,8 @@ namespace graphics
 class Mesh
 {
   public:
-	Mesh(VertexBuffer*, const VertexDecl& decl, GLuint type = GL_TRIANGLES);
-	Mesh(VertexBuffer*, IndexBuffer*, const VertexDecl& decl, GLuint type = GL_TRIANGLES);
+	Mesh(VertexBuffer*, GLuint type = GL_TRIANGLES);
+	Mesh(VertexBuffer*, IndexBuffer*, GLuint type = GL_TRIANGLES);
 	~Mesh();
 
 	std::shared_ptr<VertexBuffer> GetVertexBuffer();
@@ -52,10 +52,6 @@ class Mesh
   private:
 	GLuint _vao;
 	GLuint _type;
-
-	VertexDecl _vertexDecl;
-
-	void bindVertexDecl();
 };
 
 } // namespace graphics

--- a/src/Graphics/Mesh.h
+++ b/src/Graphics/Mesh.h
@@ -22,7 +22,6 @@
 
 #include <Graphics/IndexBuffer.h>
 #include <Graphics/VertexBuffer.h>
-#include <vector>
 
 using namespace openblack::graphics;
 
@@ -30,25 +29,6 @@ namespace openblack
 {
 namespace graphics
 {
-
-struct VertexAttrib
-{
-	GLuint index;         ///< Index of the vertex attribute.
-	GLint size;           ///< Number of components per vertex attribute, must be 1, 2, 3, 4.
-	GLenum type;          ///< Data type of each attribute component in the array.
-	GLsizei stride;       ///< Byte offset between consecutive vertex attributes.
-	ptrdiff_t offset;     ///< Offset of the first component of the first generic vertex attribute.
-	bool normalized;
-	bool integer;
-
-	VertexAttrib() {}
-	VertexAttrib(GLuint i, GLint s, GLenum t, GLsizei st = 0, const ptrdiff_t of = 0):
-	    index(i), size(s), type(t), stride(st), offset(of), normalized(false), integer(false) {}
-	VertexAttrib(GLuint i, GLint s, GLenum t, bool intg, bool norm, GLsizei st = 0, const ptrdiff_t of = 0):
-	    index(i), size(s), type(t), stride(st), offset(of), normalized(norm), integer(intg) {}
-};
-
-typedef std::vector<VertexAttrib> VertexDecl;
 
 class Mesh
 {

--- a/src/Graphics/VertexBuffer.cpp
+++ b/src/Graphics/VertexBuffer.cpp
@@ -85,26 +85,26 @@ void VertexBuffer::Bind()
 
 void VertexBuffer::bindVertexDecl()
 {
-	for (auto& d : _vertexDecl)
+	for (size_t i = 0; i < _vertexDecl.size(); ++i)
 	{
-		if (d._asInt)
+		if (_vertexDecl[i]._asInt)
 		{
-			glVertexAttribIPointer(d._index,
-								   d._size,
-								   d._type,
-								   d._stride,
-								   reinterpret_cast<const void*>(d._offset));
+			glVertexAttribIPointer(i,
+			                       _vertexDecl[i]._size,
+			                       _vertexDecl[i]._type,
+			                       _vertexDecl[i]._stride,
+			                       reinterpret_cast<const void*>(_vertexDecl[i]._offset));
 		}
 		else
 		{
-			glVertexAttribPointer(d._index,
-								  d._size,
-								  d._type,
-								  d._normalized ? GL_TRUE : GL_FALSE,
-								  d._stride,
-								  reinterpret_cast<const void*>(d._offset));
+			glVertexAttribPointer(i,
+			                      _vertexDecl[i]._size,
+			                      _vertexDecl[i]._type,
+			                      _vertexDecl[i]._normalized ? GL_TRUE : GL_FALSE,
+			                      _vertexDecl[i]._stride,
+			                      reinterpret_cast<const void*>(_vertexDecl[i]._offset));
 		}
 
-		glEnableVertexAttribArray(d._index);
+		glEnableVertexAttribArray(i);
 	}
 }

--- a/src/Graphics/VertexBuffer.h
+++ b/src/Graphics/VertexBuffer.h
@@ -24,8 +24,6 @@
 #include <memory>
 #include <vector>
 
-#include "OpenGL.h"
-
 namespace openblack
 {
 namespace graphics
@@ -33,19 +31,35 @@ namespace graphics
 
 struct VertexAttrib
 {
-	GLuint index;         ///< Index of the vertex attribute.
-	GLint size;           ///< Number of components per vertex attribute, must be 1, 2, 3, 4.
-	GLenum type;          ///< Data type of each attribute component in the array.
-	GLsizei stride;       ///< Byte offset between consecutive vertex attributes.
-	ptrdiff_t offset;     ///< Offset of the first component of the first generic vertex attribute.
-	bool normalized;
-	bool integer;
+	uint8_t _index;       ///< Index of the vertex attribute.
+	uint8_t _size;        ///< Number of components per vertex attribute, must be 1, 2, 3, 4.
+	uint32_t _type;       ///< Data type of each attribute component in the array.
+	intptr_t _stride;     ///< Byte offset between consecutive vertex attributes.
+	ptrdiff_t _offset;    ///< Offset of the first component of the first generic vertex attribute.
+	bool _normalized;     /// < When using fixed point values, range will be normalized to 0.0-1.0 in shader.
+	bool _asInt;          /// < Should not be altered. Unpacking will have to be done in vertex shader.
 
 	VertexAttrib() {}
-	VertexAttrib(GLuint i, GLint s, GLenum t, GLsizei st = 0, const ptrdiff_t of = 0):
-	  index(i), size(s), type(t), stride(st), offset(of), normalized(false), integer(false) {}
-	VertexAttrib(GLuint i, GLint s, GLenum t, bool intg, bool norm, GLsizei st = 0, const ptrdiff_t of = 0):
-	index(i), size(s), type(t), stride(st), offset(of), normalized(norm), integer(intg) {}
+	VertexAttrib(uint8_t index, uint8_t size, uint32_t type, intptr_t stride = 0, const ptrdiff_t offset = 0)
+		: _index(index)
+		, _size(size)
+		, _type(type)
+		, _stride(stride)
+		, _offset(offset)
+		, _normalized(false)
+		, _asInt(false)
+	{
+	}
+	VertexAttrib(uint8_t index, uint8_t size, uint32_t type, bool asInt, bool normalized, intptr_t stride = 0, const ptrdiff_t offset = 0)
+		: _index(index)
+		, _size(size)
+		, _type(type)
+		, _stride(stride)
+		, _offset(offset)
+		, _normalized(normalized)
+		, _asInt(asInt)
+		{
+		}
 };
 
 typedef std::vector<VertexAttrib> VertexDecl;

--- a/src/Graphics/VertexBuffer.h
+++ b/src/Graphics/VertexBuffer.h
@@ -22,11 +22,34 @@
 
 #include <cstdint>
 #include <memory>
+#include <vector>
+
+#include "OpenGL.h"
 
 namespace openblack
 {
 namespace graphics
 {
+
+struct VertexAttrib
+{
+	GLuint index;         ///< Index of the vertex attribute.
+	GLint size;           ///< Number of components per vertex attribute, must be 1, 2, 3, 4.
+	GLenum type;          ///< Data type of each attribute component in the array.
+	GLsizei stride;       ///< Byte offset between consecutive vertex attributes.
+	ptrdiff_t offset;     ///< Offset of the first component of the first generic vertex attribute.
+	bool normalized;
+	bool integer;
+
+	VertexAttrib() {}
+	VertexAttrib(GLuint i, GLint s, GLenum t, GLsizei st = 0, const ptrdiff_t of = 0):
+	  index(i), size(s), type(t), stride(st), offset(of), normalized(false), integer(false) {}
+	VertexAttrib(GLuint i, GLint s, GLenum t, bool intg, bool norm, GLsizei st = 0, const ptrdiff_t of = 0):
+	index(i), size(s), type(t), stride(st), offset(of), normalized(norm), integer(intg) {}
+};
+
+typedef std::vector<VertexAttrib> VertexDecl;
+
 class VertexBuffer
 {
   public:

--- a/src/Graphics/VertexBuffer.h
+++ b/src/Graphics/VertexBuffer.h
@@ -31,28 +31,22 @@ namespace graphics
 
 struct VertexAttrib
 {
-	uint8_t _size;        ///< Number of components per vertex attribute, must be 1, 2, 3, 4.
-	uint32_t _type;       ///< Data type of each attribute component in the array.
-	intptr_t _stride;     ///< Byte offset between consecutive vertex attributes.
-	ptrdiff_t _offset;    ///< Offset of the first component of the first generic vertex attribute.
+	enum class Type : uint8_t
+	{
+		Uint8,
+		Int16,
+		Float,
+	};
+
+	uint8_t _num;         ///< Number of components per vertex attribute, must be 1, 2, 3, 4.
+	Type _type;           ///< Data type of each attribute component in the array.
 	bool _normalized;     /// < When using fixed point values, range will be normalized to 0.0-1.0 in shader.
 	bool _asInt;          /// < Should not be altered. Unpacking will have to be done in vertex shader.
 
 	VertexAttrib() {}
-	VertexAttrib(uint8_t size, uint32_t type, intptr_t stride = 0, const ptrdiff_t offset = 0)
-		: _size(size)
+	VertexAttrib(uint8_t num, Type type, bool normalized=false, bool asInt=false)
+		: _num(num)
 		, _type(type)
-		, _stride(stride)
-		, _offset(offset)
-		, _normalized(false)
-		, _asInt(false)
-	{
-	}
-	VertexAttrib(uint8_t size, uint32_t type, bool asInt, bool normalized, intptr_t stride = 0, const ptrdiff_t offset = 0)
-		: _size(size)
-		, _type(type)
-		, _stride(stride)
-		, _offset(offset)
 		, _normalized(normalized)
 		, _asInt(asInt)
 		{
@@ -78,6 +72,8 @@ class VertexBuffer
 	uint32_t _vbo;
 	size_t _vertexCount;
 	const VertexDecl _vertexDecl;
+	size_t _strideBytes;
+	std::vector<const void*> _vertexDeclOffsets;
 };
 
 } // namespace graphics

--- a/src/Graphics/VertexBuffer.h
+++ b/src/Graphics/VertexBuffer.h
@@ -67,7 +67,7 @@ typedef std::vector<VertexAttrib> VertexDecl;
 class VertexBuffer
 {
   public:
-	VertexBuffer(const void* vertices, size_t vertexCount, size_t strideBytes);
+	VertexBuffer(const void* vertices, size_t vertexCount, VertexDecl decl);
 	~VertexBuffer();
 
 	[[nodiscard]] size_t GetVertexCount() const noexcept;
@@ -75,11 +75,12 @@ class VertexBuffer
 	[[nodiscard]] size_t GetSizeInBytes() const noexcept;
 
 	void Bind();
+	void bindVertexDecl();
 
   private:
 	uint32_t _vbo;
 	size_t _vertexCount;
-	size_t _strideBytes;
+	const VertexDecl _vertexDecl;
 };
 
 } // namespace graphics

--- a/src/Graphics/VertexBuffer.h
+++ b/src/Graphics/VertexBuffer.h
@@ -31,7 +31,6 @@ namespace graphics
 
 struct VertexAttrib
 {
-	uint8_t _index;       ///< Index of the vertex attribute.
 	uint8_t _size;        ///< Number of components per vertex attribute, must be 1, 2, 3, 4.
 	uint32_t _type;       ///< Data type of each attribute component in the array.
 	intptr_t _stride;     ///< Byte offset between consecutive vertex attributes.
@@ -40,9 +39,8 @@ struct VertexAttrib
 	bool _asInt;          /// < Should not be altered. Unpacking will have to be done in vertex shader.
 
 	VertexAttrib() {}
-	VertexAttrib(uint8_t index, uint8_t size, uint32_t type, intptr_t stride = 0, const ptrdiff_t offset = 0)
-		: _index(index)
-		, _size(size)
+	VertexAttrib(uint8_t size, uint32_t type, intptr_t stride = 0, const ptrdiff_t offset = 0)
+		: _size(size)
 		, _type(type)
 		, _stride(stride)
 		, _offset(offset)
@@ -50,9 +48,8 @@ struct VertexAttrib
 		, _asInt(false)
 	{
 	}
-	VertexAttrib(uint8_t index, uint8_t size, uint32_t type, bool asInt, bool normalized, intptr_t stride = 0, const ptrdiff_t offset = 0)
-		: _index(index)
-		, _size(size)
+	VertexAttrib(uint8_t size, uint32_t type, bool asInt, bool normalized, intptr_t stride = 0, const ptrdiff_t offset = 0)
+		: _size(size)
 		, _type(type)
 		, _stride(stride)
 		, _offset(offset)


### PR DESCRIPTION
Refactoring VertexDecl mainly.

The constructor has been greatly simplified to an api that looks a lot like bgfx.
Remove a lot of explicit `sizeofs` that are mostly opengl specific.
Moved the `VertexDecl` to vertex buffer.
Converted all usages of vertex attributes to this api.
Force alignment on 4 bytes in terrain.

Fix a few issues.
This includes #94 