### PR TITLE
Profiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,14 @@ if (NOT bgfx_FOUND)
   add_library(bgfx::bgfx ALIAS bgfx)
 endif()
 
+FetchContent_Declare(
+  imgui-flame-graph
+  GIT_REPOSITORY https://github.com/bwrsandman/imgui-flame-graph.git
+  GIT_TAG        master
+)
+set(IMGUI_FLAME_GRAPH_BUILD_EXAMPLE OFF CACHE BOOL "imgui-flame bgfx examples.")
+FetchContent_MakeAvailable(imgui-flame-graph)
+
 # Include git hash in source
 include(CMakeModules/GetGitRevisionDescription.cmake)
 get_git_head_revision(GIT_REFSPEC GIT_SHA1)

--- a/src/3D/LandBlock.cpp
+++ b/src/3D/LandBlock.cpp
@@ -195,7 +195,7 @@ std::vector<LandVertex> LandBlock::buildVertexList(LandIsland& island)
 	return verts;
 }
 
-void LandBlock::Draw(uint8_t viewId, ShaderProgram &program, bool cullBack)
+void LandBlock::Draw(uint8_t viewId, ShaderProgram &program, bool cullBack) const
 {
 	program.SetUniformValue("u_blockPosition", &_mapPosition);
 

--- a/src/3D/LandBlock.h
+++ b/src/3D/LandBlock.h
@@ -73,7 +73,7 @@ class LandBlock
 	{}
 
 	void Load(void* block, size_t block_size);
-	void Draw(uint8_t viewId, ShaderProgram &program, bool cullBack);
+	void Draw(uint8_t viewId, ShaderProgram &program, bool cullBack) const;
 	void BuildMesh(LandIsland& island);
 
 	[[nodiscard]] const LandCell* GetCells() const { return _cells.data(); };

--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -179,7 +179,7 @@ const LandCell& LandIsland::GetCell(int x, int z) const
 	return _landBlocks[blockIndex - 1].GetCells()[(z & 0xF) + 17 * (x & 0xF)];
 }
 
-void LandIsland::Draw(uint8_t viewId, ShaderProgram &program, bool cullBack)
+void LandIsland::Draw(uint8_t viewId, ShaderProgram &program, bool cullBack) const
 {
 	program.SetTextureSampler("s_materials", 0, *_materialArray);
 	program.SetTextureSampler("s_bump", 1, *_textureBumpMap);

--- a/src/3D/LandIsland.h
+++ b/src/3D/LandIsland.h
@@ -79,7 +79,7 @@ class LandIsland
 
 	// Renderer
   public:
-	void Draw(uint8_t viewId, ShaderProgram &program, bool cullBack);
+	void Draw(uint8_t viewId, ShaderProgram &program, bool cullBack) const;
 
 	const std::vector<LandBlock>& GetBlocks() const { return _landBlocks; }
 	const std::vector<Country>& GetCountries() const { return _countries; }

--- a/src/3D/Sky.cpp
+++ b/src/3D/Sky.cpp
@@ -123,7 +123,7 @@ void Sky::CalculateTextures()
 	_texture->Create(256, 256, 1, Format::RGB5A1, Wrapping::ClampEdge, bitmap.data(), bitmap.size() * sizeof(bitmap[0]));
 }
 
