### PR TITLE
OpenGL clean-up in headers

### DIFF
--- a/src/3D/L3DMesh.cpp
+++ b/src/3D/L3DMesh.cpp
@@ -178,7 +178,7 @@ void L3DMesh::Load(IStream& stream)
 			stream.Read(data.data(), 256 * 256 * sizeof(uint16_t));
 
 			_skins[id] = std::make_unique<Texture2D>();
-			_skins[id]->Create(data.data(), data.size() * sizeof(data[0]), DataType::UnsignedShort4444Rev, Format::BGRA, 256, 256, 1, InternalFormat::RGB5A1);
+			_skins[id]->Create(256, 256, 1, InternalFormat::RGB5A1, DataType::UnsignedShort4444Rev, Format::BGRA, data.data(), data.size() * sizeof(data[0]));
 		}
 	}
 

--- a/src/3D/L3DMesh.cpp
+++ b/src/3D/L3DMesh.cpp
@@ -178,7 +178,7 @@ void L3DMesh::Load(IStream& stream)
 			stream.Read(data.data(), 256 * 256 * sizeof(uint16_t));
 
 			_skins[id] = std::make_unique<Texture2D>();
-			_skins[id]->Create(256, 256, 1, InternalFormat::RGB5A1, DataType::UnsignedShort4444Rev, Format::BGRA, data.data(), data.size() * sizeof(data[0]));
+			_skins[id]->Create(256, 256, 1, Format::RGBA4, Wrapping::ClampEdge, data.data(), data.size() * sizeof(data[0]));
 		}
 	}
 

--- a/src/3D/L3DSubMesh.cpp
+++ b/src/3D/L3DSubMesh.cpp
@@ -129,7 +129,7 @@ void L3DSubMesh::Load(IStream& stream)
 
 	// build our buffers
 	auto vertexBuffer = new VertexBuffer(reinterpret_cast<const void*>(verticies.data()), verticies.size(), decl);
-	auto indexBuffer  = new IndexBuffer(indices.data(), indices.size(), GL_UNSIGNED_SHORT);
+	auto indexBuffer  = new IndexBuffer(indices.data(), indices.size(), IndexBuffer::Type::Uint16);
 	_mesh = std::make_unique<Mesh>(vertexBuffer, indexBuffer, GL_TRIANGLES);
 
 

--- a/src/3D/L3DSubMesh.cpp
+++ b/src/3D/L3DSubMesh.cpp
@@ -18,12 +18,12 @@
  * along with openblack. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <3D/L3DMesh.h>
 #include <3D/L3DSubMesh.h>
+
+#include <3D/L3DMesh.h>
 #include <Common/IStream.h>
 #include <Game.h>
 #include <3D/MeshPack.h>
-#include <spdlog/spdlog.h>
 
 namespace openblack
 {
@@ -130,7 +130,7 @@ void L3DSubMesh::Load(IStream& stream)
 	// build our buffers
 	auto vertexBuffer = new VertexBuffer(reinterpret_cast<const void*>(verticies.data()), verticies.size(), decl);
 	auto indexBuffer  = new IndexBuffer(indices.data(), indices.size(), IndexBuffer::Type::Uint16);
-	_mesh = std::make_unique<Mesh>(vertexBuffer, indexBuffer, GL_TRIANGLES);
+	_mesh = std::make_unique<Mesh>(vertexBuffer, indexBuffer, Mesh::Topology::TriangleList);
 
 
 	// uint32_t lod = (header.flags & 0xE0000000) >> 30;

--- a/src/3D/L3DSubMesh.cpp
+++ b/src/3D/L3DSubMesh.cpp
@@ -154,11 +154,10 @@ void L3DSubMesh::Draw(const L3DMesh& mesh, ShaderProgram& program) const
 	{
 		if (prim.skinID != 0xFFFFFFFF)
 		{
-			glActiveTexture(GL_TEXTURE0);
 			if (skins.find(prim.skinID) != skins.end())
-				skins.at(prim.skinID)->Bind();
+				skins.at(prim.skinID)->Bind(0);
 			else
-				Game::instance()->GetMeshPack().GetTexture(prim.skinID).Bind();
+				Game::instance()->GetMeshPack().GetTexture(prim.skinID).Bind(0);
 		}
 
 		_mesh->Draw(prim.indicesCount, prim.indicesOffset);

--- a/src/3D/LandBlock.cpp
+++ b/src/3D/LandBlock.cpp
@@ -109,7 +109,7 @@ void LandBlock::BuildMesh(LandIsland& island)
 	auto verts = buildVertexList(island);
 
 	VertexBuffer* vertexBuffer = new VertexBuffer(verts.data(), verts.size(), decl);
-	_mesh                      = std::make_unique<Mesh>(vertexBuffer, GL_TRIANGLES);
+	_mesh = std::make_unique<Mesh>(vertexBuffer, Mesh::Topology::TriangleList);
 }
 
 std::vector<LandVertex> LandBlock::buildVertexList(LandIsland& island)

--- a/src/3D/LandBlock.h
+++ b/src/3D/LandBlock.h
@@ -22,52 +22,41 @@
 
 #include "LandCell.h"
 
-#include <Graphics/Mesh.h>
-#include <Graphics/OpenGL.h>
-#include <Graphics/ShaderProgram.h>
-#include <glm/glm.hpp>
-#include <array> 
+#include <cstdint>
+#include <array>
 #include <stdexcept>
-#include <stdint.h>
+
+#include <glm/glm.hpp>
+
+#include <Graphics/Mesh.h>
+#include <Graphics/ShaderProgram.h>
 
 namespace openblack
 {
 
-
 struct LandVertex
 {
-	GLfloat position[3];
-	GLfloat weight[3]; // interpolated
-	GLubyte firstMaterialID[4];  // force alignment 4 bytes to prevent packing
-	GLubyte secondMaterialID[4];  // force alignment 4 bytes to prevent packing
-	GLubyte materialBlendCoefficient[4];  // force alignment 4 bytes to prevent packing
-	GLubyte lightLevel;  // aligned to 4 bytes
-	GLfloat waterAlpha;
+	const float position[3];
+	const float weight[3]; // interpolated
+	const uint8_t firstMaterialID[4];  // force alignment 4 bytes to prevent packing
+	const uint8_t secondMaterialID[4];  // force alignment 4 bytes to prevent packing
+	const uint8_t materialBlendCoefficient[4];  // force alignment 4 bytes to prevent packing
+	const uint8_t lightLevel;  // aligned to 4 bytes
+	const float waterAlpha;
 
-	LandVertex() { }
 	LandVertex(glm::vec3 _position, glm::vec3 _weight,
-	           GLubyte mat1, GLubyte mat2, GLubyte mat3,
-	           GLubyte mat4, GLubyte mat5, GLubyte mat6,
-	           GLubyte blend1, GLubyte blend2, GLubyte blend3,
-	           GLubyte _lightLevel, GLfloat _alpha)
+	           uint8_t mat1, uint8_t mat2, uint8_t mat3,
+	           uint8_t mat4, uint8_t mat5, uint8_t mat6,
+	           uint8_t blend1, uint8_t blend2, uint8_t blend3,
+	           uint8_t _lightLevel, float _alpha)
+		: position{_position.x, _position.y, _position.z}
+		, weight{_weight.x, _weight.y, _weight.z}
+		, firstMaterialID{mat1, mat2, mat3}
+		, secondMaterialID{mat4, mat5, mat6}
+		, materialBlendCoefficient{blend1, blend2, blend3}
+		, lightLevel{_lightLevel}
+		, waterAlpha{_alpha}
 	{
-		position[0]                 = _position.x;
-		position[1]                 = _position.y;
-		position[2]                 = _position.z;
-		weight[0]                   = _weight.x;
-		weight[1]                   = _weight.y;
-		weight[2]                   = _weight.z;
-		firstMaterialID[0]          = mat1;
-		firstMaterialID[1]          = mat2;
-		firstMaterialID[2]          = mat3;
-		secondMaterialID[0]         = mat4;
-		secondMaterialID[1]         = mat5;
-		secondMaterialID[2]         = mat6;
-		materialBlendCoefficient[0] = blend1;
-		materialBlendCoefficient[1] = blend2;
-		materialBlendCoefficient[2] = blend3;
-		lightLevel                  = _lightLevel;
-		waterAlpha                  = _alpha;
 	}
 };
 
@@ -83,10 +72,9 @@ class LandBlock
 	void Draw(ShaderProgram& program);
 	void BuildMesh(LandIsland& island);
 
-	const LandCell* GetCells() const { return _cells.data(); };
+	[[nodiscard]] const LandCell* GetCells() const { return _cells.data(); };
 	const glm::ivec2& GetBlockPosition() { return _blockPosition; }
 	const glm::vec2& GetMapPosition() { return _mapPosition; }
-
 
   private:
 	uint32_t _index; // the blocks index in the block array (do we need to know this?)

--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -185,14 +185,9 @@ void LandIsland::Draw(ShaderProgram& program)
 	program.SetUniformValue("sBumpMap", 1);
 	program.SetUniformValue("sSmallBumpMap", 2);
 
-	glActiveTexture(GL_TEXTURE0);
-	_materialArray->Bind();
-
-	glActiveTexture(GL_TEXTURE1);
-	_textureBumpMap->Bind();
-
-	glActiveTexture(GL_TEXTURE2);
-	_textureSmallBump->Bind();
+	_materialArray->Bind(0);
+	_textureBumpMap->Bind(1);
+	_textureSmallBump->Bind(2);
 
 	for (auto& block : _landBlocks)
 		block.Draw(program);

--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -20,13 +20,14 @@
 
 #include "LandIsland.h"
 
+#include <stdexcept>
+
+#include <spdlog/spdlog.h>
+
+#include <Graphics/OpenGL.h>
 #include <Common/FileSystem.h>
 #include <Common/IStream.h>
-
 #include <Game.h>
-#include <inttypes.h>
-#include <stdexcept>
-#include <spdlog/spdlog.h>
 
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <Common/stb_image_write.h>
@@ -44,9 +45,7 @@ LandIsland::LandIsland():
 	file->Read(smallbumpa, file->Size());
 
 	_textureSmallBump = std::make_unique<Texture2D>();
-	_textureSmallBump->Create(256, 256, 1, InternalFormat::R8, DataType::UnsignedByte, Format::Red, smallbumpa, file->Size());
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+	_textureSmallBump->Create(256, 256, 1, Format::R8, Wrapping::Repeat, smallbumpa, file->Size());
 	delete[] smallbumpa;
 }
 
