### PR TITLE
Framebuffer: Remove OpenGL from header

### DIFF
--- a/src/3D/Water.cpp
+++ b/src/3D/Water.cpp
@@ -75,7 +75,7 @@ Water::Water()
 
 	// _waterShader = resourceCaches.shaderProgram->Request("water.program");
 
-	_reflectionFrameBuffer = std::make_unique<FrameBuffer>(1024, 1024, graphics::Format::RGBA8);
+	_reflectionFrameBuffer = std::make_unique<FrameBuffer>(1024, 1024, graphics::Format::RGBA8, graphics::Format::Depth24Stencil8);
 
 	createMesh();
 }
@@ -104,7 +104,7 @@ void Water::createMesh()
 void Water::Draw(ShaderProgram& program) const
 {
 	program.SetUniformValue("sReflection", 0);
-	_reflectionFrameBuffer->GetTexture().Bind(0);
+	_reflectionFrameBuffer->GetColorAttachment().Bind(0);
 
 	_mesh->Draw(program);
 }
@@ -133,7 +133,7 @@ void Water::EndReflection()
 void Water::DebugGUI()
 {
 	ImGui::Begin("Water Debug");
-	ImGui::Image((void*)(intptr_t)_reflectionFrameBuffer->GetTexture().GetNativeHandle(), ImVec2(256, 256), ImVec2(0, 1), ImVec2(1, 0));
+	ImGui::Image((void*)(intptr_t) _reflectionFrameBuffer->GetColorAttachment().GetNativeHandle(), ImVec2(256, 256), ImVec2(0, 1), ImVec2(1, 0));
 	ImGui::End();
 }
 

--- a/src/3D/Water.cpp
+++ b/src/3D/Water.cpp
@@ -18,8 +18,10 @@
  * along with openblack. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <3D/Water.h>
 #include <imgui/imgui.h>
+
+#include <3D/Water.h>
+#include <Graphics/OpenGL.h>
 
 using namespace openblack;
 
@@ -73,7 +75,7 @@ Water::Water()
 
 	// _waterShader = resourceCaches.shaderProgram->Request("water.program");
 
-	_reflectionFrameBuffer = std::make_unique<FrameBuffer>(1024, 1024, GL_RGBA);
+	_reflectionFrameBuffer = std::make_unique<FrameBuffer>(1024, 1024, graphics::Format::RGBA8);
 
 	createMesh();
 }
@@ -102,7 +104,7 @@ void Water::createMesh()
 void Water::Draw(ShaderProgram& program) const
 {
 	program.SetUniformValue("sReflection", 0);
-	_reflectionFrameBuffer->GetTexture()->Bind(0);
+	_reflectionFrameBuffer->GetTexture().Bind(0);
 
 	_mesh->Draw(program);
 }
@@ -131,7 +133,7 @@ void Water::EndReflection()
 void Water::DebugGUI()
 {
 	ImGui::Begin("Water Debug");
-	ImGui::Image((void*)(intptr_t)_reflectionFrameBuffer->GetTexture()->GetNativeHandle(), ImVec2(256, 256), ImVec2(0, 1), ImVec2(1, 0));
+	ImGui::Image((void*)(intptr_t)_reflectionFrameBuffer->GetTexture().GetNativeHandle(), ImVec2(256, 256), ImVec2(0, 1), ImVec2(1, 0));
 	ImGui::End();
 }
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -20,9 +20,16 @@
 
 #include "Game.h"
 
+#include <string>
+
+#include <SDL.h>
+#include <glm/glm.hpp>
+#include <glm/gtc/type_ptr.hpp>
+#include <glm/gtx/intersect.hpp>
+
 #include "GitSHA1.h"
 #include "Gui.h"
-
+#include <Graphics/OpenGL.h>
 #include <3D/Camera.h>
 #include <3D/L3DMesh.h>
 #include <3D/LandIsland.h>
@@ -33,18 +40,9 @@
 #include <Common/FileSystem.h>
 #include <Entities/Components/Model.h>
 #include <Entities/Registry.h>
-#include <Graphics/Texture2D.h>
-#include <Graphics/VertexBuffer.h>
-#include <Gui.h>
 #include <LHScriptX/Script.h>
 #include <MeshViewer.h>
 #include <Renderer.h>
-#include <SDL.h>
-#include <glm/glm.hpp>
-#include <glm/gtc/type_ptr.hpp>
-#include <glm/gtx/intersect.hpp>
-#include <iostream>
-#include <string>
 
 #ifdef WIN32
 #include <Windows.h>

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -218,7 +218,7 @@ void Game::Run()
 		// Reflection Pass
 		_water->BeginReflection(*_camera);
 		_renderer->UploadUniforms(deltaTime, *this, _water->GetReflectionCamera());
