### PR TITLE
Shader Cleanup

### DIFF
--- a/assets/shaders/line.frag
+++ b/assets/shaders/line.frag
@@ -1,9 +1,8 @@
 #version 150 core
 
 in vec4 v_color;
-out vec4 outColor;
 
 void main()
 {
-    outColor = v_color;
+    gl_FragColor = v_color;
 }

--- a/assets/shaders/line.frag
+++ b/assets/shaders/line.frag
@@ -2,7 +2,9 @@
 
 in vec4 v_color;
 
+out vec4 o_color;
+
 void main()
 {
-    gl_FragColor = v_color;
+    o_color = v_color;
 }

--- a/assets/shaders/line.vert
+++ b/assets/shaders/line.vert
@@ -1,7 +1,7 @@
 #version 330 core
 
-layout(location = 0) in vec3 in_pos;
-layout(location = 1) in vec3 in_col;
+layout(location = 0) in vec3 a_position;
+layout(location = 1) in vec3 a_color0;
 
 uniform mat4 u_viewProj;
 uniform mat4 u_model;
@@ -10,6 +10,6 @@ out vec4 v_color;
 
 void main()
 {
-    gl_Position = u_viewProj * u_model * vec4(in_pos, 1.0);
-    v_color = vec4(in_col, 1.0);
+	gl_Position = u_viewProj * u_model * vec4(a_position, 1.0);
+	v_color = vec4(a_color0, 1.0);
 }

--- a/assets/shaders/line.vert
+++ b/assets/shaders/line.vert
@@ -3,13 +3,13 @@
 layout(location = 0) in vec3 in_pos;
 layout(location = 1) in vec3 in_col;
 
-uniform mat4 u_viewProjection;
+uniform mat4 u_viewProj;
 uniform mat4 u_model;
 
 out vec4 v_color;
 
 void main()
 {
-    gl_Position = u_viewProjection * u_model * vec4(in_pos, 1.0);
+    gl_Position = u_viewProj * u_model * vec4(in_pos, 1.0);
     v_color = vec4(in_col, 1.0);
 }

--- a/assets/shaders/object.frag
+++ b/assets/shaders/object.frag
@@ -1,10 +1,9 @@
 #version 150 core
 
-in vec3 v_norm;
-out vec4 outColor;
+in vec3 v_normal;
 
 void main()
 {
-	vec3 col = 0.5 + 0.5 * v_norm;
-    outColor = vec4(col, 1.0);
+	vec3 col = 0.5 + 0.5 * v_normal;
+	gl_FragColor = vec4(col, 1.0);
 }

--- a/assets/shaders/object.frag
+++ b/assets/shaders/object.frag
@@ -2,8 +2,10 @@
 
 in vec3 v_normal;
 
+out vec4 o_color;
+
 void main()
 {
 	vec3 col = 0.5 + 0.5 * v_normal;
-	gl_FragColor = vec4(col, 1.0);
+	o_color = vec4(col, 1.0);
 }

--- a/assets/shaders/object.vert
+++ b/assets/shaders/object.vert
@@ -6,11 +6,11 @@ layout(location = 2) in vec3 normal;
 
 out vec3 v_norm;
 
-uniform mat4 viewProj;
-uniform mat4 modelTransform;
+uniform mat4 u_viewProj;
+uniform mat4 u_model;
 
 void main()
 {
 	v_norm = normal;
-	gl_Position = viewProj * modelTransform * vec4(position, 1.0);
+	gl_Position = u_viewProj * u_model * vec4(position, 1.0);
 }

--- a/assets/shaders/object.vert
+++ b/assets/shaders/object.vert
@@ -1,8 +1,8 @@
 #version 330 core
 
-layout(location = 0) in vec3 position;
-layout(location = 1) in vec2 tex;
-layout(location = 2) in vec3 normal;
+layout(location = 0) in vec3 a_position;
+layout(location = 1) in vec2 a_texcoord0;
+layout(location = 2) in vec3 a_normal;
 
 out vec3 v_norm;
 
@@ -12,5 +12,5 @@ uniform mat4 u_model;
 void main()
 {
 	v_norm = normal;
-	gl_Position = u_viewProj * u_model * vec4(position, 1.0);
+	gl_Position = u_viewProj * u_model * vec4(a_position, 1.0);
 }

--- a/assets/shaders/object.vert
+++ b/assets/shaders/object.vert
@@ -4,13 +4,13 @@ layout(location = 0) in vec3 a_position;
 layout(location = 1) in vec2 a_texcoord0;
 layout(location = 2) in vec3 a_normal;
 
-out vec3 v_norm;
+out vec3 v_normal;
 
 uniform mat4 u_viewProj;
 uniform mat4 u_model;
 
 void main()
 {
-	v_norm = normal;
+	v_normal = normal;
 	gl_Position = u_viewProj * u_model * vec4(a_position, 1.0);
 }

--- a/assets/shaders/skin.frag
+++ b/assets/shaders/skin.frag
@@ -2,11 +2,9 @@
 
 uniform sampler2D tex;
 
-in vec3 v_pos;
-in vec3 v_norm;
-in vec2 v_tex;
-
-out vec4 color;
+in vec3 v_position;
+in vec3 v_normal;
+in vec2 v_texcoord0;
 
 float alphaThreshold = 1.0 / 255.0;
 
@@ -16,17 +14,17 @@ void main()
 	vec3 lightPos = vec3(-4000, 1300, -1435);
 
 	// ambient
-    float ambientStrength = 0.5;
-    vec3 ambient = ambientStrength * lightColor;
+	float ambientStrength = 0.5;
+	vec3 ambient = ambientStrength * lightColor;
 
-    // diffuse
-	vec3 norm = normalize(v_norm);
-	vec3 lightDir = normalize(lightPos - v_pos);
-	float diff = max(dot(norm, lightDir), 0.0);
+	// diffuse
+	vec3 norm = normalize(v_normal);
+	vec3 lightDir = normalize(lightPos - v_position);
+	float diff = max(dot(v_normal, lightDir), 0.0);
 	vec3 diffuse = diff * lightColor * 0.5;
 
-	vec4 diffuseTex = texture2D(tex, v_tex);
+	vec4 diffuseTex = texture2D(tex, v_texcoord0);
 	diffuseTex.rgb = diffuseTex.rgb * (ambient + diffuse);
 	if(diffuseTex.a <= alphaThreshold) discard;
-	color = diffuseTex;
+	gl_FragColor = diffuseTex;
 }

--- a/assets/shaders/skin.frag
+++ b/assets/shaders/skin.frag
@@ -1,6 +1,6 @@
 #version 330
 
-uniform sampler2D tex;
+uniform sampler2D s_diffuse;
 
 in vec3 v_position;
 in vec3 v_normal;
@@ -23,7 +23,7 @@ void main()
 	float diff = max(dot(v_normal, lightDir), 0.0);
 	vec3 diffuse = diff * lightColor * 0.5;
 
-	vec4 diffuseTex = texture2D(tex, v_texcoord0);
+	vec4 diffuseTex = texture2D(s_diffuse, v_texcoord0);
 	diffuseTex.rgb = diffuseTex.rgb * (ambient + diffuse);
 	if(diffuseTex.a <= alphaThreshold) discard;
 	gl_FragColor = diffuseTex;

--- a/assets/shaders/skin.frag
+++ b/assets/shaders/skin.frag
@@ -6,6 +6,8 @@ in vec3 v_position;
 in vec3 v_normal;
 in vec2 v_texcoord0;
 
+out vec4 o_color;
+
 float alphaThreshold = 1.0 / 255.0;
 
 void main()
@@ -26,5 +28,5 @@ void main()
 	vec4 diffuseTex = texture2D(s_diffuse, v_texcoord0);
 	diffuseTex.rgb = diffuseTex.rgb * (ambient + diffuse);
 	if(diffuseTex.a <= alphaThreshold) discard;