@@ -117,18 +116,18 @@ void LandIsland::LoadFromFile(IStream& stream)
 		convertRGB5ToRGB8(rgba5TextureData.data(), rgba8TextureData.data() + i * rgba5TextureData.size(), 256 * 256);
 	}
 	_materialArray = std::make_unique<Texture2D>();
-	_materialArray->Create(256, 256, _materialCount, InternalFormat::RGBA8, DataType::UnsignedByte, Format::RGBA, rgba8TextureData.data(), rgba8TextureData.size() * sizeof(rgba8TextureData[0]));
+	_materialArray->Create(256, 256, _materialCount, Format::RGBA8, Wrapping::ClampEdge, rgba8TextureData.data(), rgba8TextureData.size() * sizeof(rgba8TextureData[0]));
 
 	// read noise map into Texture2D
 	stream.Read(_noiseMap.data(), _noiseMap.size() * sizeof(_noiseMap[0]));
 	_textureNoiseMap = std::make_unique<Texture2D>();
-	_textureNoiseMap->Create(256, 256, 1, InternalFormat::R8, DataType::UnsignedByte, Format::Red, _noiseMap.data(), _noiseMap.size() * sizeof(_noiseMap[0]));
+	_textureNoiseMap->Create(256, 256, 1, Format::R8, Wrapping::ClampEdge, _noiseMap.data(), _noiseMap.size() * sizeof(_noiseMap[0]));
 
 	// read bump map into Texture2D
 	std::array<uint8_t, 256* 256> bumpMapTextureData;
 	stream.Read(bumpMapTextureData.data(), bumpMapTextureData.size() * sizeof(bumpMapTextureData[0]));
 	_textureBumpMap = std::make_unique<Texture2D>();
-	_textureBumpMap->Create(256, 256, 1, InternalFormat::R8, DataType::UnsignedByte, Format::Red, bumpMapTextureData.data(), bumpMapTextureData.size() * sizeof(bumpMapTextureData[0]));
+	_textureBumpMap->Create(256, 256, 1, Format::R8, Wrapping::ClampEdge, bumpMapTextureData.data(), bumpMapTextureData.size() * sizeof(bumpMapTextureData[0]));
 
 	// build the meshes (we could move this elsewhere)
 	for (auto& block : _landBlocks)

--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -44,7 +44,7 @@ LandIsland::LandIsland():
 	file->Read(smallbumpa, file->Size());
 
 	_textureSmallBump = std::make_unique<Texture2D>();
-	_textureSmallBump->Create(smallbumpa, file->Size(), DataType::UnsignedByte, Format::Red, 256, 256, 1, InternalFormat::R8);
+	_textureSmallBump->Create(256, 256, 1, InternalFormat::R8, DataType::UnsignedByte, Format::Red, smallbumpa, file->Size());
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 	delete[] smallbumpa;
@@ -117,18 +117,18 @@ void LandIsland::LoadFromFile(IStream& stream)
 		convertRGB5ToRGB8(rgba5TextureData.data(), rgba8TextureData.data() + i * rgba5TextureData.size(), 256 * 256);
 	}
 	_materialArray = std::make_unique<Texture2D>();