-		_renderer->DrawScene(*this, false);
+		_renderer->DrawScene(*this, false, false, false);
 		_water->EndReflection();
 
 		// Main Draw Pass

--- a/src/Graphics/FrameBuffer.cpp
+++ b/src/Graphics/FrameBuffer.cpp
@@ -19,13 +19,15 @@
  */
 
 #include <Graphics/FrameBuffer.h>
+
 #include <cassert>
 #include <stdexcept>
 
-namespace openblack::graphics
-{
+#include <Graphics/OpenGL.h>
 
-FrameBuffer::FrameBuffer(GLsizei width, GLsizei height, GLenum format) :
+using namespace openblack::graphics;
+
+FrameBuffer::FrameBuffer(uint32_t width, uint32_t height, Format format) :
     _handle(0), _width(width), _height(height), _format(format)
 {
 	glGenFramebuffers(1, &_handle);
@@ -33,8 +35,8 @@ FrameBuffer::FrameBuffer(GLsizei width, GLsizei height, GLenum format) :
 
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, _handle);
 
-	_texture = new Texture2D();
-	_texture->Create(_width, _height, 1);
+	_texture = std::make_unique<Texture2D>();
+	_texture->Create(_width, _height, 1, format);
 
 	glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, _texture->GetNativeHandle(), 0);
 
@@ -49,9 +51,14 @@ FrameBuffer::~FrameBuffer()
 {
 	if (_handle != 0)
 		glDeleteFramebuffers(1, &_handle);
-
-	if (_texture != nullptr)
-		delete _texture;
 }
 
+void FrameBuffer::Bind()
+{
+	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, _handle);
+}
+
+void FrameBuffer::Unbind()
+{
+	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
 }

--- a/src/Graphics/FrameBuffer.h
+++ b/src/Graphics/FrameBuffer.h
@@ -22,6 +22,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 
 #include <Graphics/Texture2D.h>
 
@@ -30,13 +31,13 @@ namespace openblack::graphics {
 class FrameBuffer {
 public:
 	FrameBuffer() = delete;
-	FrameBuffer(uint32_t width, uint32_t height, Format format);
+	FrameBuffer(uint32_t width, uint32_t height, Format colorFormat, std::optional<Format> depthStencilFormat={});
 	~FrameBuffer();
 
 	void Bind();
 	void Unbind();
 
-	Texture2D& GetTexture() { return *_texture; }
+	Texture2D& GetColorAttachment() { return *_colorAttachment; }
 
 	//inline void Bind() { glBindTexture(GL_TEXTURE_RECTANGLE, _textureID); }
 
@@ -48,9 +49,11 @@ private:
 
 	uint32_t _width;
 	uint32_t _height;
-	Format _format;
+	Format _colorFormat;
+	std::optional<Format> _depthStencilFormat;
 
-	std::unique_ptr<Texture2D> _texture;
+	std::unique_ptr<Texture2D> _colorAttachment;
+	std::unique_ptr<Texture2D> _depthStencilAttachment;
 };
 
 }  // namespace openblack::graphics

--- a/src/Graphics/FrameBuffer.h
+++ b/src/Graphics/FrameBuffer.h
@@ -20,36 +20,37 @@
 
 #pragma once
 
-#include <Graphics/OpenGL.h>
+#include <cstdint>
+#include <memory>
+
 #include <Graphics/Texture2D.h>
 
-namespace openblack {
-namespace graphics {
+namespace openblack::graphics {
 
 class FrameBuffer {
 public:
 	FrameBuffer() = delete;
-	FrameBuffer(GLsizei width, GLsizei height, GLenum format);
+	FrameBuffer(uint32_t width, uint32_t height, Format format);
 	~FrameBuffer();
 
-	void Bind() { glBindFramebuffer(GL_DRAW_FRAMEBUFFER, _handle); }
-	void Unbind() { glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0); }
+	void Bind();
+	void Unbind();
 
-	Texture2D* GetTexture() { return _texture; }
+	Texture2D& GetTexture() { return *_texture; }
 
 	//inline void Bind() { glBindTexture(GL_TEXTURE_RECTANGLE, _textureID); }
 
-	GLsizei GetWidth() const { return _width; }
-	GLsizei GetHeight() const { return _height; }
+	[[nodiscard]] uint32_t GetWidth() const { return _width; }
+	[[nodiscard]] uint32_t GetHeight() const { return _height; }
+
 private:
-	GLuint _handle;
+	uint32_t _handle;
 
-	GLsizei _width;
-	GLsizei _height;
-	GLenum _format;
+	uint32_t _width;
+	uint32_t _height;
+	Format _format;
 
-	Texture2D* _texture;
+	std::unique_ptr<Texture2D> _texture;
 };
 
-}
-}
+}  // namespace openblack::graphics

