### PR TITLE
index buffer: Add function to bind itself

### DIFF
--- a/src/Graphics/IndexBuffer.cpp
+++ b/src/Graphics/IndexBuffer.cpp
@@ -69,12 +69,12 @@ IndexBuffer::Type IndexBuffer::GetType() const
 	return _type;
 }
 
-uint32_t IndexBuffer::GetIBO() const
-{
-	return _ibo;
-}
-
 std::size_t IndexBuffer::GetTypeSize(Type type)
 {
 	return type == Type::Uint16 ? sizeof(uint16_t) : sizeof(uint32_t);
+}
+
+void IndexBuffer::Bind()
+{
+	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, _ibo);
 }

--- a/src/Graphics/IndexBuffer.h
+++ b/src/Graphics/IndexBuffer.h
@@ -49,7 +49,8 @@ class IndexBuffer
 	std::size_t GetSize() const;
 	std::size_t GetStride() const;
 	Type GetType() const;
-	uint32_t GetIBO() const;
+
+	void Bind();
 
   private:
 	std::size_t _count;

--- a/src/Graphics/Mesh.cpp
+++ b/src/Graphics/Mesh.cpp
@@ -61,7 +61,7 @@ Mesh::Mesh(VertexBuffer* vertexBuffer, IndexBuffer* indexBuffer, Topology topolo
 
 	_vertexBuffer->Bind();
 	_vertexBuffer->bindVertexDecl();
-	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, _indexBuffer->GetIBO());
+	_indexBuffer->Bind();
 
 	glBindVertexArray(0);
 }


### PR DESCRIPTION
Move index binding (`glBindBuffer(GL_ELEMENT_ARRAY_BUFFER...)` to the index
class.
Remove `GetIBO` to discourage external use of `_ibo`.