-	_materialArray->Create(rgba8TextureData.data(), rgba8TextureData.size() * sizeof(rgba8TextureData[0]), DataType::UnsignedByte, Format::RGBA, 256, 256, _materialCount, InternalFormat::RGBA8);
+	_materialArray->Create(256, 256, _materialCount, InternalFormat::RGBA8, DataType::UnsignedByte, Format::RGBA, rgba8TextureData.data(), rgba8TextureData.size() * sizeof(rgba8TextureData[0]));
 
 	// read noise map into Texture2D
 	stream.Read(_noiseMap.data(), _noiseMap.size() * sizeof(_noiseMap[0]));
 	_textureNoiseMap = std::make_unique<Texture2D>();
-	_textureNoiseMap->Create(_noiseMap.data(), _noiseMap.size() * sizeof(_noiseMap[0]), DataType::UnsignedByte, Format::Red, 256, 256, 1, InternalFormat::R8);
+	_textureNoiseMap->Create(256, 256, 1, InternalFormat::R8, DataType::UnsignedByte, Format::Red, _noiseMap.data(), _noiseMap.size() * sizeof(_noiseMap[0]));
 
 	// read bump map into Texture2D
 	std::array<uint8_t, 256* 256> bumpMapTextureData;
 	stream.Read(bumpMapTextureData.data(), bumpMapTextureData.size() * sizeof(bumpMapTextureData[0]));
 	_textureBumpMap = std::make_unique<Texture2D>();
-	_textureBumpMap->Create(bumpMapTextureData.data(), bumpMapTextureData.size() * sizeof(bumpMapTextureData[0]), DataType::UnsignedByte, Format::Red, 256, 256, 1, InternalFormat::R8);
+	_textureBumpMap->Create(256, 256, 1, InternalFormat::R8, DataType::UnsignedByte, Format::Red, bumpMapTextureData.data(), bumpMapTextureData.size() * sizeof(bumpMapTextureData[0]));
 
 	// build the meshes (we could move this elsewhere)
 	for (auto& block : _landBlocks)

--- a/src/3D/MeshPack.cpp
+++ b/src/3D/MeshPack.cpp
@@ -105,7 +105,7 @@ void createCompressedDDS(graphics::Texture2D* texture, uint8_t* buffer)
 	int bpp = internalFormat == InternalFormat::CompressedRGBAS3TCDXT3 ? 16 : 8;
 	size_t size = std::max(1, ((int) width + 3) >> 2) * std::max(1, ((int) height + 3) >> 2) * bpp;
 
-	texture->CreateCompressed(buffer + header->dwSize, size, width, height, 1, internalFormat);
+	texture->Create(width, height, 1, internalFormat, graphics::DataType::UnsignedByte, Format::RGBA, buffer + header->dwSize, size);
 }
 
 

--- a/src/3D/MeshPack.cpp
+++ b/src/3D/MeshPack.cpp
@@ -27,8 +27,6 @@
 #include <algorithm>
 #include <spdlog/spdlog.h>
 #include <stdexcept>
-#include <stdint.h>
-#include <stdlib.h> // snprintf
 
 namespace openblack
 {
@@ -83,7 +81,7 @@ void createCompressedDDS(graphics::Texture2D* texture, uint8_t* buffer)
 	// - always dxt1 or dxt3
 	// - all are compressed
 
-	graphics::InternalFormat internalFormat;
+	graphics::Format internalFormat;
 	GLsizei width  = header->dwWidth;
 	GLsizei height = header->dwHeight;
 	int bytesPerBlock;
@@ -91,10 +89,10 @@ void createCompressedDDS(graphics::Texture2D* texture, uint8_t* buffer)
 	switch (header->ddspf.dwFourCC)
 	{
 	case ('D' | ('X' << 8) | ('T' << 16) | ('1' << 24)):
-		internalFormat = graphics::InternalFormat::CompressedRGBAS3TCDXT1;
+		internalFormat = graphics::Format::BlockCompression1;
 		break;
 	case ('D' | ('X' << 8) | ('T' << 16) | ('3' << 24)):
-		internalFormat = graphics::InternalFormat::CompressedRGBAS3TCDXT3;
+		internalFormat = graphics::Format::BlockCompression2;
 		break;
 	default:
 		throw std::runtime_error("Unsupported compressed texture format");
@@ -102,10 +100,10 @@ void createCompressedDDS(graphics::Texture2D* texture, uint8_t* buffer)
 	}
 
 	// DXT1 = 8bpp or DXT3 = 16bpp
-	int bpp = internalFormat == InternalFormat::CompressedRGBAS3TCDXT3 ? 16 : 8;
+	int bpp = internalFormat == Format::BlockCompression2 ? 16 : 8;
 	size_t size = std::max(1, ((int) width + 3) >> 2) * std::max(1, ((int) height + 3) >> 2) * bpp;
 
-	texture->Create(width, height, 1, internalFormat, graphics::DataType::UnsignedByte, Format::RGBA, buffer + header->dwSize, size);
+	texture->Create(width, height, 1, internalFormat, Wrapping::ClampEdge, buffer + header->dwSize, size);
 }
 
 

--- a/src/3D/Sky.cpp
+++ b/src/3D/Sky.cpp
@@ -120,7 +120,7 @@ void Sky::CalculateTextures()
 	for (unsigned int i = 0; i < 256 * 256; i++)
 		bitmap[i] = bitmap[i] | 0x8000;
 
-	_texture->Create(bitmap.data(), bitmap.size() * sizeof(bitmap[0]), DataType::UnsignedShort1555Rev, Format::BGRA, 256, 256, 1, InternalFormat::RGB5A1);
+	_texture->Create(256, 256, 1, InternalFormat::RGB5A1, DataType::UnsignedShort1555Rev, Format::BGRA, bitmap.data(), bitmap.size() * sizeof(bitmap[0]));
 }
 
 void Sky::Draw(graphics::ShaderProgram& program)

--- a/src/3D/Sky.cpp
+++ b/src/3D/Sky.cpp
@@ -120,7 +120,7 @@ void Sky::CalculateTextures()
 	for (unsigned int i = 0; i < 256 * 256; i++)
 		bitmap[i] = bitmap[i] | 0x8000;
 
-	_texture->Create(256, 256, 1, InternalFormat::RGB5A1, DataType::UnsignedShort1555Rev, Format::BGRA, bitmap.data(), bitmap.size() * sizeof(bitmap[0]));
+	_texture->Create(256, 256, 1, Format::RGB5A1, Wrapping::ClampEdge, bitmap.data(), bitmap.size() * sizeof(bitmap[0]));
 }
 
 void Sky::Draw(graphics::ShaderProgram& program)

--- a/src/3D/Sky.cpp
+++ b/src/3D/Sky.cpp
@@ -127,8 +127,7 @@ void Sky::Draw(graphics::ShaderProgram& program)
 {
 	program.SetUniformValue("u_modelTransform", glm::mat4(1.0f));
 
-	glActiveTexture(GL_TEXTURE0);
-	_texture->Bind();
+	_texture->Bind(0);
 
 	_model->Draw(program, 0);
 }

