### PR TITLE
Add convenience commandline parameters

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -70,12 +70,17 @@ Game::Game(int argc, char** argv)
 
 	int windowWidth = 1280, windowHeight = 1024;
 	bool vsync = false;
-	DisplayMode displayMode = DisplayMode::Windowed;
+	bool fullscreen = false;
+	bool borderless = false;
 
 	auto args = CmdLineArgs(argc, argv);
 	args.Get("w", windowWidth);
 	args.Get("h", windowHeight);
 	args.Get("v", vsync);
+	args.Get("f", fullscreen);
+	args.Get("b", borderless);
+
+	DisplayMode displayMode = borderless ? DisplayMode::Borderless : (fullscreen ? DisplayMode::Fullscreen : DisplayMode::Windowed);
 
 	std::string binaryPath = fs::path{argv[0]}.parent_path().generic_string();
 	spdlog::info("current binary path: {}", binaryPath);

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -69,11 +69,13 @@ Game::Game(int argc, char** argv)
 	sInstance = this;
 
 	int windowWidth = 1280, windowHeight = 1024;
+	bool vsync = false;
 	DisplayMode displayMode = DisplayMode::Windowed;
 
 	auto args = CmdLineArgs(argc, argv);
 	args.Get("w", windowWidth);
 	args.Get("h", windowHeight);
+	args.Get("v", vsync);
 
 	std::string binaryPath = fs::path{argv[0]}.parent_path().generic_string();
 	spdlog::info("current binary path: {}", binaryPath);
@@ -85,7 +87,7 @@ Game::Game(int argc, char** argv)
 
 	_window = std::make_unique<GameWindow>(kWindowTitle + " [" + kBuildStr + "]", windowWidth, windowHeight, displayMode);
 
-	_renderer = std::make_unique<Renderer>(*_window, binaryPath);
+	_renderer = std::make_unique<Renderer>(*_window, vsync, binaryPath);
 
 	_fileSystem->SetGamePath(GetGamePath());
 	spdlog::debug("The GamePath is \"{}\".", _fileSystem->GetGamePath().generic_string());

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -132,7 +132,7 @@ struct ApiThreadArgs
 
 }  // namespace openblack
 
-Renderer::Renderer(const GameWindow& window, const std::string binaryPath)
+Renderer::Renderer(const GameWindow& window, bool vsync, const std::string binaryPath)
 	: _shaderManager(std::make_unique<ShaderManager>())
 	, _bgfxCallback(std::make_unique<BgfxCallback>())
 {
@@ -163,7 +163,11 @@ Renderer::Renderer(const GameWindow& window, const std::string binaryPath)
 	init.platformData = apiThreadArgs.platformData;
 	init.resolution.width = (uint32_t)drawable_width;
 	init.resolution.height = (uint32_t)drawable_height;
-	init.resolution.reset = BGFX_RESET_VSYNC;
+	init.resolution.reset = BGFX_RESET_NONE;
+	if (vsync)
+	{
+		init.resolution.reset |= BGFX_RESET_VSYNC;
+	}
 	init.callback = dynamic_cast<bgfx::CallbackI*>(_bgfxCallback.get());
 
 	if (!bgfx::init(init)) {

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -69,7 +69,7 @@ class Renderer {
 	};
 
 	Renderer() = delete;
-	explicit Renderer(const GameWindow& window, const std::string binaryPath);
+	explicit Renderer(const GameWindow& window, bool vsync, const std::string binaryPath);
 
 	virtual ~Renderer();
 


### PR DESCRIPTION
`-v`: enable vsync (defaulted to false)
`-b`, `-f`: windowing borderless or fullscreen respecively. If both are supplied, borderless takes precedence. If none are supplied, windowed is used.