-	gl_FragColor = diffuseTex;
+	o_color = diffuseTex;
 }

--- a/assets/shaders/skin.vert
+++ b/assets/shaders/skin.vert
@@ -4,8 +4,8 @@ layout(location = 0) in vec3 in_pos;
 layout(location = 1) in vec2 in_tex;
 layout(location = 2) in vec3 in_norm;
 
-uniform mat4 u_viewProjection;
-uniform mat4 u_modelTransform;
+uniform mat4 u_viewProj;
+uniform mat4 u_model;
 
 out vec3 v_pos;
 out vec3 v_norm;
@@ -13,9 +13,9 @@ out vec2 v_tex;
 
 void main()
 {
-	gl_Position = u_viewProjection * u_modelTransform * vec4(in_pos, 1.0);
+	gl_Position = u_viewProj * u_model * vec4(in_pos, 1.0);
 
-	v_pos = (u_modelTransform * vec4(in_pos, 1.0)).xyz;
+	v_pos = (u_model * vec4(in_pos, 1.0)).xyz;
 	v_norm = in_norm;
 	v_tex = in_tex;
 }

--- a/assets/shaders/skin.vert
+++ b/assets/shaders/skin.vert
@@ -1,8 +1,8 @@
 #version 330 core
 
-layout(location = 0) in vec3 in_pos;
-layout(location = 1) in vec2 in_tex;
-layout(location = 2) in vec3 in_norm;
+layout(location = 0) in vec3 a_position;
+layout(location = 1) in vec2 a_texcoord0;
+layout(location = 2) in vec3 a_normal;
 
 uniform mat4 u_viewProj;
 uniform mat4 u_model;
@@ -13,9 +13,9 @@ out vec2 v_tex;
 
 void main()
 {
-	gl_Position = u_viewProj * u_model * vec4(in_pos, 1.0);
+	gl_Position = u_viewProj * u_model * vec4(a_position, 1.0);
 
-	v_pos = (u_model * vec4(in_pos, 1.0)).xyz;
-	v_norm = in_norm;
-	v_tex = in_tex;
+	v_pos = (u_model * vec4(a_position, 1.0)).xyz;
+	v_norm = a_normal;
+	v_tex = a_texcoord0;
 }

--- a/assets/shaders/skin.vert
+++ b/assets/shaders/skin.vert
@@ -7,15 +7,15 @@ layout(location = 2) in vec3 a_normal;
 uniform mat4 u_viewProj;
 uniform mat4 u_model;
 
-out vec3 v_pos;
-out vec3 v_norm;
-out vec2 v_tex;
+out vec3 v_position;
+out vec3 v_normal;
+out vec2 v_texcoord0;
 
 void main()
 {
 	gl_Position = u_viewProj * u_model * vec4(a_position, 1.0);
 
-	v_pos = (u_model * vec4(a_position, 1.0)).xyz;
-	v_norm = a_normal;
-	v_tex = a_texcoord0;
+	v_position = (u_model * vec4(a_position, 1.0)).xyz;
+	v_normal = a_normal;
+	v_texcoord0 = a_texcoord0;
 }

--- a/assets/shaders/sky.frag
+++ b/assets/shaders/sky.frag
@@ -1,17 +1,15 @@
 #version 150 core
 
-in vec3 v_norm;
-in vec2 TexCoord;
-
-out vec4 outColor;
+in vec3 v_normal;
+in vec2 v_texcoord0;
 
 uniform sampler2D tex;
 
 void main()
 {
-	vec3 col = 0.5 + 0.5 * v_norm;
-    outColor = vec4(col, 1.0);
+	vec3 col = 0.5 + 0.5 * v_normal;
+	vec4 outColor = vec4(col, 1.0);
 
-	outColor = texture(tex, TexCoord);
+	outColor = texture(tex, v_texcoord0);
 	outColor.a = 1.0f;
 }

--- a/assets/shaders/sky.frag
+++ b/assets/shaders/sky.frag
@@ -3,13 +3,13 @@
 in vec3 v_normal;
 in vec2 v_texcoord0;
 
-uniform sampler2D tex;
+uniform sampler2D s_diffuse;
 
 void main()
 {
 	vec3 col = 0.5 + 0.5 * v_normal;
 	vec4 outColor = vec4(col, 1.0);
 
-	outColor = texture(tex, v_texcoord0);
+	outColor = texture(s_diffuse, v_texcoord0);
 	outColor.a = 1.0f;
 }

--- a/assets/shaders/sky.frag
+++ b/assets/shaders/sky.frag
@@ -5,11 +5,13 @@ in vec2 v_texcoord0;
 
 uniform sampler2D s_diffuse;
 
+out vec4 o_color;
+
 void main()
 {
 	vec3 col = 0.5 + 0.5 * v_normal;
-	vec4 outColor = vec4(col, 1.0);
+	o_color = vec4(col, 1.0);
 
-	outColor = texture(s_diffuse, v_texcoord0);
-	outColor.a = 1.0f;
+	o_color = texture(s_diffuse, v_texcoord0);
+	o_color.a = 1.0f;
 }

--- a/assets/shaders/sky.vert
+++ b/assets/shaders/sky.vert
@@ -1,8 +1,8 @@
 #version 330 core
 
-layout(location = 0) in vec3 position;
-layout(location = 1) in vec2 tex;
-layout(location = 2) in vec3 normal;
+layout(location = 0) in vec3 a_position;
+layout(location = 1) in vec2 a_texcoord0;
+layout(location = 2) in vec3 a_normal;
 
 out vec3 v_norm;
 out vec2 TexCoord;
@@ -11,8 +11,8 @@ uniform mat4 u_viewProj;
 
 void main()
 {
-	v_norm = normal;
-	TexCoord = tex;
+	v_norm = a_normal;
+	TexCoord = a_texcoord0;
 
-	gl_Position = u_viewProj * vec4(position, 1.0);
+	gl_Position = u_viewProj * vec4(a_position, 1.0);
 }

--- a/assets/shaders/sky.vert
+++ b/assets/shaders/sky.vert
@@ -7,12 +7,12 @@ layout(location = 2) in vec3 normal;
 out vec3 v_norm;
 out vec2 TexCoord;
 
-uniform mat4 viewProj;
+uniform mat4 u_viewProj;
 
 void main()
 {
 	v_norm = normal;
 	TexCoord = tex;
 
-	gl_Position = viewProj * vec4(position, 1.0);
+	gl_Position = u_viewProj * vec4(position, 1.0);
 }

--- a/assets/shaders/sky.vert
+++ b/assets/shaders/sky.vert
@@ -4,15 +4,15 @@ layout(location = 0) in vec3 a_position;
 layout(location = 1) in vec2 a_texcoord0;
 layout(location = 2) in vec3 a_normal;
 
-out vec3 v_norm;
-out vec2 TexCoord;
+out vec3 v_normal;
+out vec2 v_texcoord0;
 
 uniform mat4 u_viewProj;
 
 void main()
 {
-	v_norm = a_normal;
-	TexCoord = a_texcoord0;
+	v_normal = a_normal;
+	v_texcoord0 = a_texcoord0;
 
 	gl_Position = u_viewProj * vec4(a_position, 1.0);
 }

--- a/assets/shaders/terrain.frag
+++ b/assets/shaders/terrain.frag
@@ -11,9 +11,9 @@ in float WaterAlpha;
 uniform sampler2DArray sMaterials;
 uniform sampler2D sBumpMap;
 uniform sampler2D sSmallBumpMap;
-uniform float timeOfDay;
-uniform float bumpmapStrength;
-uniform float smallBumpmapStrength;
+uniform float u_timeOfDay;
+uniform float u_bumpmapStrength;
+uniform float u_smallBumpmapStrength;
 
 out vec4 FragColor;
 