--- a/src/3D/Water.cpp
+++ b/src/3D/Water.cpp
@@ -91,10 +91,10 @@ void Water::createMesh()
 		glm::vec2(-1.0f, -1.0f),
 	};
 
-	static const unsigned short indices[6] = { 2, 1, 0, 0, 3, 2 };
+	static const uint16_t indices[6] = { 2, 1, 0, 0, 3, 2 };
 
 	VertexBuffer* vertexBuffer = new VertexBuffer(points, 4, decl);
-	IndexBuffer* indexBuffer   = new IndexBuffer(indices, 6, GL_UNSIGNED_SHORT);
+	IndexBuffer* indexBuffer   = new IndexBuffer(indices, 6, IndexBuffer::Type::Uint16);
 
 	_mesh = std::make_unique<Mesh>(vertexBuffer, indexBuffer, GL_TRIANGLES);
 }

--- a/src/3D/Water.cpp
+++ b/src/3D/Water.cpp
@@ -96,7 +96,7 @@ void Water::createMesh()
 	VertexBuffer* vertexBuffer = new VertexBuffer(points, 4, decl);
 	IndexBuffer* indexBuffer   = new IndexBuffer(indices, 6, IndexBuffer::Type::Uint16);
 
-	_mesh = std::make_unique<Mesh>(vertexBuffer, indexBuffer, GL_TRIANGLES);
+	_mesh = std::make_unique<Mesh>(vertexBuffer, indexBuffer, Mesh::Topology::TriangleList);
 }
 
 void Water::Draw(ShaderProgram& program) const

--- a/src/3D/Water.cpp
+++ b/src/3D/Water.cpp
@@ -102,8 +102,7 @@ void Water::createMesh()
 void Water::Draw(ShaderProgram& program) const
 {
 	program.SetUniformValue("sReflection", 0);
-	glActiveTexture(GL_TEXTURE0);
-	_reflectionFrameBuffer->GetTexture()->Bind();
+	_reflectionFrameBuffer->GetTexture()->Bind(0);
 
 	_mesh->Draw();
 }

--- a/src/Graphics/DebugLines.cpp
+++ b/src/Graphics/DebugLines.cpp
@@ -47,7 +47,7 @@ std::unique_ptr<DebugLines> DebugLines::CreateDebugLines(uint32_t size, const vo
 	decl.emplace_back(3, VertexAttrib::Type::Float); // color
 
 	auto vertexBuffer = new VertexBuffer(data, vertexCount, decl);
-	auto mesh = std::make_unique<Mesh>(vertexBuffer, GL_LINES);
+	auto mesh = std::make_unique<Mesh>(vertexBuffer, Mesh::Topology::LineList);
 
 	return std::unique_ptr<DebugLines>(new DebugLines(std::move(mesh)));
 }

--- a/src/Graphics/IndexBuffer.cpp
+++ b/src/Graphics/IndexBuffer.cpp
@@ -22,9 +22,11 @@
 
 #include <cassert>
 
+#include "OpenGL.h"
+
 using namespace openblack::graphics;
 
-IndexBuffer::IndexBuffer(const void* indices, size_t indicesCount, GLenum type):
+IndexBuffer::IndexBuffer(const void* indices, size_t indicesCount, Type type):
     _ibo(0), _count(indicesCount), _type(type), _hint(GL_STATIC_DRAW)
 {
 	assert(indices != nullptr);
@@ -59,34 +61,17 @@ std::size_t IndexBuffer::GetStride() const
 	return GetTypeSize(_type);
 }
 
-GLenum IndexBuffer::GetType() const
+IndexBuffer::Type IndexBuffer::GetType() const
 {
 	return _type;
 }
 
-GLuint IndexBuffer::GetIBO() const
+uint32_t IndexBuffer::GetIBO() const
 {
 	return _ibo;
 }
 
-std::size_t IndexBuffer::GetTypeSize(GLenum type)
+std::size_t IndexBuffer::GetTypeSize(Type type)
 {
-	switch (type)
-	{
-	case GL_UNSIGNED_BYTE:
-		return 1;
-	case GL_SHORT:
-	case GL_UNSIGNED_SHORT:
-		return 2;
-	case GL_INT:
-	case GL_UNSIGNED_INT:
-	case GL_FLOAT:
-		return 4;
-	case GL_DOUBLE:
-		return 8;
-	default:
-		break;
-	}
-
-	return 0;
+	return type == Type::Uint16 ? sizeof(uint16_t) : sizeof(uint32_t);
 }

--- a/src/Graphics/IndexBuffer.h
+++ b/src/Graphics/IndexBuffer.h
@@ -20,10 +20,8 @@
 
 #pragma once
 
-#include "OpenGL.h"
-
-#include <cstdio>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 
 namespace openblack
 {
@@ -32,28 +30,33 @@ namespace graphics
 class IndexBuffer
 {
   public:
+	enum class Type : uint8_t
+	{
+		Uint16,
+		Uint32,
+	};
+	static std::size_t GetTypeSize(Type type);
+
 	IndexBuffer()                         = delete;
 	IndexBuffer(const IndexBuffer& other) = delete;
 	IndexBuffer(IndexBuffer&&)            = default;
 
-	IndexBuffer(const void* indices, std::size_t indicesCount, GLenum type);
+	IndexBuffer(const void* indices, std::size_t indicesCount, Type type);
 
 	~IndexBuffer();
 
 	std::size_t GetCount() const;
 	std::size_t GetSize() const;
 	std::size_t GetStride() const;
-	GLenum GetType() const;
-	GLuint GetIBO() const;
+	Type GetType() const;
+	uint32_t GetIBO() const;
 
   private:
 	std::size_t _count;
-	GLenum _type;
+	Type _type;
 
-	GLuint _ibo;
-	GLuint _hint;
-
-	static std::size_t GetTypeSize(GLenum type);
+	uint32_t _ibo;
+	uint32_t _hint;
 };
 
 } // namespace graphics

