### PR TITLE
ui: remove use of transient buffers

### DIFF
--- a/src/Gui.h
+++ b/src/Gui.h
@@ -122,6 +122,10 @@ class Gui
 	uint64_t _time;
 	CircularBuffer<float, 100> _times;
 	CircularBuffer<float, 100> _fps;
+	bgfx::DynamicVertexBufferHandle _vertexBuffer;
+	bgfx::DynamicIndexBufferHandle _indexBuffer;
+	uint32_t _vertexCount;
+	uint32_t _indexCount;
 	bgfx::VertexLayout  _layout;
 	bgfx::ProgramHandle _program;
 	bgfx::ProgramHandle _imageProgram;


### PR DESCRIPTION
Transient buffers are destroyed and recreated at every frame.
The default size of a transient buffer (`init.limits.transientVbSize`) is
rather large and this causes the destruction, recreation and upload of
large GPU buffers.

A dynamic buffer is used instead which is recreated only when the ui needs
more space for vertices and indices. This prevents the recreation of the
buffers and leaves the uploads to only the size of buffers needed to be
done every frame.

On my machine this means a difference of 10ms:

Current Master:
![Screenshot from 2019-10-20 17-38-51](https://user-images.githubusercontent.com/1013356/67617231-5955ac80-f7e1-11e9-910d-f9ac50d1193a.png)
This PR:
![Screenshot from 2019-10-21 11-34-25](https://user-images.githubusercontent.com/1013356/67617241-75594e00-f7e1-11e9-84b7-7abfbc310907.png)

Related issue https://github.com/bkaradzic/bgfx/issues/1023
Note that the profiler as it is does not record the Update Vertex time, this is because I made local changes to the bgfx internal stats but did not push them since they were pretty hacky.