### PR TITLE
Texture: Store dimensions in 16 bits

### DIFF
--- a/src/Graphics/FrameBuffer.cpp
+++ b/src/Graphics/FrameBuffer.cpp
@@ -27,7 +27,7 @@
 
 using namespace openblack::graphics;
 
-FrameBuffer::FrameBuffer(uint32_t width, uint32_t height, Format colorFormat, std::optional<Format> depthStencilFormat) :
+FrameBuffer::FrameBuffer(uint16_t width, uint16_t height, Format colorFormat, std::optional<Format> depthStencilFormat) :
 	_handle(0), _width(width), _height(height), _colorFormat(colorFormat), _depthStencilFormat(depthStencilFormat)
 {
 	glGenFramebuffers(1, &_handle);

--- a/src/Graphics/FrameBuffer.h
+++ b/src/Graphics/FrameBuffer.h
@@ -31,7 +31,7 @@ namespace openblack::graphics {
 class FrameBuffer {
 public:
 	FrameBuffer() = delete;
-	FrameBuffer(uint32_t width, uint32_t height, Format colorFormat, std::optional<Format> depthStencilFormat={});
+	FrameBuffer(uint16_t width, uint16_t height, Format colorFormat, std::optional<Format> depthStencilFormat={});
 	~FrameBuffer();
 
 	void Bind();
@@ -41,14 +41,14 @@ public:
 
 	//inline void Bind() { glBindTexture(GL_TEXTURE_RECTANGLE, _textureID); }
 
-	[[nodiscard]] uint32_t GetWidth() const { return _width; }
-	[[nodiscard]] uint32_t GetHeight() const { return _height; }
+	[[nodiscard]] uint16_t GetWidth() const { return _width; }
+	[[nodiscard]] uint16_t GetHeight() const { return _height; }
 
 private:
 	uint32_t _handle;
 
-	uint32_t _width;
-	uint32_t _height;
+	uint16_t _width;
+	uint16_t _height;
 	Format _colorFormat;
 	std::optional<Format> _depthStencilFormat;
 

--- a/src/Graphics/Texture2D.cpp
+++ b/src/Graphics/Texture2D.cpp
@@ -118,7 +118,7 @@ Texture2D::~Texture2D()
 	}
 }
 
-void Texture2D::Create(uint32_t width, uint32_t height, uint32_t layers, Format format, Wrapping wrapping, const void* data, size_t size)
+void Texture2D::Create(uint16_t width, uint16_t height, uint16_t layers, Format format, Wrapping wrapping, const void* data, size_t size)
 {
 	auto bindPoint = layers > 1 ? GL_TEXTURE_2D_ARRAY : GL_TEXTURE_2D;
 	auto textureFormat = textureFormats[static_cast<size_t>(format)];

--- a/src/Graphics/Texture2D.h
+++ b/src/Graphics/Texture2D.h
@@ -108,12 +108,12 @@ class Texture2D
 	Texture2D(const Texture2D&) = delete;
 	Texture2D& operator=(const Texture2D&) = delete;
 
-	void Create(uint32_t width, uint32_t height, uint32_t layers, Format format=Format::RGBA8, Wrapping wrapping=Wrapping::ClampEdge, const void* data=nullptr, size_t size=0);
+	void Create(uint16_t width, uint16_t height, uint16_t layers, Format format=Format::RGBA8, Wrapping wrapping=Wrapping::ClampEdge, const void* data=nullptr, size_t size=0);
 
 	[[nodiscard]] uint32_t GetNativeHandle() const { return _handle; }
-	[[nodiscard]] uint32_t GetWidth() const { return _width; }
-	[[nodiscard]] uint32_t GetHeight() const { return _height; }
-	[[nodiscard]] uint32_t GetLayerCount() const { return _layers; }
+	[[nodiscard]] uint16_t GetWidth() const { return _width; }
+	[[nodiscard]] uint16_t GetHeight() const { return _height; }
+	[[nodiscard]] uint16_t GetLayerCount() const { return _layers; }
 
 	void Bind(uint8_t textureBindingPoint) const;
 
@@ -121,9 +121,9 @@ class Texture2D
 
   protected:
 	uint32_t _handle;
-	uint32_t _width;
-	uint32_t _height;
-	uint32_t _layers;
+	uint16_t _width;
+	uint16_t _height;
+	uint16_t _layers;
 };
 
 } // namespace graphics


### PR DESCRIPTION
One can reasonably assume that the textures will not have dimensions of
more than 65536.