-void Sky::Draw(uint8_t viewId, graphics::ShaderProgram &program)
+void Sky::Draw(uint8_t viewId, graphics::ShaderProgram &program) const
 {
 //	program.SetUniformValue("u_model", glm::mat4(1.0f));
 	program.SetTextureSampler("s_diffuse", 0, *_texture);

--- a/src/3D/Sky.h
+++ b/src/3D/Sky.h
@@ -45,7 +45,7 @@ class Sky
 	void Interpolate555Texture(uint16_t* bitmap, uint16_t*, uint16_t*, float);
 
 	void CalculateTextures();
-	void Draw(uint8_t viewId, graphics::ShaderProgram &program);
+	void Draw(uint8_t viewId, graphics::ShaderProgram &program) const;
 	void SetTime(float time);
 	void Update();
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,6 +93,7 @@ set_target_properties(openblack PROPERTIES LINKER_LANGUAGE CXX)
 target_include_directories(openblack PRIVATE ${CMAKE_CURRENT_LIST_DIR} ${CMAKE_CURRENT_BINARY_DIR}/../include)
 target_link_libraries(openblack PRIVATE
 	imgui
+	imgui-flame-graph
 	ScriptLibrary
 	SDL2::SDL2main
 	# SDL2::SDL2-static

--- a/src/Entities/Registry.cpp
+++ b/src/Entities/Registry.cpp
@@ -18,7 +18,7 @@
 namespace openblack::Entities
 {
 
-void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager)
+void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager) const
 {
 	graphics::ShaderProgram* debugShader            = shaderManager.GetShader("DebugLine");
 	graphics::ShaderProgram* objectShader = shaderManager.GetShader("Object");
@@ -29,7 +29,7 @@ void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager
 		| BGFX_STATE_MSAA
 	;
 
-	_registry.view<Tree, Transform>().each([viewId, objectShader, state](Tree& tree, Transform& transform) {
+	_registry.view<const Tree, const Transform>().each([viewId, objectShader, state](const Tree& tree, const Transform& transform) {
 		glm::mat4 modelMatrix = glm::mat4(1.0f);
 		modelMatrix           = glm::translate(modelMatrix, transform.position);
 		modelMatrix           = glm::rotate(modelMatrix, transform.rotation.x, glm::vec3(1.0f, 0.0f, 0.0f));
@@ -44,7 +44,7 @@ void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager
 		mesh.Submit(viewId, *objectShader, state);
 	});
 
-	_registry.view<Stream>().each([viewId, debugShader](Stream& stream) {
+	_registry.view<const Stream>().each([viewId, debugShader](const Stream& stream) {
 		auto nodes       = stream.streamNodes;
 		const auto color = glm::vec4(1, 0, 0, 1);
 
@@ -62,7 +62,7 @@ void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager
 		}
 	});
 
-	_registry.view<Abode, Transform>().each([viewId, state, objectShader](Abode& abode, Transform& transform) {
+	_registry.view<const Abode, const Transform>().each([viewId, state, objectShader](const Abode& abode, const Transform& transform) {
 		glm::mat4 modelMatrix = glm::mat4(1.0f);
 		modelMatrix           = glm::translate(modelMatrix, transform.position);
 		modelMatrix           = glm::rotate(modelMatrix, transform.rotation.x, glm::vec3(1.0f, 0.0f, 0.0f));
@@ -77,7 +77,7 @@ void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager
 		mesh.Submit(viewId, *objectShader, state);
 	});
 
-	_registry.view<AnimatedStatic, Transform>().each([viewId, state, objectShader](AnimatedStatic& animated, Transform& transform) {
+	_registry.view<const AnimatedStatic, const Transform>().each([viewId, state, objectShader](const AnimatedStatic& animated, const Transform& transform) {
 		glm::mat4 modelMatrix = glm::mat4(1.0f);
 		modelMatrix           = glm::translate(modelMatrix, transform.position);
 		modelMatrix           = glm::rotate(modelMatrix, transform.rotation.x, glm::vec3(1.0f, 0.0f, 0.0f));
@@ -110,7 +110,7 @@ void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager
 		}
 	});
 
-	_registry.view<MobileStatic, Transform>().each([viewId, state, objectShader](MobileStatic& mobile, Transform& transform) {
+	_registry.view<const MobileStatic, const Transform>().each([viewId, state, objectShader](const MobileStatic& mobile, const Transform& transform) {
 		glm::mat4 modelMatrix = glm::mat4(1.0f);
 		modelMatrix           = glm::translate(modelMatrix, transform.position);
 		modelMatrix           = glm::rotate(modelMatrix, transform.rotation.x, glm::vec3(1.0f, 0.0f, 0.0f));
@@ -125,7 +125,7 @@ void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager
 		mesh.Submit(viewId, *objectShader, state);
 	});
 
-	_registry.view<Feature, Transform>().each([viewId, state, objectShader](Feature& feature, Transform& transform) {
+	_registry.view<const Feature, const Transform>().each([viewId, state, objectShader](const Feature& feature, const Transform& transform) {
 		glm::mat4 modelMatrix = glm::mat4(1.0f);
 		modelMatrix           = glm::translate(modelMatrix, transform.position);
 		modelMatrix           = glm::rotate(modelMatrix, transform.rotation.x, glm::vec3(1.0f, 0.0f, 0.0f));
@@ -140,7 +140,7 @@ void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager
 		mesh.Submit(viewId, *objectShader, state);
 	});
 
-	_registry.view<Field, Transform>().each([viewId, state, objectShader](Field& feature, Transform& transform) {
+	_registry.view<const Field, const Transform>().each([viewId, state, objectShader](const Field& feature, const Transform& transform) {
 		glm::mat4 modelMatrix = glm::mat4(1.0f);
 		modelMatrix           = glm::translate(modelMatrix, transform.position);
 		modelMatrix           = glm::rotate(modelMatrix, transform.rotation.x, glm::vec3(1.0f, 0.0f, 0.0f));
@@ -155,7 +155,7 @@ void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager
 		mesh.Submit(viewId, *objectShader, state);
 	});
 
-	_registry.view<Forest, Transform>().each([viewId, state, objectShader](Forest& forest, Transform& transform) {
+	_registry.view<const Forest, const Transform>().each([viewId, state, objectShader](const Forest& forest, const Transform& transform) {
 		glm::mat4 modelMatrix = glm::mat4(1.0f);
 		modelMatrix           = glm::translate(modelMatrix, transform.position);
 		modelMatrix           = glm::rotate(modelMatrix, transform.rotation.x, glm::vec3(1.0f, 0.0f, 0.0f));
@@ -170,7 +170,7 @@ void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager
 		mesh.Submit(viewId, *objectShader, state);
 	});
 
-	_registry.view<MobileObject, Transform>().each([viewId, state, objectShader](MobileObject& mobileObject, Transform& transform) {
+	_registry.view<const MobileObject, const Transform>().each([viewId, state, objectShader](const MobileObject& mobileObject, const Transform& transform) {
 		glm::mat4 modelMatrix = glm::mat4(1.0f);
 		modelMatrix           = glm::translate(modelMatrix, transform.position);
 		modelMatrix           = glm::rotate(modelMatrix, transform.rotation.x, glm::vec3(1.0f, 0.0f, 0.0f));

--- a/src/Entities/Registry.h
+++ b/src/Entities/Registry.h
@@ -28,7 +28,7 @@ class Registry
 	}
 
 	void DebugCreateEntities(float x, float y, float z);
-	void DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager);
+	void DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager) const;
 	void Update();
 	decltype(auto) Create() { return _registry.create(); }
 	template <typename Component, typename... Args>

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -242,6 +242,24 @@ void Game::Run()
 		_gui->Loop(*this);
 		_profiler->End(Profiler::Stage::GuiLoop);
 
+		Renderer::DrawSceneDesc drawDesc {
+			/*viewId =*/ 0,
+			/*profiler =*/ *_profiler,
+			/*drawSky =*/ true,
+			/*sky =*/ *_sky,
+			/*drawWater =*/ true,
+			/*water =*/ *_water,
+			/*drawIsland =*/ true,
+			/*island =*/ *_landIsland,
+			/*drawEntities =*/ true,
+			/*entities =*/ *_entityRegistry,
+			/*drawDebugCross =*/ true,
+			/*cullBack =*/ true,
+			/*bgfxDebug =*/ _config.bgfxDebug,
+			/*wireframe =*/ _config.wireframe,
+			/*profile =*/ _config.showProfiler,
+		};
+
 		// Reflection Pass
 		_profiler->Begin(Profiler::Stage::ReflectionPass);
 		bgfx::setViewName(0, "Reflection Pass");
@@ -258,7 +276,11 @@ void Game::Run()
 		_renderer->UploadUniforms(deltaTime, 0, *this, reflectionCamera);
 		_profiler->End(Profiler::Stage::ReflectionUploadUniforms);
 
-		_renderer->DrawScene(*this, 0, false, false, true);
+		drawDesc.viewId = 0;
+		drawDesc.drawWater = false;
+		drawDesc.drawDebugCross = false;
+		drawDesc.cullBack = true;
+		_renderer->DrawScene(drawDesc);
 		_profiler->End(Profiler::Stage::ReflectionPass);
 
 		// Main Draw Pass
@@ -273,7 +295,11 @@ void Game::Run()
 		_renderer->UploadUniforms(deltaTime, 1, *this, *_camera);
 		_profiler->End(Profiler::Stage::MainPassUploadUniforms);
 
-		_renderer->DrawScene(*this, 1, true, true, false);
+		drawDesc.viewId = 1;
+		drawDesc.drawWater = true;
+		drawDesc.drawDebugCross = true;
+		drawDesc.cullBack = false;
+		_renderer->DrawScene(drawDesc);
 		_profiler->End(Profiler::Stage::MainPass);
 
 		_profiler->Begin(Profiler::Stage::GuiDraw);

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -245,15 +245,15 @@ void Game::Run()
 		Renderer::DrawSceneDesc drawDesc {
 			/*viewId =*/ 0,
 			/*profiler =*/ *_profiler,
-			/*drawSky =*/ true,
+			/*drawSky =*/ _config.drawSky,
 			/*sky =*/ *_sky,
-			/*drawWater =*/ true,
+			/*drawWater =*/ _config.drawWater,
 			/*water =*/ *_water,
-			/*drawIsland =*/ true,
+			/*drawIsland =*/ _config.drawIsland,
 			/*island =*/ *_landIsland,
-			/*drawEntities =*/ true,
+			/*drawEntities =*/ _config.drawEntities,
 			/*entities =*/ *_entityRegistry,
-			/*drawDebugCross =*/ true,
+			/*drawDebugCross =*/ _config.drawDebugCross,
 			/*cullBack =*/ true,
 			/*bgfxDebug =*/ _config.bgfxDebug,
 			/*wireframe =*/ _config.wireframe,
@@ -296,8 +296,8 @@ void Game::Run()
 		_profiler->End(Profiler::Stage::MainPassUploadUniforms);
 
 		drawDesc.viewId = 1;
-		drawDesc.drawWater = true;
-		drawDesc.drawDebugCross = true;
+		drawDesc.drawWater = _config.drawWater;
+		drawDesc.drawDebugCross = _config.drawDebugCross;
 		drawDesc.cullBack = false;
 		_renderer->DrawScene(drawDesc);
 		_profiler->End(Profiler::Stage::MainPass);

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -253,7 +253,11 @@ void Game::Run()
 			_renderer->ClearScene(0, width, height);
 		}
 		auto reflectionCamera = _water->GetReflectionCamera();
+
+		_profiler->Begin(Profiler::Stage::ReflectionUploadUniforms);
 		_renderer->UploadUniforms(deltaTime, 0, *this, reflectionCamera);
+		_profiler->End(Profiler::Stage::ReflectionUploadUniforms);
+
 		_renderer->DrawScene(*this, 0, false, false, true);
 		_profiler->End(Profiler::Stage::ReflectionPass);
 
@@ -269,9 +273,7 @@ void Game::Run()
 		_renderer->UploadUniforms(deltaTime, 1, *this, *_camera);
 		_profiler->End(Profiler::Stage::MainPassUploadUniforms);
 
-		_profiler->Begin(Profiler::Stage::MainPassDrawScene);
 		_renderer->DrawScene(*this, 1, true, true, false);
-		_profiler->End(Profiler::Stage::MainPassDrawScene);
 		_profiler->End(Profiler::Stage::MainPass);
 
 		_profiler->Begin(Profiler::Stage::GuiDraw);

--- a/src/Game.h
+++ b/src/Game.h
@@ -22,8 +22,8 @@
 
 #include <LHVM/LHVM.h>
 #include <glm/glm.hpp>
-#include <string>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace openblack
@@ -34,6 +34,7 @@ class GameWindow;
 class Gui;
 class MeshPack;
 class LandIsland;
+class Profiler;
 class Renderer;
 class L3DMesh;
 class Sky;
@@ -90,6 +91,7 @@ class Game
 	GameWindow& GetWindow() { return *_window; }
 	[[nodiscard]] const GameWindow& GetWindow() const { return *_window; }
 	Camera& GetCamera() { return *_camera; }
+	[[nodiscard]] Profiler& GetProfiler() const { return *_profiler; }
 	[[nodiscard]] Renderer& GetRenderer() const { return *_renderer; }
 	[[nodiscard]] Camera& GetCamera() const { return *_camera; }
 	[[nodiscard]] Sky& GetSky() const { return *_sky; }
@@ -122,6 +124,7 @@ class Game
 	std::unique_ptr<Renderer> _renderer;
 	std::unique_ptr<Gui> _gui;
 	std::unique_ptr<Camera> _camera;
+	std::unique_ptr<Profiler> _profiler;
 
 	std::unique_ptr<FileSystem> _fileSystem;
 	std::unique_ptr<LandIsland> _landIsland;

--- a/src/Game.h
+++ b/src/Game.h
@@ -59,6 +59,11 @@ class Game
 			: wireframe(false)
 			, waterDebug(false)
 			, showProfiler(false)
+			, drawSky(true)
+			, drawWater(true)
+			, drawIsland(true)
+			, drawEntities(true)
+			, drawDebugCross(true)
 			, timeOfDay(1.0f)
 			, bumpMapStrength(1.0f)
 			, smallBumpMapStrength(1.0f)
@@ -69,6 +74,12 @@ class Game
 		bool wireframe;
 		bool waterDebug;
 		bool showProfiler;
+
+		bool drawSky;
+		bool drawWater;
+		bool drawIsland;
+		bool drawEntities;
+		bool drawDebugCross;
 
 		float timeOfDay;
 		float bumpMapStrength;

--- a/src/Game.h
+++ b/src/Game.h
@@ -58,6 +58,7 @@ class Game
 		Config()
 			: wireframe(false)
 			, waterDebug(false)
+			, showProfiler(false)
 			, timeOfDay(1.0f)
 			, bumpMapStrength(1.0f)
 			, smallBumpMapStrength(1.0f)
@@ -67,6 +68,7 @@ class Game
 
 		bool wireframe;
 		bool waterDebug;
+		bool showProfiler;
 
 		float timeOfDay;
 		float bumpMapStrength;

--- a/src/Graphics/DebugLines.cpp
+++ b/src/Graphics/DebugLines.cpp
@@ -114,7 +114,7 @@ void DebugLines::SetPose(const glm::vec3 &center, float size)
 	_model = glm::translate(center) * glm::scale(glm::vec3(size, size, size));
 }
 
-void DebugLines::Draw(uint8_t viewId, ShaderProgram &program)
+void DebugLines::Draw(uint8_t viewId, ShaderProgram &program) const
 {
 	uint64_t state = 0u
 		| BGFX_STATE_DEFAULT

--- a/src/Graphics/DebugLines.h
+++ b/src/Graphics/DebugLines.h
@@ -40,7 +40,7 @@ class DebugLines
 
 	virtual ~DebugLines();
 
-	void Draw(uint8_t viewId, ShaderProgram &program);
+	void Draw(uint8_t viewId, ShaderProgram &program) const;
 
 	void SetPose(const glm::vec3 &center, float size);
 

--- a/src/Graphics/Mesh.cpp
+++ b/src/Graphics/Mesh.cpp
@@ -48,7 +48,7 @@ Mesh::Topology Mesh::GetTopology() const noexcept
 	return _topology;
 }
 
-void Mesh::Draw(uint8_t viewId, const openblack::graphics::ShaderProgram &program, uint64_t state, uint32_t rgba)
+void Mesh::Draw(uint8_t viewId, const openblack::graphics::ShaderProgram &program, uint64_t state, uint32_t rgba) const
 {
 	if (_indexBuffer != nullptr && _indexBuffer->GetCount() > 0)
 	{
@@ -60,7 +60,7 @@ void Mesh::Draw(uint8_t viewId, const openblack::graphics::ShaderProgram &progra
 	}
 }
 
-void Mesh::Draw(uint8_t viewId, const openblack::graphics::ShaderProgram &program, uint32_t count, uint32_t startIndex, uint64_t state, uint32_t rgba)
+void Mesh::Draw(uint8_t viewId, const openblack::graphics::ShaderProgram &program, uint32_t count, uint32_t startIndex, uint64_t state, uint32_t rgba) const
 {
 	if (_indexBuffer != nullptr && _indexBuffer->GetCount() > 0)
 	{

--- a/src/Graphics/Mesh.h
+++ b/src/Graphics/Mesh.h
@@ -52,8 +52,8 @@ class Mesh
 
 	[[nodiscard]] Topology GetTopology() const noexcept;
 
-	void Draw(uint8_t viewId, const openblack::graphics::ShaderProgram &program, uint64_t state, uint32_t rgba = 0);
-	void Draw(uint8_t viewId, const openblack::graphics::ShaderProgram &program, uint32_t count, uint32_t startIndex, uint64_t state, uint32_t rgba = 0);
+	void Draw(uint8_t viewId, const openblack::graphics::ShaderProgram &program, uint64_t state, uint32_t rgba = 0) const;
+	void Draw(uint8_t viewId, const openblack::graphics::ShaderProgram &program, uint32_t count, uint32_t startIndex, uint64_t state, uint32_t rgba = 0) const;
 
   protected:
 	std::unique_ptr<VertexBuffer> _vertexBuffer;

--- a/src/Gui.cpp
+++ b/src/Gui.cpp
@@ -726,7 +726,7 @@ void Gui::Draw()
 	RenderDrawDataBgfx(ImGui::GetDrawData());
 }
 
-void Gui::ShowProfilerWindow(const Game& game)
+void Gui::ShowProfilerWindow(Game& game)
 {
 	if (ImGui::Begin("Profiler"))
 	{
@@ -742,6 +742,14 @@ void Gui::ShowProfilerWindow(const Game& game)
 
 		ImGui::Text("Submit CPU %0.3f, GPU %0.3f (Max GPU Latency: %d)", double(stats->cpuTimeEnd - stats->cpuTimeBegin) * toMsCpu, double(stats->gpuTimeEnd - stats->gpuTimeBegin) * toMsGpu, stats->maxGpuLatency);
 		ImGui::Text("Wait Submit %0.3f, Wait Render %0.3f", stats->waitSubmit * toMsCpu, stats->waitRender * toMsCpu);
+
+		ImGui::Columns(5);
+		ImGui::Checkbox("Sky", &game.GetConfig().drawSky); ImGui::NextColumn();
+		ImGui::Checkbox("Water", &game.GetConfig().drawWater); ImGui::NextColumn();
+		ImGui::Checkbox("Island", &game.GetConfig().drawIsland); ImGui::NextColumn();
+		ImGui::Checkbox("Entities", &game.GetConfig().drawEntities); ImGui::NextColumn();
+		ImGui::Checkbox("Debug Cross", &game.GetConfig().drawDebugCross);
+		ImGui::Columns(1);
 
 		auto width = ImGui::GetColumnWidth() - ImGui::CalcTextSize("Frame").x;
 		ImGui::PlotHistogram("Frame", _times._values, decltype(_times)::_bufferSize, _times._offset, frameTextOverlay, 0.0f, FLT_MAX, ImVec2(width, 45.0f));

--- a/src/Gui.cpp
+++ b/src/Gui.cpp
@@ -40,6 +40,7 @@
 #include <3D/Sky.h>
 #include <3D/Water.h>
 #include <Entities/Components/Transform.h>
+#include <Entities/Components/Tree.h>
 
 #include "Entities/Registry.h"
 #include "Graphics/Shaders/vs_ocornut_imgui.bin.h"
@@ -747,6 +748,7 @@ void Gui::ShowProfilerWindow(const Game& game)
 
 		ImGui::Text("Primitives Triangles %u, Triangle Strips %u, Lines %u Line Strips %u, Points %u", stats->numPrims[0], stats->numPrims[1], stats->numPrims[2], stats->numPrims[3], stats->numPrims[4]);
 		ImGui::Columns(2);
+		ImGui::Text("Num Entities %u, Trees %u", static_cast<uint32_t>(game.GetEntityRegistry().Size<const Transform>()), static_cast<uint32_t>(game.GetEntityRegistry().Size<const Tree>()));
 		ImGui::Text("Num Draw %u, Num Compute %u, Num Blit %u", stats->numDraw, stats->numCompute, stats->numBlit);
 		ImGui::Text("Num Buffers Index %u, Vertex %u", stats->numIndexBuffers, stats->numVertexBuffers);
 		ImGui::Text("Num Dynamic Buffers Index %u, Vertex %u", stats->numDynamicIndexBuffers, stats->numDynamicVertexBuffers);

--- a/src/Gui.cpp
+++ b/src/Gui.cpp
@@ -737,9 +737,8 @@ void Gui::ShowProfilerWindow(const Game& game)
 		char frameTextOverlay[256];
 		std::snprintf(frameTextOverlay, sizeof(frameTextOverlay), "%.3fms, %.1f FPS", _times.back(), _fps.back());
 
-		//	ImGui::PushStyleColor(ImGuiCol_PlotHistogram, ImColor(0.0f, 0.5f, 0.15f, 1.0f).Value);
-		ImGui::PlotHistogram("Frame", _times._values, decltype(_times)::_bufferSize, _times._offset, frameTextOverlay, 0.0f, FLT_MAX, ImVec2(0.0f, 45.0f));
-		//	ImGui::PopStyleColor();
+		auto width = ImGui::GetColumnWidth() - ImGui::CalcTextSize("Frame").x;
+		ImGui::PlotHistogram("Frame", _times._values, decltype(_times)::_bufferSize, _times._offset, frameTextOverlay, 0.0f, FLT_MAX, ImVec2(width, 45.0f));
 
 		ImGui::Text("Submit CPU %0.3f, GPU %0.3f (Max GPU Latency: %d)", double(stats->cpuTimeEnd - stats->cpuTimeBegin) * toMsCpu, double(stats->gpuTimeEnd - stats->gpuTimeBegin) * toMsGpu, stats->maxGpuLatency);
 		ImGui::Text("Wait Submit %0.3f, Wait Render %0.3f", stats->waitSubmit * toMsCpu, stats->waitRender * toMsCpu);
@@ -770,7 +769,7 @@ void Gui::ShowProfilerWindow(const Game& game)
 				{
 					*caption = Profiler::stageNames[idx].data();
 				}
-			}, &entry, static_cast<uint8_t>(Profiler::Stage::_count), 0, "Main Thread");
+			}, &entry, static_cast<uint8_t>(Profiler::Stage::_count), 0, "Main Thread", 0, FLT_MAX, ImVec2(width, 0));
 
 		ImGuiWidgetFlameGraph::PlotFlame("GPU",
 			[](float* startTimestamp, float* endTimestamp, ImU8* level, const char** caption, const void* data, int idx) -> void {
@@ -791,7 +790,8 @@ void Gui::ShowProfilerWindow(const Game& game)
 				{
 					*caption = stats->viewStats[idx].name;
 				}
-			}, stats, stats->numViews, 0, "GPU Frame", 0, 1000.0f * (stats->gpuTimeEnd - stats->gpuTimeBegin) / (double)stats->gpuTimerFreq);
+			}, stats, stats->numViews, 0, "GPU Frame",
+            0, 1000.0f * (stats->gpuTimeEnd - stats->gpuTimeBegin) / (double)stats->gpuTimerFreq, ImVec2(width, 0));
 
 		ImGui::Columns(2);
 		if (ImGui::CollapsingHeader("Details (CPU)", ImGuiTreeNodeFlags_DefaultOpen))

--- a/src/Gui.cpp
+++ b/src/Gui.cpp
@@ -39,7 +39,9 @@
 #include <3D/MeshPack.h>
 #include <3D/Sky.h>
 #include <3D/Water.h>
+#include <Entities/Components/Transform.h>
 
+#include "Entities/Registry.h"
 #include "Graphics/Shaders/vs_ocornut_imgui.bin.h"
 #include "Graphics/Shaders/fs_ocornut_imgui.bin.h"
 #include "Graphics/Shaders/vs_imgui_image.bin.h"
@@ -737,11 +739,26 @@ void Gui::ShowProfilerWindow(const Game& game)
 		char frameTextOverlay[256];
 		std::snprintf(frameTextOverlay, sizeof(frameTextOverlay), "%.3fms, %.1f FPS", _times.back(), _fps.back());
 
+		ImGui::Text("Submit CPU %0.3f, GPU %0.3f (Max GPU Latency: %d)", double(stats->cpuTimeEnd - stats->cpuTimeBegin) * toMsCpu, double(stats->gpuTimeEnd - stats->gpuTimeBegin) * toMsGpu, stats->maxGpuLatency);
+		ImGui::Text("Wait Submit %0.3f, Wait Render %0.3f", stats->waitSubmit * toMsCpu, stats->waitRender * toMsCpu);
+
 		auto width = ImGui::GetColumnWidth() - ImGui::CalcTextSize("Frame").x;
 		ImGui::PlotHistogram("Frame", _times._values, decltype(_times)::_bufferSize, _times._offset, frameTextOverlay, 0.0f, FLT_MAX, ImVec2(width, 45.0f));
 
-		ImGui::Text("Submit CPU %0.3f, GPU %0.3f (Max GPU Latency: %d)", double(stats->cpuTimeEnd - stats->cpuTimeBegin) * toMsCpu, double(stats->gpuTimeEnd - stats->gpuTimeBegin) * toMsGpu, stats->maxGpuLatency);
-		ImGui::Text("Wait Submit %0.3f, Wait Render %0.3f", stats->waitSubmit * toMsCpu, stats->waitRender * toMsCpu);
+		ImGui::Text("Primitives Triangles %u, Triangle Strips %u, Lines %u Line Strips %u, Points %u", stats->numPrims[0], stats->numPrims[1], stats->numPrims[2], stats->numPrims[3], stats->numPrims[4]);
+		ImGui::Columns(2);
+		ImGui::Text("Num Draw %u, Num Compute %u, Num Blit %u", stats->numDraw, stats->numCompute, stats->numBlit);
+		ImGui::Text("Num Buffers Index %u, Vertex %u", stats->numIndexBuffers, stats->numVertexBuffers);
+		ImGui::Text("Num Dynamic Buffers Index %u, Vertex %u", stats->numDynamicIndexBuffers, stats->numDynamicVertexBuffers);
+		ImGui::Text("Num Transient Buffers Index %u, Vertex %u", stats->transientIbUsed, stats->transientVbUsed);
+		ImGui::NextColumn();
+		ImGui::Text("Num Vertex Layouts %u", stats->numVertexLayouts);
+		ImGui::Text("Num Textures %u, FrameBuffers %u", stats->numTextures, stats->numFrameBuffers);
+		ImGui::Text("Memory Texture %ld, RenderTarget %ld", stats->textureMemoryUsed, stats->rtMemoryUsed);
+		ImGui::Text("Num Programs %u, Num Shaders %u, Uniforms %u", stats->numPrograms, stats->numShaders, stats->numUniforms);
+		ImGui::Text("Num Occlusion Queries %u", stats->numOcclusionQueries);
+
+		ImGui::Columns(1);
 
 		auto& entry = game.GetProfiler()._entries[game.GetProfiler().GetCurrentEntryIndex()];
 

--- a/src/Gui.h
+++ b/src/Gui.h
@@ -92,7 +92,7 @@ class Gui
 	bool CreateDeviceObjectsBgfx();
 	void RenderDrawDataBgfx(ImDrawData* drawData);
 
-	void ShowProfilerWindow(const Game& game);
+	void ShowProfilerWindow(Game& game);
 
 	static const char* StaticGetClipboardText(void* ud) { return reinterpret_cast<Gui*>(ud)->GetClipboardText(); }
 	static void StaticSetClipboardText(void* ud, const char* text)  { reinterpret_cast<Gui*>(ud)->SetClipboardText(text); }

--- a/src/Gui.h
+++ b/src/Gui.h
@@ -92,6 +92,8 @@ class Gui
 	bool CreateDeviceObjectsBgfx();
 	void RenderDrawDataBgfx(ImDrawData* drawData);
 
+	void ShowProfilerWindow(const Game& game);
+
 	static const char* StaticGetClipboardText(void* ud) { return reinterpret_cast<Gui*>(ud)->GetClipboardText(); }
 	static void StaticSetClipboardText(void* ud, const char* text)  { reinterpret_cast<Gui*>(ud)->SetClipboardText(text); }
 	const char* GetClipboardText();
@@ -101,8 +103,25 @@ class Gui
 	void UpdateMouseCursor();
 	void UpdateGamepads();
 
+	template<typename T, uint8_t N>
+	struct CircularBuffer
+	{
+		static constexpr uint8_t _bufferSize = N;
+		T _values[_bufferSize] = {};
+		uint8_t _offset = 0;
+
+		[[nodiscard]] T back() const { return _values[_offset]; }
+		void pushBack(T value)
+		{
+			_values[_offset] = value;
+			_offset = (_offset + 1u) % _bufferSize;
+		}
+	};
+
 	ImGuiContext* _imgui;
 	uint64_t _time;
+	CircularBuffer<float, 100> _times;
+	CircularBuffer<float, 100> _fps;
 	bgfx::VertexLayout  _layout;
 	bgfx::ProgramHandle _program;
 	bgfx::ProgramHandle _imageProgram;

--- a/src/Profiler.cpp
+++ b/src/Profiler.cpp
@@ -1,0 +1,51 @@
+/* openblack - A reimplementation of Lionhead's Black & White.
+ *
+ * openblack is the legal property of its developers, whose names
+ * can be found in the AUTHORS.md file distributed with this source
+ * distribution.
+ *
+ * openblack is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * openblack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with openblack. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Profiler.h"
+
+#include <cassert>
+
+void openblack::Profiler::Begin(Stage stage)
+{
+	assert(_currentLevel < 255);
+	auto& entry = _entries[_currentEntry]._stages[static_cast<uint8_t>(stage)];
+	_currentLevel++;
+	entry._level = _currentLevel;
+	entry._start = std::chrono::system_clock::now();
+	entry._finalized = false;
+}
+
+void openblack::Profiler::End(Stage stage)
+{
+	assert(_currentLevel > 0);
+	auto& entry = _entries[_currentEntry]._stages[static_cast<uint8_t>(stage)];
+	assert(!entry._finalized);
+	assert(entry._level == _currentLevel);
+	_currentLevel--;
+	entry._end = std::chrono::system_clock::now();
+	entry._finalized = true;
+}
+
+void openblack::Profiler::Frame()
+{
+	auto& prevEntry = _entries[_currentEntry];
+	_currentEntry = (_currentEntry + 1) % _bufferSize;
+	prevEntry._frameEnd = _entries[_currentEntry]._frameStart = std::chrono::system_clock::now();
+}

--- a/src/Profiler.cpp
+++ b/src/Profiler.cpp
@@ -26,8 +26,8 @@ void openblack::Profiler::Begin(Stage stage)
 {
 	assert(_currentLevel < 255);
 	auto& entry = _entries[_currentEntry]._stages[static_cast<uint8_t>(stage)];
-	_currentLevel++;
 	entry._level = _currentLevel;
+	_currentLevel++;
 	entry._start = std::chrono::system_clock::now();
 	entry._finalized = false;
 }
@@ -37,8 +37,8 @@ void openblack::Profiler::End(Stage stage)
 	assert(_currentLevel > 0);
 	auto& entry = _entries[_currentEntry]._stages[static_cast<uint8_t>(stage)];
 	assert(!entry._finalized);
-	assert(entry._level == _currentLevel);
 	_currentLevel--;
+	assert(entry._level == _currentLevel);
 	entry._end = std::chrono::system_clock::now();
 	entry._finalized = true;
 }

--- a/src/Profiler.h
+++ b/src/Profiler.h
@@ -32,6 +32,35 @@ namespace openblack
 
 class Profiler
 {
+public:
+
+	enum class Stage : uint8_t
+	{
+		SdlInput,
+		UpdatePositions,
+		GuiLoop,
+		ReflectionPass,
+		ReflectionUploadUniforms,
+		ReflectionDrawScene,
+		ReflectionDrawSky,
+		ReflectionDrawWater,
+		ReflectionDrawIsland,
+		ReflectionDrawModels,
+		ReflectionDrawDebugCross,
+		MainPass,
+		MainPassUploadUniforms,
+		MainPassDrawScene,
+		MainPassDrawSky,
+		MainPassDrawWater,
+		MainPassDrawIsland,
+		MainPassDrawModels,
+		MainPassDrawDebugCross,
+		GuiDraw,
+		RendererFrame,
+
+		_count,
+	};
+
 	struct Scope
 	{
 		uint8_t _level;
@@ -40,32 +69,28 @@ class Profiler
 		bool _finalized = false;
 	};
 
-public:
-	enum class Stage : uint8_t
-	{
-		SdlInput,
-		UpdatePositions,
-		GuiLoop,
-		ReflectionPass,
-		MainPass,
-		MainPassUploadUniforms,
-		MainPassDrawScene,
-		GuiDraw,
-		RendererFrame,
-
-		_count,
-	};
-
 	static constexpr std::array<std::string_view, static_cast<uint8_t>(Stage::_count)> stageNames = {
-		"SdlInput",
-		"UpdatePositions",
-		"GuiLoop",
-		"ReflectionPass",
-		"MainPass",
-		"MainPassUploadUniforms",
-		"MainPassDrawScene",
-		"GuiDraw",
-		"RendererFrame",
+		"SDL Input",
+		"Update Positions",
+		"GUI Loop",
+		"Reflection Pass",
+		"Upload Uniforms",
+		"Draw Scene",
+		"Draw Sky",
+		"Draw Water",
+		"Draw Island",
+		"Draw Models",
+		"Draw Debug Cross",
+		"Main Pass",
+		"Upload Uniforms",
+		"Draw Scene",
+		"Draw Sky",
+		"Draw Water",
+		"Draw Island",
+		"Draw Models",
+		"Draw Debug Cross",
+		"GUI Draw",
+		"Renderer Frame",
 	};
 
 	struct Entry
@@ -78,6 +103,11 @@ public:
 	void Frame();
 	void Begin(Stage stage);
 	void End(Stage stage);
+
+	[[ nodiscard ]] uint8_t GetCurrentEntryIndex() const
+	{
+		return (_currentEntry + _bufferSize - 1) % _bufferSize;
+	}
 
 	static constexpr uint8_t _bufferSize = 100;
 	std::array<Entry, _bufferSize> _entries;

--- a/src/Profiler.h
+++ b/src/Profiler.h
@@ -1,0 +1,90 @@
+/* openblack - A reimplementation of Lionhead's Black & White.
+ *
+ * openblack is the legal property of its developers, whose names
+ * can be found in the AUTHORS.md file distributed with this source
+ * distribution.
+ *
+ * openblack is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * openblack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with openblack. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+#include <array>
+#include <chrono>
+#include <map>
+#include <string_view>
+
+namespace openblack
+{
+
+class Profiler
+{
+	struct Scope
+	{
+		uint8_t _level;
+		std::chrono::system_clock::time_point _start;
+		std::chrono::system_clock::time_point _end;
+		bool _finalized = false;
+	};
+
+public:
+	enum class Stage : uint8_t
+	{
+		SdlInput,
+		UpdatePositions,
+		GuiLoop,
+		ReflectionPass,
+		MainPass,
+		MainPassUploadUniforms,
+		MainPassDrawScene,
+		GuiDraw,
+		RendererFrame,
+
+		_count,
+	};
+
+	static constexpr std::array<std::string_view, static_cast<uint8_t>(Stage::_count)> stageNames = {
+		"SdlInput",
+		"UpdatePositions",
+		"GuiLoop",
+		"ReflectionPass",
+		"MainPass",
+		"MainPassUploadUniforms",
+		"MainPassDrawScene",
+		"GuiDraw",
+		"RendererFrame",
+	};
+
+	struct Entry
+	{
+		std::chrono::system_clock::time_point _frameStart;
+		std::chrono::system_clock::time_point _frameEnd;
+		std::array<Scope, static_cast<uint8_t>(Stage::_count)> _stages;
+	};
+
+	void Frame();
+	void Begin(Stage stage);
+	void End(Stage stage);
+
+	static constexpr uint8_t _bufferSize = 100;
+	std::array<Entry, _bufferSize> _entries;
+
+private:
+	uint8_t _currentEntry = _bufferSize - 1;
+	uint8_t _currentLevel = 0;
+};
+
+}  // openblack

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -283,6 +283,10 @@ void Renderer::DrawScene(const Game &game, uint8_t viewId, bool drawWater, bool 
 	{
 		debugMode |= BGFX_DEBUG_WIREFRAME;
 	}
+	if (game.GetConfig().showProfiler)
+	{
+		debugMode |= BGFX_DEBUG_PROFILER;
+	}
 	bgfx::setDebug(debugMode);
 	game.GetProfiler().End(viewId == 0 ? Profiler::Stage::ReflectionDrawScene : Profiler::Stage::MainPassDrawScene);
 }

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -80,13 +80,13 @@ class Renderer {
 		uint8_t viewId;
 		Profiler& profiler;
 		bool drawSky;
-		Sky& sky;
+		const Sky& sky;
 		bool drawWater;
-		Water& water;
+		const Water& water;
 		bool drawIsland;
-		LandIsland& island;
+		const LandIsland& island;
 		bool drawEntities;
-		Entities::Registry& entities;
+		const Entities::Registry& entities;
 		bool drawDebugCross;
 		bool cullBack;
 		bool bgfxDebug;

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -34,6 +34,15 @@ namespace openblack
 struct BgfxCallback;
 class GameWindow;
 class Game;
+class LandIsland;
+class Profiler;
+class Sky;
+class Water;
+
+namespace Entities
+{
+class Registry;
+}
 
 namespace graphics
 {
@@ -67,6 +76,23 @@ class Renderer {
 		uint32_t name;
 		int value;
 	};
+	struct DrawSceneDesc {
+		uint8_t viewId;
+		Profiler& profiler;
+		bool drawSky;
+		Sky& sky;
+		bool drawWater;
+		Water& water;
+		bool drawIsland;
+		LandIsland& island;
+		bool drawEntities;
+		Entities::Registry& entities;
+		bool drawDebugCross;
+		bool cullBack;
+		bool bgfxDebug;
+		bool wireframe;
+		bool profile;
+	};
 
 	Renderer() = delete;
 	explicit Renderer(const GameWindow& window, bool vsync, const std::string binaryPath);
@@ -80,7 +106,7 @@ class Renderer {
 
 	void UploadUniforms(std::chrono::microseconds dt, uint8_t viewId, const Game &game, const Camera &camera);
 	void ClearScene(uint8_t viewId, int width, int height);
-	void DrawScene(const Game &game, uint8_t viewId, bool drawWater, bool drawDebugCross, bool cullBack = true);
+	void DrawScene(const DrawSceneDesc &desc);
 	void Frame();
 
   private:


### PR DESCRIPTION
This is the first step for optimization.
Add a profiler and ui using an [imgui widget which I maintain](https://github.com/bwrsandman/imgui-flame-graph).
![Screenshot from 2019-10-24 00-35-55](https://user-images.githubusercontent.com/1013356/67439346-48951300-f5f6-11e9-82f4-cad09a6fc91a.png)

The window shows basic bgfx stats for CPU and GPU times.
Bellow is a row of check boxes to turn off certain parts of the rendering. This is useful for finding bottlenecks. This required some configs to be added to Game and for many more parameters to be passed to Renderer. For this reason, I added `DrawSceneDesc`.

Next is a history of frame times, which is useful for seeing jitter.

Bellow that are the complete bgfx stats and some stats from openblack such as the number of entities in the scene and particularly trees which are very expensive to render at this stage. Note that there's a stat on transient buffers. A later PR will remove the use of transients.

Following that are two flame graphs for the CPU and GPU respectively. If an additional thread were added, a new flame graph would need to be put there.
Note that this is less detailed that I would like to be because bgfx doesn't keep time stamps for all its stats and in my debugging I had to add them to the library to see them. In order to be more compatible with upstream, I left those out of this PR.

Finally under this is a detailed report of the durations of each element in both flame graphs.

The data for the CPU flame graphs come from the new `Profiler` class. It is purposely using a per-determined set of frames that it profiles in order to be more efficient as dynamic arrays could add more to the run time. In the future a more elegant profiling library could populate the flame graph such as https://github.com/jonasmr/microprofile or other elegant solutions.

Finally, there have been some general tidying up. Making draw functions const mainly and removing dead commented out code .