### PR TITLE
bgfx: Move back to upstream bgfx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,8 @@ else()
 
   FetchContent_Declare(
     bgfx
-    GIT_REPOSITORY https://github.com/openblack/bgfx.cmake.git
-    GIT_TAG master
+    GIT_REPOSITORY https://github.com/JoshuaBrookover/bgfx.cmake.git
+    GIT_TAG        master
   )
 
   # don't build anymore targets then what we need


### PR DESCRIPTION
Our use of bgfx https://github.com/openblack/bgfx has a few modifications
- [x] Fixes to shaderc and shader loading for our terrain fragment shader https://github.com/bkaradzic/bgfx/pull/1920
- [x] Fixes to instance rebinds for our submesh primitive rendering:
    - [x] https://github.com/bkaradzic/bgfx/pull/1919
    - [x] https://github.com/bkaradzic/bgfx/pull/2020
- [x] Data made available for profiler, mainly view `gpuTimeBegin`, `gpuTimeEnd`,  `cpuTimeBegin`, `cpuTimeEnd` (https://github.com/bkaradzic/bgfx/pull/1921)
- [x] The sky texture has color order inverted in OpenGL but not in D3D (https://github.com/bkaradzic/bgfx/pull/1932)
- [x] The L3D RGBA4 textures have inverted color order in some backends (https://github.com/bkaradzic/bgfx/pull/2029)

Once these changes are merged, we can switch from using our own fork to using upstream.