--- a/src/Graphics/Mesh.cpp
+++ b/src/Graphics/Mesh.cpp
@@ -93,7 +93,8 @@ void Mesh::Draw(uint32_t count, uint32_t startIndex)
 	if (_indexBuffer != nullptr && _indexBuffer->GetCount() > 0)
 	{
 		auto indexBufferOffset = startIndex * _indexBuffer->GetStride();
-		glDrawElements(_type, count, _indexBuffer->GetType(), reinterpret_cast<void*>(indexBufferOffset));
+		auto indexType = _indexBuffer->GetType() == IndexBuffer::Type::Uint16 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_INT;
+		glDrawElements(_type, count, indexType, reinterpret_cast<void*>(indexBufferOffset));
 	}
 	else
 	{

--- a/src/Graphics/Mesh.h
+++ b/src/Graphics/Mesh.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "OpenGL.h"
 #include <Graphics/IndexBuffer.h>
 #include <Graphics/VertexBuffer.h>
 

--- a/src/Graphics/Mesh.h
+++ b/src/Graphics/Mesh.h
@@ -20,7 +20,8 @@
 
 #pragma once
 
-#include "OpenGL.h"
+#include <cstdint>
+
 #include <Graphics/IndexBuffer.h>
 #include <Graphics/VertexBuffer.h>
 
@@ -34,25 +35,34 @@ namespace graphics
 class Mesh
 {
   public:
-	Mesh(VertexBuffer*, GLuint type = GL_TRIANGLES);
-	Mesh(VertexBuffer*, IndexBuffer*, GLuint type = GL_TRIANGLES);
+	enum class Topology
+	{
+		PointList,
+		LineList,
+		LineStrip,
+		TriangleList,
+		TriangleStrip,
+	};
+
+	explicit Mesh(VertexBuffer* vertexBuffer, Topology topology = Topology::TriangleList);
+	Mesh(VertexBuffer* vertexBuffer, IndexBuffer* indexBuffer, Topology topology = Topology::TriangleList);
 	~Mesh();
 
-	std::shared_ptr<VertexBuffer> GetVertexBuffer();
-	std::shared_ptr<IndexBuffer> GetIndexBuffer();
+	[[nodiscard]] const VertexBuffer& GetVertexBuffer() const;
+	[[nodiscard]] const IndexBuffer& GetIndexBuffer() const;
 
-	GLuint GetType() const noexcept;
+	[[nodiscard]] Topology GetTopology() const noexcept;
 
 	void Draw();
 	void Draw(uint32_t count, uint32_t startIndex);
 
   protected:
-	std::shared_ptr<VertexBuffer> _vertexBuffer;
-	std::shared_ptr<IndexBuffer> _indexBuffer;
+	std::unique_ptr<VertexBuffer> _vertexBuffer;
+	std::unique_ptr<IndexBuffer> _indexBuffer;
 
   private:
-	GLuint _vao;
-	GLuint _type;
+	uint32_t _vao;
+	Topology _topology;
 };
 
 } // namespace graphics

--- a/src/Graphics/ShaderProgram.h
+++ b/src/Graphics/ShaderProgram.h
@@ -20,10 +20,11 @@
 
 #pragma once
 
-#include <Graphics/OpenGL.h>
-#include <glm/glm.hpp>
+#include <cstdint>
 #include <map>
 #include <string>
+
+#include <glm/glm.hpp>
 
 namespace openblack
 {
@@ -33,6 +34,13 @@ namespace graphics
 class ShaderProgram
 {
   public:
+	enum class Type
+	{
+		Vertex,
+		Fragment,
+		Compute,
+	};
+
 	ShaderProgram() = delete;
 	ShaderProgram(const std::string& vertexSource, const std::string& fragmentSource);
 	~ShaderProgram();
@@ -48,13 +56,13 @@ class ShaderProgram
 	void SetUniformValue(const char* uniformName, const glm::mat4& m);
 	void SetUniformValue(const char* uniformName, size_t count, const glm::mat4* m);
 
-	GLuint GetRawHandle() const { return _program; }
+	[[nodiscard]] uint32_t GetRawHandle() const { return _program; }
 
   private:
-	GLuint _program;
-	std::map<std::string, GLint> _uniforms;
+	uint32_t _program;
+	std::map<std::string, int32_t> _uniforms;
 
-	GLuint createSubShader(GLenum type, const std::string& source);
+	uint32_t createSubShader(Type type, const std::string& source);
 };
 
 } // namespace graphics

--- a/src/Graphics/Texture2D.cpp
+++ b/src/Graphics/Texture2D.cpp
@@ -41,22 +41,7 @@ Texture2D::~Texture2D()
 	}
 }
 
