### PR TITLE
cmake: add option to use system spirv-tools in bgfx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,16 @@ if (NOT bgfx_FOUND)
   set(BGFX_CUSTOM_TARGETS OFF CACHE BOOL "Include convenience custom targets.")
   set(BGFX_USE_DEBUG_SUFFIX OFF CACHE BOOL "Add 'd' suffix to debug output targets")
 
+  include(CMakeDependentOption)
+  option(OPENBLACK_BGFX_USE_SYSTEM_DEPS "Search for system libraries for all 3rd parties of bgfx" OFF)
+  cmake_dependent_option(OPENBLACK_BGFX_USE_SYSTEM_SPIRV_TOOLS "Search for system spirv tools instead of building it" ON "OPENBLACK_BGFX_USE_SYSTEM_DEPS" OFF)
+
+  if (OPENBLACK_BGFX_USE_SYSTEM_SPIRV_TOOLS)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(SPIRV_TOOLS REQUIRED IMPORTED_TARGET GLOBAL SPIRV-Tools)
+    add_library(spirv-tools ALIAS PkgConfig::SPIRV_TOOLS)
+  endif()
+
   # declare this here so bgfx compiles in a reasonable time
   if (MSVC)
     add_compile_options(/MP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,11 +75,27 @@ if (NOT bgfx_FOUND)
   include(CMakeDependentOption)
   option(OPENBLACK_BGFX_USE_SYSTEM_DEPS "Search for system libraries for all 3rd parties of bgfx" OFF)
   cmake_dependent_option(OPENBLACK_BGFX_USE_SYSTEM_SPIRV_TOOLS "Search for system spirv tools instead of building it" ON "OPENBLACK_BGFX_USE_SYSTEM_DEPS" OFF)
+  cmake_dependent_option(OPENBLACK_BGFX_USE_SYSTEM_SPIRV_CROSS "Search for system spirv cross instead of building it" ON "OPENBLACK_BGFX_USE_SYSTEM_DEPS" OFF)
 
   if (OPENBLACK_BGFX_USE_SYSTEM_SPIRV_TOOLS)
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(SPIRV_TOOLS REQUIRED IMPORTED_TARGET GLOBAL SPIRV-Tools)
     add_library(spirv-tools ALIAS PkgConfig::SPIRV_TOOLS)
+  endif()
+  if (OPENBLACK_BGFX_USE_SYSTEM_SPIRV_CROSS)
+    find_package(spirv_cross_c_shared REQUIRED)
+    find_package(spirv_cross_glsl REQUIRED)
+    find_package(spirv_cross_msl REQUIRED)
+    find_package(spirv_cross_reflect REQUIRED)
+    #set_target_properties(spirv-cross-c-shared PROPERTIES IMPORTED_GLOBAL TRUE)
+    add_library(spirv-cross INTERFACE)
+    target_link_libraries(spirv-cross
+      INTERFACE
+        spirv-cross-c-shared
+        spirv-cross-glsl
+        spirv-cross-msl
+        spirv-cross-reflect
+    )
   endif()
 
   # declare this here so bgfx compiles in a reasonable time


### PR DESCRIPTION
The option is off by default but if enabled, it will find and create the spirv-tools target from the system installed library (if it doesn't exist, it will error here).
Thanks to this bit of code in bgfx.cmake and the alias library, bgfx.cmake will use the system instead of building it itself.
https://github.com/JoshuaBrookover/bgfx.cmake/blob/master/cmake/3rdparty/spirv-tools.cmake#L11-L13