--- a/src/MeshViewer.cpp
+++ b/src/MeshViewer.cpp
@@ -18,6 +18,10 @@
  * along with openblack. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <imgui/imgui.h>
+#include <glm/gtc/matrix_transform.hpp>
+
+#include <Graphics/OpenGL.h>
 #include <3D/L3DMesh.h>
 #include <3D/MeshPack.h>
 #include <Game.h>
@@ -25,14 +29,12 @@
 #include <Graphics/ShaderManager.h>
 #include <Graphics/Texture2D.h>
 #include <MeshViewer.h>
-#include <imgui/imgui.h>
-#include <glm/gtc/matrix_transform.hpp>
 
-namespace openblack
-{
+using namespace openblack;
+
 MeshViewer::MeshViewer()
 {
-	_frameBuffer  = std::make_unique<graphics::FrameBuffer>(512, 512, GL_RGBA);
+	_frameBuffer  = std::make_unique<graphics::FrameBuffer>(512, 512, graphics::Format::RGBA8);
 	_selectedMesh    = MeshId::Dummy;
 	_selectedSubMesh = 0;
 	_cameraPosition  = glm::vec3(5.0f, 3.0f, 5.0f);
@@ -83,7 +85,7 @@ void MeshViewer::DrawWindow()
 
 	ImGui::DragFloat3("position", &_cameraPosition[0], 0.5f);
 
-	ImGui::Image((void*)(intptr_t)_frameBuffer->GetTexture()->GetNativeHandle(), ImVec2(512, 512), ImVec2(0, 1), ImVec2(1, 0));
+	ImGui::Image((void*)(intptr_t)_frameBuffer->GetTexture().GetNativeHandle(), ImVec2(512, 512), ImVec2(0, 1), ImVec2(1, 0));
 
 	ImGui::EndChild();
 
@@ -124,5 +126,3 @@ void MeshViewer::DrawScene()
 
 	_frameBuffer->Unbind();
 }
-
-} // namespace openblack

--- a/src/MeshViewer.cpp
+++ b/src/MeshViewer.cpp
@@ -85,7 +85,7 @@ void MeshViewer::DrawWindow()
 
 	ImGui::DragFloat3("position", &_cameraPosition[0], 0.5f);
 
-	ImGui::Image((void*)(intptr_t)_frameBuffer->GetTexture().GetNativeHandle(), ImVec2(512, 512), ImVec2(0, 1), ImVec2(1, 0));
+	ImGui::Image((void*)(intptr_t) _frameBuffer->GetColorAttachment().GetNativeHandle(), ImVec2(512, 512), ImVec2(0, 1), ImVec2(1, 0));
 
 	ImGui::EndChild();
 

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -194,7 +194,7 @@ void Renderer::ClearScene(int width, int height)
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 }
 
-void Renderer::DrawScene(const Game &game, bool drawWater, bool drawDebugCross)
+void Renderer::DrawScene(const Game &game, bool drawWater, bool drawDebugCross, bool cullBack)
 {
 	ShaderProgram* objectShader = _shaderManager->GetShader("SkinnedMesh");
 	ShaderProgram* waterShader = _shaderManager->GetShader("Water");
@@ -208,7 +208,7 @@ void Renderer::DrawScene(const Game &game, bool drawWater, bool drawDebugCross)
 	game.GetSky().Draw(*objectShader);
 
 	glEnable(GL_CULL_FACE);
-	glCullFace(GL_BACK);
+	glCullFace(cullBack ? GL_BACK : GL_FRONT);
 	glFrontFace(GL_CCW);
 
 	if (drawWater)

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -88,7 +88,7 @@ class Renderer {
 
 	void UploadUniforms(std::chrono::microseconds dt, const Game& game, const Camera& camera);
 	void ClearScene(int width, int height);
-	void DrawScene(const Game &game, bool drawWater, bool drawDebugCross=false);
+	void DrawScene(const Game &game, bool drawWater, bool drawDebugCross, bool cullBack=true);
 
   private:
   static std::vector<RequiredAttribute> GetRequiredContextAttributes();


### PR DESCRIPTION
Store Texture in unique_ptr.
Use uint32_t as width and height.
Pass format to texture. Use Format enum.
Texture2D get returns a reference.

Add optional depth stencil to framebuffer