-void Texture2D::Create(uint32_t width, uint32_t height, uint32_t layers)
-{
-	auto bindPoint = layers > 1 ? GL_TEXTURE_2D_ARRAY : GL_TEXTURE_2D;
-
-	glBindTexture(bindPoint, static_cast<GLuint>(_handle));
-
-	if (layers == 1)
-		glTexImage2D(bindPoint, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
-	else
-		glTexImage3D(bindPoint, 0, GL_RGBA, width, height, layers, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
-
-	glTexParameteri(bindPoint, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glTexParameteri(bindPoint, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-}
-
-void Texture2D::Create(const void* data, size_t size, DataType type, Format format, uint32_t width, uint32_t height, uint32_t layers, InternalFormat internalFormat)
+void Texture2D::Create(uint32_t width, uint32_t height, uint32_t layers, InternalFormat internalFormat, DataType type, Format format, const void* data, size_t size)
 {
 	auto bindPoint = layers > 1 ? GL_TEXTURE_2D_ARRAY : GL_TEXTURE_2D;
 

--- a/src/Graphics/Texture2D.cpp
+++ b/src/Graphics/Texture2D.cpp
@@ -18,13 +18,90 @@
  * along with openblack. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <Graphics/OpenGL.h>
 #include <Graphics/Texture2D.h>
 
 #include <algorithm>
+#include <array>
+
+#include <Graphics/OpenGL.h>
 
 namespace openblack::graphics
 {
+struct TextureFormat
+{
+  const GLenum _internalFormat;
+  const GLenum _format;
+  const GLenum _type;
+  const bool _compressed;
+};
+
+constexpr std::array<TextureFormat, static_cast<size_t>(Format::RGBA4) + 1> textureFormats = {
+	TextureFormat { GL_COMPRESSED_RGBA_S3TC_DXT1_EXT,  GL_COMPRESSED_RGBA_S3TC_DXT1_EXT,  GL_ZERO,                         true,  }, // BlockCompression1
+	TextureFormat { GL_COMPRESSED_RGBA_S3TC_DXT3_EXT,  GL_COMPRESSED_RGBA_S3TC_DXT3_EXT,  GL_ZERO,                         true,  }, // BlockCompression2
+	TextureFormat { GL_COMPRESSED_RGBA_S3TC_DXT5_EXT,  GL_COMPRESSED_RGBA_S3TC_DXT5_EXT,  GL_ZERO,                         true,  }, // BlockCompression3
+	TextureFormat { GL_DEPTH24_STENCIL8,               GL_DEPTH_STENCIL,                  GL_UNSIGNED_INT_24_8,            false, }, // Depth24Stencil8
+	TextureFormat { GL_DEPTH_COMPONENT16,              GL_DEPTH_COMPONENT,                GL_UNSIGNED_SHORT,               false, }, // DepthComponent16
+	TextureFormat { GL_DEPTH_COMPONENT24,              GL_DEPTH_COMPONENT,                GL_UNSIGNED_INT,                 false, }, // DepthComponent24
+	TextureFormat { GL_R16F,                           GL_RED,                            GL_HALF_FLOAT,                   false, }, // R16F
+	TextureFormat { GL_R16I,                           GL_RED,                            GL_SHORT,                        false, }, // R16I
+	TextureFormat { GL_R16_SNORM,                      GL_RED,                            GL_SHORT,                        false, }, // R16SNorm
+	TextureFormat { GL_R16UI,                          GL_RED,                            GL_UNSIGNED_SHORT,               false, }, // R16UI
+	TextureFormat { GL_R32F,                           GL_RED,                            GL_FLOAT,                        false, }, // R32F
+	TextureFormat { GL_R32I,                           GL_RED,                            GL_INT,                          false, }, // R32I
+	TextureFormat { GL_R32UI,                          GL_RED,                            GL_UNSIGNED_INT,                 false, }, // R32UI
+	TextureFormat { GL_R8,                             GL_RED,                            GL_UNSIGNED_BYTE,                false, }, // R8
+	TextureFormat { GL_R8I,                            GL_RED,                            GL_BYTE,                         false, }, // R8I
+	TextureFormat { GL_R8_SNORM,                       GL_RED,                            GL_BYTE,                         false, }, // R8SNorm
+	TextureFormat { GL_R8UI,                           GL_RED,                            GL_UNSIGNED_BYTE,                false, }, // R8UI
+	TextureFormat { GL_RG16,                           GL_RG,                             GL_UNSIGNED_SHORT,               false, }, // RG16
+	TextureFormat { GL_RG16F,                          GL_RG,                             GL_FLOAT,                        false, }, // RG16F
+	TextureFormat { GL_RG16_SNORM,                     GL_RG,                             GL_SHORT,                        false, }, // RG16SNorm
+	TextureFormat { GL_RG32F,                          GL_RG,                             GL_FLOAT,                        false, }, // RG32F
+	TextureFormat { GL_RG32I,                          GL_RG,                             GL_INT,                          false, }, // RG32I
+	TextureFormat { GL_RG32UI,                         GL_RG,                             GL_UNSIGNED_INT,                 false, }, // RG32UI
+	TextureFormat { GL_RG8,                            GL_RG,                             GL_UNSIGNED_BYTE,                false, }, // RG8
+	TextureFormat { GL_RG8I,                           GL_RG,                             GL_BYTE,                         false, }, // RG8I
+	TextureFormat { GL_RG8_SNORM,                      GL_RG,                             GL_BYTE,                         false, }, // RG8SNorm
+	TextureFormat { GL_RG8UI,                          GL_RG,                             GL_UNSIGNED_BYTE,                false, }, // RG8UI
+	TextureFormat { GL_RGB10_A2,                       GL_RGBA,                           GL_UNSIGNED_INT_2_10_10_10_REV,  false, }, // RGB10A2
+	TextureFormat { 0x8D62 /*GL_RGB565*/,              GL_RGB,                            GL_UNSIGNED_SHORT_5_6_5,         false, }, // R5G6B5
+	TextureFormat { GL_RGB5_A1,                        GL_BGRA,                           GL_UNSIGNED_SHORT_1_5_5_5_REV,   false, }, // RGB5A1
+	TextureFormat { GL_RGB8,                           GL_RGB,                            GL_UNSIGNED_BYTE,                false, }, // RGB8
+	TextureFormat { GL_RGB8I,                          GL_RGB,                            GL_BYTE,                         false, }, // RGB8I
+	TextureFormat { GL_RGB8UI,                         GL_RGB,                            GL_UNSIGNED_BYTE,                false, }, // RGB8UI
+	TextureFormat { GL_RGB9_E5,                        GL_RGB,                            GL_UNSIGNED_INT_5_9_9_9_REV,     false, }, // RGB9E5
+	TextureFormat { GL_RGBA8,                          GL_RGBA,                           GL_UNSIGNED_BYTE,                false, }, // RGBA8
+	TextureFormat { GL_RGBA8I,                         GL_RGBA,                           GL_BYTE,                         false, }, // RGBA8I
+	TextureFormat { GL_RGBA8UI,                        GL_RGBA,                           GL_UNSIGNED_BYTE,                false, }, // RGBA8UI
+	TextureFormat { GL_RGBA8_SNORM,                    GL_RGBA,                           GL_BYTE,                         false, }, // RGBA8SNorm
+	TextureFormat { GL_RGBA8,                          GL_BGRA,                           GL_UNSIGNED_BYTE,                false, }, // BGRA8
+	TextureFormat { GL_RGBA16,                         GL_RGBA,                           GL_UNSIGNED_SHORT,               false, }, // RGBA16
+	TextureFormat { GL_RGBA16F,                        GL_RGBA,                           GL_HALF_FLOAT,                   false, }, // RGBA16F
+	TextureFormat { GL_RGBA16I,                        GL_RGBA,                           GL_SHORT,                        false, }, // RGBA16I
+	TextureFormat { GL_RGBA16UI,                       GL_RGBA,                           GL_UNSIGNED_SHORT,               false, }, // RGBA16UI
+	TextureFormat { GL_RGBA16_SNORM,                   GL_RGBA,                           GL_SHORT,                        false, }, // RGBA16SNorm
+	TextureFormat { GL_RGBA32F,                        GL_RGBA,                           GL_FLOAT,                        false, }, // RGBA32F
+	TextureFormat { GL_RGBA32I,                        GL_RGBA,                           GL_INT,                          false, }, // RGBA32I
+	TextureFormat { GL_RGBA32UI,                       GL_RGBA,                           GL_UNSIGNED_INT,                 false, }, // RGBA32UI
+	TextureFormat { GL_RGBA4,                          GL_BGRA,                           GL_UNSIGNED_SHORT_4_4_4_4_REV,   false, }, // RGBA4
+};
+
+constexpr std::array<GLenum, static_cast<size_t>(Filter::LinearMipmapLinear) + 1> filters {
+	GL_NEAREST,
+	GL_LINEAR,
+	GL_NEAREST_MIPMAP_NEAREST,
+	GL_LINEAR_MIPMAP_NEAREST,
+	GL_NEAREST_MIPMAP_LINEAR,
+	GL_LINEAR_MIPMAP_LINEAR
+};
+
+constexpr std::array<GLenum, static_cast<size_t>(Wrapping::MirroredRepeat) + 1> wrappingModes {
+	GL_CLAMP_TO_EDGE,
+	GL_CLAMP_TO_BORDER,
+	GL_REPEAT,
+	GL_MIRRORED_REPEAT
+};
+
 Texture2D::Texture2D()
 {
 	GLuint texture;
@@ -41,31 +118,30 @@ Texture2D::~Texture2D()
 	}
 }
 
-void Texture2D::Create(uint32_t width, uint32_t height, uint32_t layers, InternalFormat internalFormat, DataType type, Format format, const void* data, size_t size)
+void Texture2D::Create(uint32_t width, uint32_t height, uint32_t layers, Format format, Wrapping wrapping, const void* data, size_t size)
 {
 	auto bindPoint = layers > 1 ? GL_TEXTURE_2D_ARRAY : GL_TEXTURE_2D;
-
-	bool isCompressed = internalFormat == InternalFormat::CompressedRGBAS3TCDXT1 || internalFormat == InternalFormat::CompressedRGBAS3TCDXT3;
+	auto textureFormat = textureFormats[static_cast<size_t>(format)];
 
 	glBindTexture(bindPoint, static_cast<GLuint>(_handle));
 
-	if (isCompressed)
+	if (textureFormat._compressed)
 	{
 		if (layers == 1)
-			glCompressedTexImage2D(bindPoint, 0, static_cast<GLenum>(internalFormat), width, height, 0, size, data);
+			glCompressedTexImage2D(bindPoint, 0, textureFormat._internalFormat, width, height, 0, size, data);
 		else
-			glCompressedTexImage3D(bindPoint, 0, static_cast<GLenum>(internalFormat), width, height, layers, 0, size, data);
+			glCompressedTexImage3D(bindPoint, 0, textureFormat._internalFormat, width, height, layers, 0, size, data);
 	}
 	else
 	{
 		if (layers==1)
-			glTexImage2D(bindPoint, 0, static_cast<GLint>(internalFormat), width, height, 0, static_cast<GLenum>(format), static_cast<GLenum>(type), data);
+			glTexImage2D(bindPoint, 0, textureFormat._internalFormat, width, height, 0, textureFormat._format, textureFormat._type, data);
 		else
-			glTexImage3D(bindPoint, 0, static_cast<GLint>(internalFormat), width, height, layers, 0, static_cast<GLenum>(format), static_cast<GLenum>(type), data);
+			glTexImage3D(bindPoint, 0, textureFormat._internalFormat, width, height, layers, 0, textureFormat._format, textureFormat._type, data);
 	}
 
-	glTexParameteri(bindPoint, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	glTexParameteri(bindPoint, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	glTexParameteri(bindPoint, GL_TEXTURE_WRAP_S, wrappingModes[static_cast<size_t>(wrapping)]);
+	glTexParameteri(bindPoint, GL_TEXTURE_WRAP_T, wrappingModes[static_cast<size_t>(wrapping)]);
 	glTexParameteri(bindPoint, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 	glTexParameteri(bindPoint, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 

--- a/src/Graphics/Texture2D.cpp
+++ b/src/Graphics/Texture2D.cpp
@@ -74,8 +74,10 @@ void Texture2D::Create(uint32_t width, uint32_t height, uint32_t layers, Interna
 	_layers = layers;
 }
 
-void Texture2D::Bind() const
+void Texture2D::Bind(uint8_t textureBindingPoint) const
 {
+	glActiveTexture(GL_TEXTURE0 + textureBindingPoint);
+
 	auto bindPoint = _layers > 1 ? GL_TEXTURE_2D_ARRAY : GL_TEXTURE_2D;
 	auto texture = static_cast<GLuint>(_handle);
 	glBindTexture(bindPoint, texture);

--- a/src/Graphics/Texture2D.h
+++ b/src/Graphics/Texture2D.h
@@ -21,9 +21,6 @@
 #pragma once
 
 #include <cstdint>
-
-#include <Graphics/OpenGL.h>
-
 #include <cstddef>
 
 namespace openblack
@@ -31,125 +28,74 @@ namespace openblack
 namespace graphics
 {
 
-enum class InternalFormat : GLint
+enum class Format : uint8_t
 {
-	CompressedRGBAS3TCDXT1   = GL_COMPRESSED_RGBA_S3TC_DXT1_EXT,
-	CompressedRGBAS3TCDXT3   = GL_COMPRESSED_RGBA_S3TC_DXT3_EXT,
-	DepthStencil             = GL_DEPTH_STENCIL,
-	Depth24Stencil8          = GL_DEPTH24_STENCIL8,
-	Depth32FStencil8         = GL_DEPTH32F_STENCIL8,
-	DepthComponent           = GL_DEPTH_COMPONENT,
-	DepthComponent16         = GL_DEPTH_COMPONENT16,
-	DepthComponent24         = GL_DEPTH_COMPONENT24,
-	DepthComponent32F        = GL_DEPTH_COMPONENT32F,
-	R16F                     = GL_R16F,
-	R16I                     = GL_R16I,
-	R16SNorm                 = GL_R16_SNORM,
-	R16UI                    = GL_R16UI,
-	R32F                     = GL_R32F,
-	R32I                     = GL_R32I,
-	R32UI                    = GL_R32UI,
-	R3G3B2                   = GL_R3_G3_B2,
-	R8                       = GL_R8,
-	R8I                      = GL_R8I,
-	R8SNorm                  = GL_R8_SNORM,
-	R8UI                     = GL_R8UI,
-	RG                       = GL_RG,
-	RG16                     = GL_RG16,
-	RG16F                    = GL_RG16F,
-	RG16SNorm                = GL_RG16_SNORM,
-	RG32F                    = GL_RG32F,
-	RG32I                    = GL_RG32I,
-	RG32UI                   = GL_RG32UI,
-	RG8                      = GL_RG8,
-	RG8I                     = GL_RG8I,
-	RG8SNorm                 = GL_RG8_SNORM,
-	RG8UI                    = GL_RG8UI,
-	RGB                      = GL_RGB,
-	RGB10                    = GL_RGB10,
-	RGB10A2                  = GL_RGB10_A2,
-	RGB12                    = GL_RGB12,
-	RGB16                    = GL_RGB16,
-	RGB16F                   = GL_RGB16F,
-	RGB16I                   = GL_RGB16I,
-	RGB16UI                  = GL_RGB16UI,
-	RGB32F                   = GL_RGB32F,
-	RGB32I                   = GL_RGB32I,
-	RGB32UI                  = GL_RGB32UI,
-	RGB4                     = GL_RGB4,
-	RGB5                     = GL_RGB5,
-	RGB5A1                   = GL_RGB5_A1,
-	RGB8                     = GL_RGB8,
-	RGB8I                    = GL_RGB8I,
-	RGB8UI                   = GL_RGB8UI,
-	RGB9E5                   = GL_RGB9_E5,
-	RGBA                     = GL_RGBA,
-	RGBA12                   = GL_RGBA12,
-	RGBA16                   = GL_RGBA16,
-	RGBA16F                  = GL_RGBA16F,
-	RGBA16I                  = GL_RGBA16I,
-	RGBA16UI                 = GL_RGBA16UI,
-	RGBA2                    = GL_RGBA2,
-	RGBA32F                  = GL_RGBA32F,
-	RGBA32I                  = GL_RGBA32I,
-	RGBA32UI                 = GL_RGBA32UI,
-	RGBA4                    = GL_RGBA4,
-	RGBA8                    = GL_RGBA8,
-	RGBA8UI                  = GL_RGBA8UI,
-	SRGB8                    = GL_SRGB8,
-	SRGB8A8                  = GL_SRGB8_ALPHA8,
-	SRGBA                    = GL_SRGB_ALPHA,
+	BlockCompression1,
+	BlockCompression2,
+	BlockCompression3,
+	Depth24Stencil8,
+	DepthComponent16,
+	DepthComponent24,
+	R16F,
+	R16I,
+	R16SNorm,
+	R16UI,
+	R32F,
+	R32I,
+	R32UI,
+	R8,
+	R8I,
+	R8SNorm,
+	R8UI,
+	RG16,
+	RG16F,
+	RG16SNorm,
+	RG32F,
+	RG32I,
+	RG32UI,
+	RG8,
+	RG8I,
+	RG8SNorm,
+	RG8UI,
+	RGB10A2,
+	R5G6B5,
+	RGB5A1,
+	RGB8,
+	RGB8I,
+	RGB8UI,
+	RGB9E5,
+	RGBA8,
+	RGBA8I,
+	RGBA8UI,
+	RGBA8SNorm,
+	BGRA8,
+	RGBA16,
+	RGBA16F,
+	RGBA16I,
+	RGBA16UI,
+	RGBA16SNorm,
+	RGBA32F,
+	RGBA32I,
+	RGBA32UI,
+	RGBA4,
 };
 
-enum class Format : GLenum
+enum class Filter : uint8_t
 {
-	Red  = GL_RED,
-	RGB  = GL_RGB,
-	BGR  = GL_BGR,
-	RGBA = GL_RGBA,
-	BGRA = GL_BGRA
+	Nearest,
+	Linear,
+	NearestMipmapNearest,
+	LinearMipmapNearest,
+	NearestMipmapLinear,
+	LinearMipmapLinear,
 };
 
-enum class DataType : GLenum
+enum class Wrapping : uint8_t
 {
-	Byte          = GL_BYTE,
-	UnsignedByte  = GL_UNSIGNED_BYTE,
-	Short         = GL_SHORT,
-	UnsignedShort = GL_UNSIGNED_SHORT,
-	Int           = GL_INT,
-	UnsignedInt   = GL_UNSIGNED_INT,
-	Float         = GL_FLOAT,
-	Double        = GL_DOUBLE,
-
-	UnsignedByte332      = GL_UNSIGNED_BYTE_3_3_2,
-	UnsignedByte233Rev   = GL_UNSIGNED_BYTE_2_3_3_REV,
-	UnsignedShort565     = GL_UNSIGNED_SHORT_5_6_5,
-	UnsignedShort565Rev  = GL_UNSIGNED_SHORT_5_6_5,
-	UnsignedShort4444    = GL_UNSIGNED_SHORT_4_4_4_4,
-	UnsignedShort4444Rev = GL_UNSIGNED_SHORT_4_4_4_4_REV,
-	UnsignedShort5551    = GL_UNSIGNED_SHORT_5_5_5_1,
-	UnsignedShort1555Rev = GL_UNSIGNED_SHORT_1_5_5_5_REV,
-	UnsignedInt8888      = GL_UNSIGNED_INT_8_8_8_8,
-	UnsignedInt8888Rev   = GL_UNSIGNED_INT_8_8_8_8_REV,
-	UnsignedInt101010102 = GL_UNSIGNED_INT_10_10_10_2
-};
-
-enum class Filter : GLenum
-{
-	Nearest              = GL_NEAREST,
-	Linear               = GL_LINEAR,
-	NearestMipmapNearest = GL_NEAREST_MIPMAP_NEAREST,
-	LinearMipmapNearest  = GL_LINEAR_MIPMAP_NEAREST,
-	NearestMipmapLinear  = GL_NEAREST_MIPMAP_LINEAR,
-	LinearMipmapLinear   = GL_LINEAR_MIPMAP_LINEAR
-};
-
-enum class Wrapping : GLenum
-{
-	ClampEdge      = GL_CLAMP_TO_EDGE,
-	ClampBorder    = GL_CLAMP_TO_BORDER,
-	Repeat         = GL_REPEAT,
-	MirroredRepeat = GL_MIRRORED_REPEAT
+	ClampEdge,
+	ClampBorder,
+	Repeat,
+	MirroredRepeat,
 };
 
 class Texture2D
@@ -162,7 +108,7 @@ class Texture2D
 	Texture2D(const Texture2D&) = delete;
 	Texture2D& operator=(const Texture2D&) = delete;
 
-	void Create(uint32_t width, uint32_t height, uint32_t layers, InternalFormat internalFormat=InternalFormat::RGBA, DataType type=DataType::UnsignedByte, Format format=Format::RGBA, const void* data=nullptr, size_t size=0);
+	void Create(uint32_t width, uint32_t height, uint32_t layers, Format format=Format::RGBA8, Wrapping wrapping=Wrapping::ClampEdge, const void* data=nullptr, size_t size=0);
 
 	[[nodiscard]] uint32_t GetNativeHandle() const { return _handle; }
 	[[nodiscard]] uint32_t GetWidth() const { return _width; }

--- a/src/Graphics/Texture2D.h
+++ b/src/Graphics/Texture2D.h
@@ -162,8 +162,7 @@ class Texture2D
 	Texture2D(const Texture2D&) = delete;
 	Texture2D& operator=(const Texture2D&) = delete;
 
-	void Create(uint32_t width, uint32_t height, uint32_t layers);
-	void Create(const void* data, size_t size, DataType type, Format format, uint32_t width, uint32_t height, uint32_t layers, InternalFormat internalFormat);
+	void Create(uint32_t width, uint32_t height, uint32_t layers, InternalFormat internalFormat=InternalFormat::RGBA, DataType type=DataType::UnsignedByte, Format format=Format::RGBA, const void* data=nullptr, size_t size=0);
 	void CreateCompressed(const void* data, size_t size, uint32_t width, uint32_t height, uint32_t layers, InternalFormat internalFormat);
 
 	[[nodiscard]] uint32_t GetNativeHandle() const { return _handle; }

--- a/src/Graphics/Texture2D.h
+++ b/src/Graphics/Texture2D.h
@@ -163,7 +163,6 @@ class Texture2D
 	Texture2D& operator=(const Texture2D&) = delete;
 
 	void Create(uint32_t width, uint32_t height, uint32_t layers, InternalFormat internalFormat=InternalFormat::RGBA, DataType type=DataType::UnsignedByte, Format format=Format::RGBA, const void* data=nullptr, size_t size=0);
-	void CreateCompressed(const void* data, size_t size, uint32_t width, uint32_t height, uint32_t layers, InternalFormat internalFormat);
 
 	[[nodiscard]] uint32_t GetNativeHandle() const { return _handle; }
 	[[nodiscard]] uint32_t GetWidth() const { return _width; }

--- a/src/Graphics/Texture2D.h
+++ b/src/Graphics/Texture2D.h
@@ -169,7 +169,7 @@ class Texture2D
 	[[nodiscard]] uint32_t GetHeight() const { return _height; }
 	[[nodiscard]] uint32_t GetLayerCount() const { return _layers; }
 
-	void Bind() const;
+	void Bind(uint8_t textureBindingPoint) const;
 
 	void GenerateMipmap();
 


### PR DESCRIPTION
Add enums for opengl types.
Remove include of opengl from headers and move them to impl files.