@@ -40,14 +40,14 @@ void main()
 	vec4 col = colOne + colTwo + colThree;
 
 	// apply bump map (2x because it's half bright?)
-	float bump = mix(1.0f, texture(sBumpMap, UV).r * 2, bumpmapStrength);
+	float bump = mix(1.0f, texture(sBumpMap, UV).r * 2, u_bumpmapStrength);
 	col = col * bump;
 
-	float smallbump = 1 - mix(0.0f, texture(sSmallBumpMap, UV * 10).r, smallBumpmapStrength);
+	float smallbump = 1 - mix(0.0f, texture(sSmallBumpMap, UV * 10).r, u_smallBumpmapStrength);
 	col = col * smallbump;
 
 	// apply light map
-	col = col * mix(.25f, clamp(LightLevel * 2, 0.5, 1), timeOfDay);
+	col = col * mix(.25f, clamp(LightLevel * 2, 0.5, 1), u_timeOfDay);
 
 	FragColor = vec4(col.r, col.g, col.b, WaterAlpha);
 

--- a/assets/shaders/terrain.frag
+++ b/assets/shaders/terrain.frag
@@ -8,9 +8,9 @@ flat in vec3 v_MaterialBlendCoefficient;
 in float v_LightLevel;
 in float v_WaterAlpha;
 
-uniform sampler2DArray sMaterials;
-uniform sampler2D sBumpMap;
-uniform sampler2D sSmallBumpMap;
+uniform sampler2DArray s_materials;
+uniform sampler2D s_bump;
+uniform sampler2D s_smallBump;
 uniform float u_timeOfDay;
 uniform float u_bumpmapStrength;
 uniform float u_smallBumpmapStrength;
@@ -21,18 +21,18 @@ void main()
 {
 	// do each vert with both materials
 	vec4 colOne = mix(
-		texture(sMaterials, vec3(v_texcoord0, v_FirstMaterialID.r)),
-		texture(sMaterials, vec3(v_texcoord0, v_SecondMaterialID.r)),
+		texture(s_materials, vec3(v_texcoord0, v_FirstMaterialID.r)),
+		texture(s_materials, vec3(v_texcoord0, v_SecondMaterialID.r)),
 		v_MaterialBlendCoefficient.r
 	) * v_weights.r;
 	vec4 colTwo = mix(
-		texture(sMaterials, vec3(v_texcoord0, v_FirstMaterialID.g)),
-		texture(sMaterials, vec3(v_texcoord0, v_SecondMaterialID.g)),
+		texture(s_materials, vec3(v_texcoord0, v_FirstMaterialID.g)),
+		texture(s_materials, vec3(v_texcoord0, v_SecondMaterialID.g)),
 		v_MaterialBlendCoefficient.g
 	) * v_weights.g;
 	vec4 colThree = mix(
-		texture(sMaterials, vec3(v_texcoord0, v_FirstMaterialID.b)),
-		texture(sMaterials, vec3(v_texcoord0, v_SecondMaterialID.b)),
+		texture(s_materials, vec3(v_texcoord0, v_FirstMaterialID.b)),
+		texture(s_materials, vec3(v_texcoord0, v_SecondMaterialID.b)),
 		v_MaterialBlendCoefficient.b
 	) * v_weights.b;
 
@@ -40,10 +40,10 @@ void main()
 	vec4 col = colOne + colTwo + colThree;
 
 	// apply bump map (2x because it's half bright?)
-	float bump = mix(1.0f, texture(sBumpMap, v_texcoord0).r * 2, u_bumpmapStrength);
+	float bump = mix(1.0f, texture(s_bump, v_texcoord0).r * 2, u_bumpmapStrength);
 	col = col * bump;
 
-	float smallbump = 1 - mix(0.0f, texture(sSmallBumpMap, v_texcoord0 * 10).r, u_smallBumpmapStrength);
+	float smallbump = 1 - mix(0.0f, texture(s_smallBump, v_texcoord0 * 10).r, u_smallBumpmapStrength);
 	col = col * smallbump;
 
 	// apply light map

--- a/assets/shaders/terrain.frag
+++ b/assets/shaders/terrain.frag
@@ -15,7 +15,7 @@ uniform float u_timeOfDay;
 uniform float u_bumpmapStrength;
 uniform float u_smallBumpmapStrength;
 
-out vec4 FragColor;
+out vec4 o_color;
 
 void main()
 {
@@ -49,7 +49,7 @@ void main()
 	// apply light map
 	col = col * mix(.25f, clamp(v_LightLevel * 2, 0.5, 1), u_timeOfDay);
 
-	FragColor = vec4(col.r, col.g, col.b, v_WaterAlpha);
+	o_color = vec4(col.r, col.g, col.b, v_WaterAlpha);
 
 	if (v_WaterAlpha == 0.0) {
 		discard;

--- a/assets/shaders/terrain.frag
+++ b/assets/shaders/terrain.frag
@@ -1,12 +1,12 @@
 #version 330 core
 
-in vec2 UV;
-in vec3 Weights;
-flat in uvec3 FirstMaterialID;
-flat in uvec3 SecondMaterialID;
-flat in vec3 MaterialBlendCoefficient;
-in float LightLevel;
-in float WaterAlpha;
+in vec2 v_texcoord0;
+in vec3 v_weights;
+flat in uvec3 v_FirstMaterialID;
+flat in uvec3 v_SecondMaterialID;
+flat in vec3 v_MaterialBlendCoefficient;
+in float v_LightLevel;
+in float v_WaterAlpha;
 
 uniform sampler2DArray sMaterials;
 uniform sampler2D sBumpMap;
@@ -21,37 +21,37 @@ void main()
 {
 	// do each vert with both materials
 	vec4 colOne = mix(
-		texture(sMaterials, vec3(UV, FirstMaterialID.r)),
-		texture(sMaterials, vec3(UV, SecondMaterialID.r)),
-		MaterialBlendCoefficient.r
-	) * Weights.r;
+		texture(sMaterials, vec3(v_texcoord0, v_FirstMaterialID.r)),
+		texture(sMaterials, vec3(v_texcoord0, v_SecondMaterialID.r)),
+		v_MaterialBlendCoefficient.r
+	) * v_weights.r;
 	vec4 colTwo = mix(
-		texture(sMaterials, vec3(UV, FirstMaterialID.g)),
-		texture(sMaterials, vec3(UV, SecondMaterialID.g)),
-		MaterialBlendCoefficient.g
-	) * Weights.g;
+		texture(sMaterials, vec3(v_texcoord0, v_FirstMaterialID.g)),
+		texture(sMaterials, vec3(v_texcoord0, v_SecondMaterialID.g)),
+		v_MaterialBlendCoefficient.g
+	) * v_weights.g;
 	vec4 colThree = mix(
-		texture(sMaterials, vec3(UV, FirstMaterialID.b)),
-		texture(sMaterials, vec3(UV, SecondMaterialID.b)),
-		MaterialBlendCoefficient.b
-	) * Weights.b;
+		texture(sMaterials, vec3(v_texcoord0, v_FirstMaterialID.b)),
+		texture(sMaterials, vec3(v_texcoord0, v_SecondMaterialID.b)),
+		v_MaterialBlendCoefficient.b
+	) * v_weights.b;
 
 	// add the 3 blended textures together
 	vec4 col = colOne + colTwo + colThree;
 
 	// apply bump map (2x because it's half bright?)
-	float bump = mix(1.0f, texture(sBumpMap, UV).r * 2, u_bumpmapStrength);
+	float bump = mix(1.0f, texture(sBumpMap, v_texcoord0).r * 2, u_bumpmapStrength);
 	col = col * bump;
 
-	float smallbump = 1 - mix(0.0f, texture(sSmallBumpMap, UV * 10).r, u_smallBumpmapStrength);
+	float smallbump = 1 - mix(0.0f, texture(sSmallBumpMap, v_texcoord0 * 10).r, u_smallBumpmapStrength);
 	col = col * smallbump;
 
 	// apply light map
-	col = col * mix(.25f, clamp(LightLevel * 2, 0.5, 1), u_timeOfDay);
+	col = col * mix(.25f, clamp(v_LightLevel * 2, 0.5, 1), u_timeOfDay);
 
-	FragColor = vec4(col.r, col.g, col.b, WaterAlpha);
+	FragColor = vec4(col.r, col.g, col.b, v_WaterAlpha);
 
-	if (WaterAlpha == 0.0) {
+	if (v_WaterAlpha == 0.0) {
 		discard;
 	}
 }

--- a/assets/shaders/terrain.vert
+++ b/assets/shaders/terrain.vert
@@ -1,11 +1,11 @@
 #version 330 core
-layout(location = 0) in vec3 position;
-layout(location = 1) in vec3 weights;
-layout(location = 2) in uvec3 firstMaterialID;
-layout(location = 3) in uvec3 secondMaterialID;
-layout(location = 4) in vec3 materialBlendCoefficient;
-layout(location = 5) in float lightLevel;
-layout(location = 6) in float waterAlpha;
+layout(location = 0) in vec3 a_position;
+layout(location = 1) in vec3 a_weights;
+layout(location = 2) in uvec3 a_firstMaterialID;
+layout(location = 3) in uvec3 a_secondMaterialID;
+layout(location = 4) in vec3 a_materialBlendCoefficient;
+layout(location = 5) in float a_lightLevel;
+layout(location = 6) in float a_waterAlpha;
 
 out vec2 UV;
 out vec3 Weights;
@@ -20,14 +20,14 @@ uniform vec2 u_blockPosition;
 
 void main()
 {
-	UV = vec2(position.z / 160.0f, position.x / 160.0f);
-	Weights = weights;
-	FirstMaterialID = firstMaterialID;
-	SecondMaterialID = secondMaterialID;
-	MaterialBlendCoefficient = materialBlendCoefficient;
-	LightLevel = lightLevel;
-	WaterAlpha = waterAlpha;
+	UV = vec2(a_position.z / 160.0f, a_position.x / 160.0f);
+	Weights = a_weights;
+	FirstMaterialID = a_firstMaterialID;
+	SecondMaterialID = a_secondMaterialID;
+	MaterialBlendCoefficient = a_materialBlendCoefficient;
+	LightLevel = a_lightLevel;
+	WaterAlpha = a_waterAlpha;
 
-	vec3 transformedPosition = vec3(position.x + u_blockPosition.x, position.y, position.z + u_blockPosition.y);
+	vec3 transformedPosition = vec3(a_position.x + u_blockPosition.x, a_position.y, a_position.z + u_blockPosition.y);
 	gl_Position = u_viewProj * vec4(transformedPosition, 1.0);
 }

--- a/assets/shaders/terrain.vert
+++ b/assets/shaders/terrain.vert
@@ -7,26 +7,26 @@ layout(location = 4) in vec3 a_materialBlendCoefficient;
 layout(location = 5) in float a_lightLevel;
 layout(location = 6) in float a_waterAlpha;
 
-out vec2 UV;
-out vec3 Weights;
-flat out uvec3 FirstMaterialID;
-flat out uvec3 SecondMaterialID;
-flat out vec3 MaterialBlendCoefficient;
-out float LightLevel;
-out float WaterAlpha;
+out vec2 v_texcoord0;
+out vec3 v_weights;
+flat out uvec3 v_FirstMaterialID;
+flat out uvec3 v_SecondMaterialID;
+flat out vec3 v_MaterialBlendCoefficient;
+out float v_LightLevel;
+out float v_WaterAlpha;
 
 uniform mat4 u_viewProj;
 uniform vec2 u_blockPosition;
 
 void main()
 {
-	UV = vec2(a_position.z / 160.0f, a_position.x / 160.0f);
-	Weights = a_weights;
-	FirstMaterialID = a_firstMaterialID;
-	SecondMaterialID = a_secondMaterialID;
-	MaterialBlendCoefficient = a_materialBlendCoefficient;
-	LightLevel = a_lightLevel;
-	WaterAlpha = a_waterAlpha;
+	v_texcoord0 = vec2(a_position.z / 160.0f, a_position.x / 160.0f);
+	v_weights = a_weights;
+	v_FirstMaterialID = a_firstMaterialID;
+	v_SecondMaterialID = a_secondMaterialID;
+	v_MaterialBlendCoefficient = a_materialBlendCoefficient;
+	v_LightLevel = a_lightLevel;
+	v_WaterAlpha = a_waterAlpha;
 
 	vec3 transformedPosition = vec3(a_position.x + u_blockPosition.x, a_position.y, a_position.z + u_blockPosition.y);
 	gl_Position = u_viewProj * vec4(transformedPosition, 1.0);

--- a/assets/shaders/terrain.vert
+++ b/assets/shaders/terrain.vert
@@ -15,8 +15,8 @@ flat out vec3 MaterialBlendCoefficient;
 out float LightLevel;
 out float WaterAlpha;
 
-uniform mat4 viewProj;
-uniform vec2 blockPosition;
+uniform mat4 u_viewProj;
+uniform vec2 u_blockPosition;
 
 void main()
 {
@@ -28,6 +28,6 @@ void main()
 	LightLevel = lightLevel;
 	WaterAlpha = waterAlpha;
 
-	vec3 transformedPosition = vec3(position.x + blockPosition.x, position.y, position.z + blockPosition.y);
-    gl_Position = viewProj * vec4(transformedPosition, 1.0);
+	vec3 transformedPosition = vec3(position.x + u_blockPosition.x, position.y, position.z + u_blockPosition.y);
+	gl_Position = u_viewProj * vec4(transformedPosition, 1.0);
 }

--- a/assets/shaders/water.frag
+++ b/assets/shaders/water.frag
@@ -4,7 +4,7 @@ varying vec4 v_texcoord0;
 
 uniform sampler2D s_reflection;
 
-out vec4 outColor;
+out vec4 o_color;
 
 void main()
 {
@@ -12,5 +12,5 @@ void main()
 	vec3 reflect_colour = texture2DProj(s_reflection, v_texcoord0).rgb;
 	vec3 water_color = vec3(0.35, 0.612, 0.643);
 
-	outColor = vec4(mix(reflect_colour, water_color, 0.8), 1.0);
+	o_color = vec4(mix(reflect_colour, water_color, 0.8), 1.0);
 }

--- a/assets/shaders/water.frag
+++ b/assets/shaders/water.frag
@@ -1,6 +1,6 @@
 #version 150 core
 
-varying vec4 screenSpacePosition;
+varying vec4 v_texcoord0;
 
 uniform sampler2D sReflection;
 
@@ -9,7 +9,7 @@ out vec4 outColor;
 void main()
 {
 
-	vec3 reflect_colour = texture2DProj(sReflection, screenSpacePosition).rgb;
+	vec3 reflect_colour = texture2DProj(sReflection, v_texcoord0).rgb;
 	vec3 water_color = vec3(0.35, 0.612, 0.643);
 
 	outColor = vec4(mix(reflect_colour, water_color, 0.8), 1.0);

--- a/assets/shaders/water.frag
+++ b/assets/shaders/water.frag
@@ -2,14 +2,14 @@
 
 varying vec4 v_texcoord0;
 
-uniform sampler2D sReflection;
+uniform sampler2D s_reflection;
 
 out vec4 outColor;
 
 void main()
 {
 
-	vec3 reflect_colour = texture2DProj(sReflection, v_texcoord0).rgb;
+	vec3 reflect_colour = texture2DProj(s_reflection, v_texcoord0).rgb;
 	vec3 water_color = vec3(0.35, 0.612, 0.643);
 
 	outColor = vec4(mix(reflect_colour, water_color, 0.8), 1.0);

--- a/assets/shaders/water.vert
+++ b/assets/shaders/water.vert
@@ -2,7 +2,7 @@
 
 layout(location = 0) in vec2 vertPos;
 
-uniform mat4 viewProj;
+uniform mat4 u_viewProj;
 
 varying vec4 screenSpacePosition;
 
@@ -18,7 +18,7 @@ vec4 ScreenSpacePosition(vec4 position)
 void main()
 {
 	vec4 vertex = vec4(vec3(vertPos.x * 10000, 0.0, vertPos.y * 10000), 1.0);
-	vec4 position = viewProj * vertex;
+	vec4 position = u_viewProj * vertex;
 	gl_Position = position;
 	
 	screenSpacePosition = ScreenSpacePosition(position);

--- a/assets/shaders/water.vert
+++ b/assets/shaders/water.vert
@@ -4,7 +4,7 @@ layout(location = 0) in vec2 vertPos;
 
 uniform mat4 u_viewProj;
 
-varying vec4 screenSpacePosition;
+varying vec4 v_texcoord0;
 
 vec4 ScreenSpacePosition(vec4 position)
 {
@@ -20,6 +20,6 @@ void main()
 	vec4 vertex = vec4(vec3(vertPos.x * 10000, 0.0, vertPos.y * 10000), 1.0);
 	vec4 position = u_viewProj * vertex;
 	gl_Position = position;
-	
-	screenSpacePosition = ScreenSpacePosition(position);
+
+	v_texcoord0 = ScreenSpacePosition(position);
 }

--- a/src/3D/Camera.cpp
+++ b/src/3D/Camera.cpp
@@ -34,12 +34,14 @@ glm::mat4 Camera::getRotationMatrix() const
 	return roll * pitch * yaw;
 }
 
+glm::mat4 Camera::GetViewMatrix() const
+{
+	return getRotationMatrix() * glm::translate(glm::mat4(1.0f), -_position);
+}
+
 glm::mat4 Camera::GetViewProjectionMatrix() const
 {
-	glm::mat4 mRotation = getRotationMatrix();
-	glm::mat4 mView     = mRotation * glm::translate(glm::mat4(1.0f), -_position);
-
-	return GetProjectionMatrix() * mView;
+	return GetProjectionMatrix() * GetViewMatrix();
 }
 
 void Camera::SetProjectionMatrixPerspective(float fov, float aspect, float nearclip, float farclip)

--- a/src/3D/Camera.h
+++ b/src/3D/Camera.h
@@ -47,8 +47,9 @@ class Camera
 
 	virtual ~Camera() = default;
 
-	virtual glm::mat4 GetViewProjectionMatrix() const;
-	glm::mat4 GetProjectionMatrix() const { return _projectionMatrix; }
+	[[nodiscard]] glm::mat4 GetViewMatrix() const;
+	[[nodiscard]] const glm::mat4& GetProjectionMatrix() const { return _projectionMatrix; }
+	[[nodiscard]] virtual glm::mat4 GetViewProjectionMatrix() const;
 
 	glm::vec3 GetPosition() const { return _position; }
 	glm::vec3 GetRotation() const { return glm::degrees(_rotation); }

--- a/src/3D/L3DSubMesh.cpp
+++ b/src/3D/L3DSubMesh.cpp
@@ -160,7 +160,7 @@ void L3DSubMesh::Draw(const L3DMesh& mesh, ShaderProgram& program) const
 				Game::instance()->GetMeshPack().GetTexture(prim.skinID).Bind(0);
 		}
 
-		_mesh->Draw(prim.indicesCount, prim.indicesOffset);
+		_mesh->Draw(program, prim.indicesCount, prim.indicesOffset);
 	}
 }
 

--- a/src/3D/LandBlock.cpp
+++ b/src/3D/LandBlock.cpp
@@ -197,6 +197,6 @@ std::vector<LandVertex> LandBlock::buildVertexList(LandIsland& island)
 
 void LandBlock::Draw(ShaderProgram& program)
 {
-	program.SetUniformValue("blockPosition", _mapPosition);
+	program.SetUniformValue("u_blockPosition", _mapPosition);
 	_mesh->Draw(program);
 }

--- a/src/3D/LandBlock.cpp
+++ b/src/3D/LandBlock.cpp
@@ -198,5 +198,5 @@ std::vector<LandVertex> LandBlock::buildVertexList(LandIsland& island)
 void LandBlock::Draw(ShaderProgram& program)
 {
 	program.SetUniformValue("blockPosition", _mapPosition);
-	_mesh->Draw();
+	_mesh->Draw(program);
 }

--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -182,9 +182,9 @@ const LandCell& LandIsland::GetCell(int x, int z) const
 
 void LandIsland::Draw(ShaderProgram& program)
 {
-	program.SetUniformValue("sMaterials", 0);
-	program.SetUniformValue("sBumpMap", 1);
-	program.SetUniformValue("sSmallBumpMap", 2);
+	program.SetUniformValue("s_materials", 0);
+	program.SetUniformValue("s_bump", 1);
+	program.SetUniformValue("s_smallBump", 2);
 
 	_materialArray->Bind(0);
 	_textureBumpMap->Bind(1);

--- a/src/3D/Sky.cpp
+++ b/src/3D/Sky.cpp
@@ -125,7 +125,7 @@ void Sky::CalculateTextures()
 
 void Sky::Draw(graphics::ShaderProgram& program)
 {
-	program.SetUniformValue("u_modelTransform", glm::mat4(1.0f));
+	program.SetUniformValue("u_model", glm::mat4(1.0f));
 
 	_texture->Bind(0);
 

--- a/src/3D/Water.cpp
+++ b/src/3D/Water.cpp
@@ -104,7 +104,7 @@ void Water::Draw(ShaderProgram& program) const
 	program.SetUniformValue("sReflection", 0);
 	_reflectionFrameBuffer->GetTexture()->Bind(0);
 
-	_mesh->Draw();
+	_mesh->Draw(program);
 }
 
 void Water::BeginReflection(const Camera& sceneCamera)

--- a/src/Entities/Registry.cpp
+++ b/src/Entities/Registry.cpp
@@ -28,7 +28,7 @@ void Registry::DrawModels(graphics::ShaderManager& shaderManager)
 		modelMatrix           = glm::rotate(modelMatrix, transform.rotation.z, glm::vec3(0.0f, 0.0f, 1.0f));
 		modelMatrix           = glm::scale(modelMatrix, transform.scale);
 
-		objectShader->SetUniformValue("u_modelTransform", modelMatrix);
+		objectShader->SetUniformValue("u_model", modelMatrix);
 		const L3DMesh& mesh = Game::instance()->GetMeshPack().GetMesh(static_cast<uint32_t>(model.meshId));
 
 		for (auto& submeshId : model.submeshIds)
@@ -43,7 +43,7 @@ void Registry::DrawModels(graphics::ShaderManager& shaderManager)
 		modelMatrix           = glm::rotate(modelMatrix, transform.rotation.z, glm::vec3(0.0f, 0.0f, 1.0f));
 		modelMatrix           = glm::scale(modelMatrix, transform.scale);
 
-		objectShader->SetUniformValue("u_modelTransform", modelMatrix);
+		objectShader->SetUniformValue("u_model", modelMatrix);
 
 		// temporary-ish:
 		MeshId meshID = MeshId::Dummy;
@@ -77,7 +77,7 @@ void Registry::DrawModels(graphics::ShaderManager& shaderManager)
 		modelMatrix           = glm::rotate(modelMatrix, transform.rotation.z, glm::vec3(0.0f, 0.0f, 1.0f));
 		modelMatrix           = glm::scale(modelMatrix, transform.scale);
 
-		objectShader->SetUniformValue("u_modelTransform", modelMatrix);
+		objectShader->SetUniformValue("u_model", modelMatrix);
 
 		// temporary-ish until we read info.dat:
 		MeshId meshID = MeshId::Dummy;

--- a/src/Entities/Registry.cpp
+++ b/src/Entities/Registry.cpp
@@ -19,7 +19,6 @@ void Registry::DebugCreateEntities(float x, float y, float z)
 void Registry::DrawModels(const Camera& camera, graphics::ShaderManager& shaderManager)
 {
 	graphics::ShaderProgram* objectShader = shaderManager.GetShader("SkinnedMesh");
-	objectShader->Bind();
 	objectShader->SetUniformValue("u_viewProjection", camera.GetViewProjectionMatrix());
 
 	_registry.view<Model, Transform>().each([objectShader](Model& model, Transform& transform) {

--- a/src/Entities/Registry.cpp
+++ b/src/Entities/Registry.cpp
@@ -16,10 +16,9 @@ void Registry::DebugCreateEntities(float x, float y, float z)
 {
 }
 
-void Registry::DrawModels(const Camera& camera, graphics::ShaderManager& shaderManager)
+void Registry::DrawModels(graphics::ShaderManager& shaderManager)
 {
 	graphics::ShaderProgram* objectShader = shaderManager.GetShader("SkinnedMesh");
-	objectShader->SetUniformValue("u_viewProjection", camera.GetViewProjectionMatrix());
 
 	_registry.view<Model, Transform>().each([objectShader](Model& model, Transform& transform) {
 		glm::mat4 modelMatrix = glm::mat4(1.0f);

--- a/src/Entities/Registry.h
+++ b/src/Entities/Registry.h
@@ -21,7 +21,7 @@ class Registry
 {
   public:
 	void DebugCreateEntities(float x, float y, float z);
-	void DrawModels(const Camera& camera, graphics::ShaderManager& shaderManager);
+	void DrawModels(graphics::ShaderManager& shaderManager);
 	void Update();
 	decltype(auto) Create() { return _registry.create(); }
 	template <typename Component, typename... Args>

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -209,25 +209,25 @@ void Game::Run()
 		_camera->Update(deltaTime);
 		_modelRotation.y = fmod(_modelRotation.y + float(deltaTime.count()) * .0001f, 360.f);
 
+		_renderer->UpdateDebugCrossPose(deltaTime, _intersection, 50.0f);
+
 		_gui->Loop(*this);
 
 		int width, height;
 		_window->GetDrawableSize(width, height);
 		_renderer->ClearScene(width, height);
 
+		// Reflection Pass
 		_water->BeginReflection(*_camera);
 		_renderer->UploadUniforms(deltaTime, *this, _water->GetReflectionCamera());
 		_renderer->DrawScene(*this, false);
 		_water->EndReflection();
 
+		// Main Draw Pass
 		// reset viewport here, should be done in EndReflection
 		glViewport(0, 0, width, height);
-
 		_renderer->UploadUniforms(deltaTime, *this, *_camera);
-
-		_renderer->DrawScene(*this, true);
-
-		_renderer->DebugDraw(deltaTime, *this, _intersection, 50.0f);
+		_renderer->DrawScene(*this, true, true);
 
 		_gui->Draw();
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -216,13 +216,16 @@ void Game::Run()
 		_renderer->ClearScene(width, height);
 
 		_water->BeginReflection(*_camera);
-		_renderer->DrawScene(deltaTime, *this, _water->GetReflectionCamera(), false);
+		_renderer->UploadUniforms(deltaTime, *this, _water->GetReflectionCamera());
+		_renderer->DrawScene(*this, false);
 		_water->EndReflection();
 
 		// reset viewport here, should be done in EndReflection
 		glViewport(0, 0, width, height);
 
-		_renderer->DrawScene(deltaTime, *this, *_camera, true);
+		_renderer->UploadUniforms(deltaTime, *this, *_camera);
+
+		_renderer->DrawScene(*this, true);
 
 		_renderer->DebugDraw(deltaTime, *this, _intersection, 50.0f);
 

--- a/src/Graphics/DebugLines.cpp
+++ b/src/Graphics/DebugLines.cpp
@@ -118,7 +118,7 @@ void DebugLines::SetPose(const glm::vec3 &center, float size)
 void DebugLines::Draw(ShaderProgram& program)
 {
 	program.SetUniformValue("u_model", _model);
-	_mesh->Draw();
+	_mesh->Draw(program);
 }
 
 DebugLines::DebugLines(std::unique_ptr<Mesh> &&mesh)

--- a/src/Graphics/Mesh.cpp
+++ b/src/Graphics/Mesh.cpp
@@ -23,6 +23,8 @@
 #include <stdexcept>
 #include <array>
 
+#include "ShaderProgram.h"
+
 #include "OpenGL.h"
 
 using namespace openblack::graphics;
@@ -87,22 +89,23 @@ Mesh::Topology Mesh::GetTopology() const noexcept
 	return _topology;
 }
 
-void Mesh::Draw()
+void Mesh::Draw(const openblack::graphics::ShaderProgram &program)
 {
 	if (_indexBuffer != nullptr && _indexBuffer->GetCount() > 0)
 	{
-		Draw(_indexBuffer->GetCount(), 0);
+		Draw(program, _indexBuffer->GetCount(), 0);
 	}
 	else
 	{
-		Draw(_vertexBuffer->GetVertexCount(), 0);
+		Draw(program, _vertexBuffer->GetVertexCount(), 0);
 	}
 }
 
-void Mesh::Draw(uint32_t count, uint32_t startIndex)
+void Mesh::Draw(const openblack::graphics::ShaderProgram &program, uint32_t count, uint32_t startIndex)
 {
 	auto topology = topologies[static_cast<size_t>(_topology)];
 	glBindVertexArray(_vao);
+	glUseProgram(program.GetRawHandle());
 	if (_indexBuffer != nullptr && _indexBuffer->GetCount() > 0)
 	{
 		auto indexBufferOffset = startIndex * _indexBuffer->GetStride();

--- a/src/Graphics/Mesh.h
+++ b/src/Graphics/Mesh.h
@@ -32,6 +32,8 @@ namespace openblack
 namespace graphics
 {
 
+class ShaderProgram;
+
 class Mesh
 {
   public:
@@ -53,8 +55,8 @@ class Mesh
 
 	[[nodiscard]] Topology GetTopology() const noexcept;
 
-	void Draw();
-	void Draw(uint32_t count, uint32_t startIndex);
+	void Draw(const openblack::graphics::ShaderProgram &program);
+	void Draw(const openblack::graphics::ShaderProgram &program, uint32_t count, uint32_t startIndex);
 
   protected:
 	std::unique_ptr<VertexBuffer> _vertexBuffer;

--- a/src/Graphics/ShaderManager.cpp
+++ b/src/Graphics/ShaderManager.cpp
@@ -20,6 +20,8 @@
 
 #include <Graphics/ShaderManager.h>
 
+#include <3D/Camera.h>
+
 namespace openblack::graphics
 {
 
@@ -52,6 +54,14 @@ ShaderProgram* ShaderManager::GetShader(const std::string& name)
 
 	// todo: return an empty shader?
 	return nullptr;
+}
+
+void ShaderManager::SetCamera(const Camera &camera)
+{
+	for (auto& [key, program]: _shaderPrograms)
+	{
+		program->SetUniformValue("u_viewProj", camera.GetViewProjectionMatrix());
+	}
 }
 
 } // namespace openblack::graphics

--- a/src/Graphics/ShaderManager.h
+++ b/src/Graphics/ShaderManager.h
@@ -26,6 +26,9 @@
 
 namespace openblack
 {
+
+class Camera;
+
 namespace graphics
 {
 
@@ -37,6 +40,8 @@ class ShaderManager
 
 	ShaderProgram* LoadShader(const std::string& name, const std::string& vertexShaderFile, const std::string& fragmentShaderFile);
 	ShaderProgram* GetShader(const std::string& name);
+
+	void SetCamera(const Camera &camera);
 
   private:
 	typedef std::map<std::string, ShaderProgram*> ShaderMap;

--- a/src/Graphics/ShaderProgram.cpp
+++ b/src/Graphics/ShaderProgram.cpp
@@ -97,48 +97,51 @@ ShaderProgram::~ShaderProgram()
 		glDeleteProgram(_program);
 }
 
-void ShaderProgram::Bind()
-{
-	glUseProgram(_program);
-}
-
 void ShaderProgram::SetUniformValue(const char* uniformName, int value)
 {
+	glUseProgram(_program);
 	glUniform1i(_uniforms[uniformName], value);
 }
 
 void ShaderProgram::SetUniformValue(const char* uniformName, float value)
 {
+	glUseProgram(_program);
 	glUniform1f(_uniforms[uniformName], value);
 }
 
 void ShaderProgram::SetUniformValue(const char* uniformName, const glm::vec2& v)
 {
+	glUseProgram(_program);
 	glUniform2fv(_uniforms[uniformName], 1, glm::value_ptr(v));
 }
 
 void ShaderProgram::SetUniformValue(const char* uniformName, const glm::vec3& v)
 {
+	glUseProgram(_program);
 	glUniform3fv(_uniforms[uniformName], 1, glm::value_ptr(v));
 }
 
 void ShaderProgram::SetUniformValue(const char* uniformName, const glm::vec4& v)
 {
+	glUseProgram(_program);
 	glUniform4fv(_uniforms[uniformName], 1, glm::value_ptr(v));
 }
 
 void ShaderProgram::SetUniformValue(const char* uniformName, const glm::mat3& m)
 {
+	glUseProgram(_program);
 	glUniformMatrix3fv(_uniforms[uniformName], 1, GL_FALSE, glm::value_ptr(m));
 }
 
 void ShaderProgram::SetUniformValue(const char* uniformName, const glm::mat4& m)
 {
+	glUseProgram(_program);
 	glUniformMatrix4fv(_uniforms[uniformName], 1, GL_FALSE, glm::value_ptr(m));
 }
 
 void ShaderProgram::SetUniformValue(const char* uniformName, size_t count, const glm::mat4* m)
 {
+	glUseProgram(_program);
 	glUniformMatrix4fv(_uniforms[uniformName], count, GL_FALSE, glm::value_ptr(m[0]));
 }
 

--- a/src/Graphics/ShaderProgram.h
+++ b/src/Graphics/ShaderProgram.h
@@ -45,8 +45,6 @@ class ShaderProgram
 	ShaderProgram(const std::string& vertexSource, const std::string& fragmentSource);
 	~ShaderProgram();
 
-	void Bind();
-
 	void SetUniformValue(const char* uniformName, int value);
 	void SetUniformValue(const char* uniformName, float value);
 	void SetUniformValue(const char* uniformName, const glm::vec2& v);

--- a/src/MeshViewer.cpp
+++ b/src/MeshViewer.cpp
@@ -115,7 +115,6 @@ void MeshViewer::DrawScene()
 	glClearColor(39.0f / 255.0f, 70.0f / 255.0f, 89.0f / 255.0f, 1);
 	glClear(GL_COLOR_BUFFER_BIT);
 
-	objectShader->Bind();
 	objectShader->SetUniformValue("u_viewProjection", perspective * view);
 	objectShader->SetUniformValue("u_modelTransform", glm::mat4(1.0f));
 

--- a/src/MeshViewer.cpp
+++ b/src/MeshViewer.cpp
@@ -115,8 +115,8 @@ void MeshViewer::DrawScene()
 	glClearColor(39.0f / 255.0f, 70.0f / 255.0f, 89.0f / 255.0f, 1);
 	glClear(GL_COLOR_BUFFER_BIT);
 
-	objectShader->SetUniformValue("u_viewProjection", perspective * view);
-	objectShader->SetUniformValue("u_modelTransform", glm::mat4(1.0f));
+	objectShader->SetUniformValue("u_viewProj", perspective * view);
+	objectShader->SetUniformValue("u_model", glm::mat4(1.0f));
 
 	const auto& mesh = meshes[static_cast<int>(_selectedMesh)];
 	if (_selectedSubMesh >= 0 && static_cast<uint32_t>(_selectedSubMesh) < mesh->GetSubMeshes().size())

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -169,6 +169,11 @@ void Renderer::MessageCallback(uint32_t source, uint32_t type, uint32_t id, uint
 	              type, severity, message);
 }
 
+void Renderer::UpdateDebugCrossPose(std::chrono::microseconds dt, const glm::vec3 &position, float scale)
+{
+	_debugCross->SetPose(position, scale);
+}
+
 void Renderer::UploadUniforms(std::chrono::microseconds dt, const Game &game, const Camera &camera)
 {
 	_shaderManager->SetCamera(camera);
@@ -189,22 +194,12 @@ void Renderer::ClearScene(int width, int height)
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 }
 
-void Renderer::DebugDraw(std::chrono::microseconds dt, const Game& game, const glm::vec3& position, float scale)
-{
-	_debugCross->SetPose(position, scale);
-
-	glDisable(GL_DEPTH_TEST);
-	glDisable(GL_BLEND);
-
-	ShaderProgram* debugShader = _shaderManager->GetShader("DebugLine");
-	_debugCross->Draw(*debugShader);
-}
-
-void Renderer::DrawScene(const Game &game, bool drawWater)
+void Renderer::DrawScene(const Game &game, bool drawWater, bool drawDebugCross)
 {
 	ShaderProgram* objectShader = _shaderManager->GetShader("SkinnedMesh");
 	ShaderProgram* waterShader = _shaderManager->GetShader("Water");
 	ShaderProgram* terrainShader = _shaderManager->GetShader("Terrain");
+	ShaderProgram* debugShader = _shaderManager->GetShader("DebugLine");
 
 	glEnable(GL_DEPTH_TEST);
 	glEnable(GL_BLEND);
@@ -233,4 +228,12 @@ void Renderer::DrawScene(const Game &game, bool drawWater)
 
 	glDisable(GL_CULL_FACE);
 	game.GetEntityRegistry().DrawModels(*_shaderManager);
+
+	if (drawDebugCross)
+	{
+		glDisable(GL_DEPTH_TEST);
+		glDisable(GL_BLEND);
+
+		_debugCross->Draw(*debugShader);
+	}
 }

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -184,7 +184,6 @@ void Renderer::DebugDraw(std::chrono::microseconds dt, const Game& game, const g
 	glDisable(GL_BLEND);
 
 	ShaderProgram* debugShader = _shaderManager->GetShader("DebugLine");
-	debugShader->Bind();
 	debugShader->SetUniformValue("u_viewProjection", game.GetCamera().GetViewProjectionMatrix());
 	_debugCross->Draw(*debugShader);
 }
@@ -196,7 +195,6 @@ void Renderer::DrawScene(std::chrono::microseconds dt, const Game& game, const C
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
 	ShaderProgram* objectShader = _shaderManager->GetShader("SkinnedMesh");
-	objectShader->Bind();
 	objectShader->SetUniformValue("u_viewProjection", camera.GetViewProjectionMatrix());
 	game.GetSky().Draw(*objectShader);
 
@@ -207,7 +205,6 @@ void Renderer::DrawScene(std::chrono::microseconds dt, const Game& game, const C
 	if (drawWater)
 	{
 		ShaderProgram* waterShader = _shaderManager->GetShader("Water");
-		waterShader->Bind();
 		waterShader->SetUniformValue("viewProj", camera.GetViewProjectionMatrix());
 		game.GetWater().Draw(*waterShader);
 	}
@@ -216,7 +213,6 @@ void Renderer::DrawScene(std::chrono::microseconds dt, const Game& game, const C
 		glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
 
 	ShaderProgram* terrainShader = _shaderManager->GetShader("Terrain");
-	terrainShader->Bind();
 	terrainShader->SetUniformValue("viewProj", camera.GetViewProjectionMatrix());
 	terrainShader->SetUniformValue("timeOfDay", game.GetConfig().timeOfDay);
 	terrainShader->SetUniformValue("bumpmapStrength", game.GetConfig().bumpMapStrength);
@@ -229,7 +225,6 @@ void Renderer::DrawScene(std::chrono::microseconds dt, const Game& game, const C
 
 	glm::mat4 modelMatrix = game.GetModelMatrix();
 
-	objectShader->Bind();
 	objectShader->SetUniformValue("u_viewProjection", camera.GetViewProjectionMatrix());
 	objectShader->SetUniformValue("u_modelTransform", modelMatrix);
 	game.GetTestModel().Draw(*objectShader, 0);

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -176,14 +176,15 @@ void Renderer::UploadUniforms(std::chrono::microseconds dt, const Game &game, co
 	ShaderProgram* waterShader = _shaderManager->GetShader("Water");
 	ShaderProgram* terrainShader = _shaderManager->GetShader("Terrain");
 
-	debugShader->SetUniformValue("u_viewProjection", game.GetCamera().GetViewProjectionMatrix());
-	waterShader->SetUniformValue("viewProj", camera.GetViewProjectionMatrix());
-	terrainShader->SetUniformValue("viewProj", camera.GetViewProjectionMatrix());
-	terrainShader->SetUniformValue("timeOfDay", game.GetConfig().timeOfDay);
-	terrainShader->SetUniformValue("bumpmapStrength", game.GetConfig().bumpMapStrength);
-	terrainShader->SetUniformValue("smallBumpmapStrength", game.GetConfig().smallBumpMapStrength);
-	objectShader->SetUniformValue("u_viewProjection", camera.GetViewProjectionMatrix());
-	objectShader->SetUniformValue("u_modelTransform", game.GetModelMatrix());
+	debugShader->SetUniformValue("u_viewProj", game.GetCamera().GetViewProjectionMatrix());
+	waterShader->SetUniformValue("u_viewProj", camera.GetViewProjectionMatrix());
+	terrainShader->SetUniformValue("u_viewProj", camera.GetViewProjectionMatrix());
+	objectShader->SetUniformValue("u_viewProj", camera.GetViewProjectionMatrix());
+
+	terrainShader->SetUniformValue("u_timeOfDay", game.GetConfig().timeOfDay);
+	terrainShader->SetUniformValue("u_bumpmapStrength", game.GetConfig().bumpMapStrength);
+	terrainShader->SetUniformValue("u_smallBumpmapStrength", game.GetConfig().smallBumpMapStrength);
+	objectShader->SetUniformValue("u_model", game.GetModelMatrix());
 }
 
 void Renderer::ClearScene(int width, int height)

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -171,19 +171,14 @@ void Renderer::MessageCallback(uint32_t source, uint32_t type, uint32_t id, uint
 
 void Renderer::UploadUniforms(std::chrono::microseconds dt, const Game &game, const Camera &camera)
 {
-	ShaderProgram* debugShader = _shaderManager->GetShader("DebugLine");
-	ShaderProgram* objectShader = _shaderManager->GetShader("SkinnedMesh");
-	ShaderProgram* waterShader = _shaderManager->GetShader("Water");
+	_shaderManager->SetCamera(camera);
+
 	ShaderProgram* terrainShader = _shaderManager->GetShader("Terrain");
-
-	debugShader->SetUniformValue("u_viewProj", game.GetCamera().GetViewProjectionMatrix());
-	waterShader->SetUniformValue("u_viewProj", camera.GetViewProjectionMatrix());
-	terrainShader->SetUniformValue("u_viewProj", camera.GetViewProjectionMatrix());
-	objectShader->SetUniformValue("u_viewProj", camera.GetViewProjectionMatrix());
-
 	terrainShader->SetUniformValue("u_timeOfDay", game.GetConfig().timeOfDay);
 	terrainShader->SetUniformValue("u_bumpmapStrength", game.GetConfig().bumpMapStrength);
 	terrainShader->SetUniformValue("u_smallBumpmapStrength", game.GetConfig().smallBumpMapStrength);
+
+	ShaderProgram* objectShader = _shaderManager->GetShader("SkinnedMesh");
 	objectShader->SetUniformValue("u_model", game.GetModelMatrix());
 }
 

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -195,7 +195,7 @@ void Renderer::ClearScene(int width, int height)
 
 void Renderer::DebugDraw(std::chrono::microseconds dt, const Game& game, const glm::vec3& position, float scale)
 {
-	_debugCross->SetPose(position, 50.0f);
+	_debugCross->SetPose(position, scale);
 
 	glDisable(GL_DEPTH_TEST);
 	glDisable(GL_BLEND);

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -84,10 +84,11 @@ class Renderer {
 	[[nodiscard]] graphics::ShaderManager& GetShaderManager() const;
 	void MessageCallback(uint32_t source, uint32_t type, uint32_t id, uint32_t severity, int32_t length, const std::string& message) const;
 
+	void UpdateDebugCrossPose(std::chrono::microseconds dt, const glm::vec3 &position, float scale);
+
 	void UploadUniforms(std::chrono::microseconds dt, const Game& game, const Camera& camera);
 	void ClearScene(int width, int height);
-	void DebugDraw(std::chrono::microseconds dt, const Game &game, const glm::vec3 &position, float scale);
-	void DrawScene(const Game &game, bool drawWater);
+	void DrawScene(const Game &game, bool drawWater, bool drawDebugCross=false);
 
   private:
   static std::vector<RequiredAttribute> GetRequiredContextAttributes();

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -84,9 +84,10 @@ class Renderer {
 	[[nodiscard]] graphics::ShaderManager& GetShaderManager() const;
 	void MessageCallback(uint32_t source, uint32_t type, uint32_t id, uint32_t severity, int32_t length, const std::string& message) const;
 
+	void UploadUniforms(std::chrono::microseconds dt, const Game& game, const Camera& camera);
 	void ClearScene(int width, int height);
 	void DebugDraw(std::chrono::microseconds dt, const Game &game, const glm::vec3 &position, float scale);
-	void DrawScene(std::chrono::microseconds dt, const Game& game, const Camera& camera, bool drawWater);
+	void DrawScene(const Game &game, bool drawWater);
 
   private:
   static std::vector<RequiredAttribute> GetRequiredContextAttributes();


### PR DESCRIPTION
This change add consitency to shader code, mainly common names and prefixes:

The updating of uniforms (with the exception of `u_model`) have been moved to their own function
`Renderer::UploadUniforms` which gets called between passes. This reduces driver overhead which can cause the rendering to stall for uniform updates. Doing all the updates before starting rendering allows rendering to run uninterrupted.

The shader manager now takes care of setting `u_viewProj` since it is expected to be the same for every shader in a same pass (i.e. Reflection Pass, Main render Pass).

The Mesh draw command now takes care of binding the proper program by using a `ShaderProgram` parameter which must be set by the caller.

The style changes in the shaders are:
* The prefix `u_` for uniforms
* The prefix `s_` for samplers
* The prefix `a_` for vertex attributes
* The prefix `v_` for varyings.
* The position is called `position` and not `pos`
* The uv element is called `texcoord0`
* The name for view projection matrix is `u_viewProj`
* The name for model matrix is `u_model`
* The name for generic diffuse textures is `s_diffuse`
* The name for generic bump maps is `s_bump`
* The final color is ~~`gl_FragColor` since we're only using 1 target.~~ is `o_color`.
* etc