### PR TITLE
L3DSubMesh Bounding Boxes

### DIFF
--- a/src/3D/AxisAlignedBoundingBox.h
+++ b/src/3D/AxisAlignedBoundingBox.h
@@ -18,39 +18,24 @@
  * along with openblack. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#pragma once
-
-#include <memory>
-
-#include <AllMeshes.h>
-#include <Graphics/FrameBuffer.h>
-#include <Graphics/DebugLines.h>
+#include <glm/vec3.hpp>
 
 namespace openblack
 {
 
-namespace graphics
+struct AxisAlignedBoundingBox
 {
-class DebugLines;
-}
+	glm::vec3 minima;
+	glm::vec3 maxima;
 
-class MeshViewer
-{
-  public:
-	explicit MeshViewer(uint8_t viewId);
-	void Open();
-	void DrawWindow();
-	void DrawScene();
-
-  private:
-	bool _open;
-	const uint8_t _viewId;
-	MeshId _selectedMesh;
-	int _selectedSubMesh;
-	ImGuiTextFilter _filter;
-	glm::vec3 _cameraPosition;
-	bool _viewBoundingBox;
-	std::unique_ptr<graphics::DebugLines> _boundingBox;
-	std::unique_ptr<graphics::FrameBuffer> _frameBuffer;
+	[[nodiscard]] inline glm::vec3 center() const
+	{
+		return (maxima + minima) * 0.5f;
+	}
+	[[nodiscard]] inline glm::vec3 size() const
+	{
+		return maxima - minima;
+	}
 };
-} // namespace openblack
+
+}  // namespace openblack::graphics

--- a/src/3D/L3DMesh.h
+++ b/src/3D/L3DMesh.h
@@ -87,6 +87,7 @@ class L3DMesh
 	void Draw(uint8_t viewId, const glm::mat4& modelMatrix, const ShaderProgram& program, uint32_t mesh, uint64_t state, uint32_t rgba = 0) const;
 	void Submit(uint8_t viewId, const glm::mat4& modelMatrix, const ShaderProgram& program, uint64_t state, uint32_t rgba = 0) const;
 
+	[[nodiscard]] uint8_t GetNumSubMeshes() const { return _subMeshes.size(); }
 	const std::vector<std::unique_ptr<L3DSubMesh>>& GetSubMeshes() const { return _subMeshes; }
 	const std::unordered_map<SkinId, std::unique_ptr<Texture2D>>& GetSkins() const { return _skins; }
 

--- a/src/3D/L3DSubMesh.h
+++ b/src/3D/L3DSubMesh.h
@@ -22,6 +22,11 @@
 
 #include <cstdint>
 #include <memory>
+#include <vector>
+
+#include <glm/fwd.hpp>
+
+#include "AxisAlignedBoundingBox.h"
 
 namespace openblack
 {
@@ -54,22 +59,25 @@ class L3DSubMesh
 	~L3DSubMesh();
 
 	void Load(IStream& stream);
-	void Submit(uint8_t viewId, const glm::mat4& modelMatrix, const ShaderProgram& program, uint64_t state, uint32_t rgba = 0, bool preserveState = false) const;
+	void Submit(uint8_t viewId, const glm::mat4& modelMatrix, const graphics::ShaderProgram& program, uint64_t state, uint32_t rgba = 0, bool preserveState = false) const;
 
 	[[ nodiscard ]] uint8_t GetLOD() const { return static_cast<uint8_t>(_flags & 0x7u); } // 29-32 (3)
 	[[ nodiscard ]] uint8_t GetStatus() const { return static_cast<uint8_t>((_flags >> 3u) & 0x3Fu); } // 22-28 (6)
 	[[ nodiscard ]] bool IsWindow() const { return static_cast<bool>(_flags & 0x1000u); } // 19
 	[[ nodiscard ]] bool IsPhysics() const { return static_cast<bool>(_flags & 0x2000u); } // 18
-	[[ nodiscard ]] uint32_t GetVertexCount() const { return _vertexBuffer->GetCount(); }
-	[[ nodiscard ]] uint32_t GetIndexCount() const { return _indexBuffer->GetCount(); }
+	[[ nodiscard ]] uint32_t GetVertexCount() const;
+	[[ nodiscard ]] uint32_t GetIndexCount() const;
+	[[ nodiscard ]] AxisAlignedBoundingBox GetBoundingBox() const { return _boundingBox; }
 
   private:
 	L3DMesh& _l3dMesh;
 
 	uint32_t _flags;
 
-	std::unique_ptr<VertexBuffer> _vertexBuffer;
-	std::unique_ptr<IndexBuffer> _indexBuffer;
+	std::unique_ptr<graphics::VertexBuffer> _vertexBuffer;
+	std::unique_ptr<graphics::IndexBuffer> _indexBuffer;
 	std::vector<Primitive> _primitives;
+
+	AxisAlignedBoundingBox _boundingBox;
 };
 } // namespace openblack

--- a/src/Entities/Registry.cpp
+++ b/src/Entities/Registry.cpp
@@ -18,7 +18,7 @@
 namespace openblack::Entities
 {
 
-void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager) const
+void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager, graphics::DebugLines* boundingBox) const
 {
 	graphics::ShaderProgram* debugShader            = shaderManager.GetShader("DebugLine");
 	graphics::ShaderProgram* objectShader = shaderManager.GetShader("Object");
@@ -29,7 +29,7 @@ void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager
 		| BGFX_STATE_MSAA
 	;
 
-	_registry.view<const Tree, const Transform>().each([viewId, objectShader, state](const Tree& tree, const Transform& transform) {
+	_registry.view<const Tree, const Transform>().each([viewId, debugShader, objectShader, state, &boundingBox](const Tree& tree, const Transform& transform) {
 		glm::mat4 modelMatrix = glm::mat4(1.0f);
 		modelMatrix           = glm::translate(modelMatrix, transform.position);
 		modelMatrix           = glm::rotate(modelMatrix, transform.rotation.x, glm::vec3(1.0f, 0.0f, 0.0f));
@@ -41,6 +41,13 @@ void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager
 		const L3DMesh& mesh = Game::instance()->GetMeshPack().GetMesh(static_cast<uint32_t>(meshId));
 
 		mesh.Submit(viewId, modelMatrix, *objectShader, state);
+
+		if (boundingBox)
+		{
+			auto box = mesh.GetSubMeshes()[mesh.GetNumSubMeshes() - 1]->GetBoundingBox();
+			boundingBox->SetPose(box.center() + transform.position, box.size() * transform.scale);
+			boundingBox->Draw(viewId, *debugShader);
+		}
 	});
 
 	_registry.view<const Stream>().each([viewId, debugShader](const Stream& stream) {
@@ -61,7 +68,7 @@ void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager
 		}
 	});
 
-	_registry.view<const Abode, const Transform>().each([viewId, state, objectShader](const Abode& abode, const Transform& transform) {
+	_registry.view<const Abode, const Transform>().each([viewId, state, objectShader, debugShader, boundingBox](const Abode& abode, const Transform& transform) {
 		glm::mat4 modelMatrix = glm::mat4(1.0f);
 		modelMatrix           = glm::translate(modelMatrix, transform.position);
 		modelMatrix           = glm::rotate(modelMatrix, transform.rotation.x, glm::vec3(1.0f, 0.0f, 0.0f));
@@ -72,9 +79,16 @@ void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager
 
 		const L3DMesh& mesh = Game::instance()->GetMeshPack().GetMesh(static_cast<uint32_t>(abodeMeshLookup[abodeId]));
 		mesh.Submit(viewId, modelMatrix, *objectShader, state);
+
+		if (boundingBox)
+		{
+			auto box = mesh.GetSubMeshes()[0]->GetBoundingBox();
+			boundingBox->SetPose(box.center() + transform.position, box.size() * transform.scale);
+			boundingBox->Draw(viewId, *debugShader);
+		}
 	});
 
-	_registry.view<const AnimatedStatic, const Transform>().each([viewId, state, objectShader](const AnimatedStatic& animated, const Transform& transform) {
+	_registry.view<const AnimatedStatic, const Transform>().each([viewId, state, objectShader, debugShader, boundingBox](const AnimatedStatic& animated, const Transform& transform) {
 		glm::mat4 modelMatrix = glm::mat4(1.0f);
 		modelMatrix           = glm::translate(modelMatrix, transform.position);
 		modelMatrix           = glm::rotate(modelMatrix, transform.rotation.x, glm::vec3(1.0f, 0.0f, 0.0f));
@@ -99,9 +113,16 @@ void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager
 
 		const L3DMesh& mesh = Game::instance()->GetMeshPack().GetMesh(static_cast<int>(meshId));
 		mesh.Submit(viewId, modelMatrix, *objectShader, state);
+
+		if (boundingBox)
+		{
+			auto box = mesh.GetSubMeshes()[0]->GetBoundingBox();
+			boundingBox->SetPose(box.center() + transform.position, box.size() * transform.scale);
+			boundingBox->Draw(viewId, *debugShader);
+		}
 	});
 
-	_registry.view<const MobileStatic, const Transform>().each([viewId, state, objectShader](const MobileStatic& mobile, const Transform& transform) {
+	_registry.view<const MobileStatic, const Transform>().each([viewId, state, objectShader, debugShader, boundingBox](const MobileStatic& mobile, const Transform& transform) {
 		glm::mat4 modelMatrix = glm::mat4(1.0f);
 		modelMatrix           = glm::translate(modelMatrix, transform.position);
 		modelMatrix           = glm::rotate(modelMatrix, transform.rotation.x, glm::vec3(1.0f, 0.0f, 0.0f));
@@ -111,11 +132,17 @@ void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager
 
 		auto meshId         = mobileStaticMeshLookup[mobile.type];
 		const L3DMesh& mesh = Game::instance()->GetMeshPack().GetMesh(static_cast<uint32_t>(meshId));
-
 		mesh.Submit(viewId, modelMatrix, *objectShader, state);
+
+		if (boundingBox)
+		{
+			auto box = mesh.GetSubMeshes()[1]->GetBoundingBox();
+			boundingBox->SetPose(box.center() + transform.position, box.size() * transform.scale);
+			boundingBox->Draw(viewId, *debugShader);
+		}
 	});
 
-	_registry.view<const Feature, const Transform>().each([viewId, state, objectShader](const Feature& feature, const Transform& transform) {
+	_registry.view<const Feature, const Transform>().each([viewId, state, objectShader, debugShader, boundingBox](const Feature& feature, const Transform& transform) {
 		glm::mat4 modelMatrix = glm::mat4(1.0f);
 		modelMatrix           = glm::translate(modelMatrix, transform.position);
 		modelMatrix           = glm::rotate(modelMatrix, transform.rotation.x, glm::vec3(1.0f, 0.0f, 0.0f));
@@ -126,9 +153,16 @@ void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager
 		auto meshId         = featureMeshLookup[feature.type];
 		const L3DMesh& mesh = Game::instance()->GetMeshPack().GetMesh(static_cast<uint32_t>(meshId));
 		mesh.Submit(viewId, modelMatrix, *objectShader, state);
+
+		if (boundingBox)
+		{
+			auto box = mesh.GetSubMeshes()[1]->GetBoundingBox();
+			boundingBox->SetPose(box.center() + transform.position, box.size() * transform.scale);
+			boundingBox->Draw(viewId, *debugShader);
+		}
 	});
 
-	_registry.view<const Field, const Transform>().each([viewId, state, objectShader](const Field& feature, const Transform& transform) {
+	_registry.view<const Field, const Transform>().each([viewId, state, objectShader, debugShader, boundingBox](const Field& feature, const Transform& transform) {
 		glm::mat4 modelMatrix = glm::mat4(1.0f);
 		modelMatrix           = glm::translate(modelMatrix, transform.position);
 		modelMatrix           = glm::rotate(modelMatrix, transform.rotation.x, glm::vec3(1.0f, 0.0f, 0.0f));
@@ -139,9 +173,16 @@ void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager
 		auto meshId         = MeshId::TreeWheat;
 		const L3DMesh& mesh = Game::instance()->GetMeshPack().GetMesh(static_cast<uint32_t>(meshId));
 		mesh.Submit(viewId, modelMatrix, *objectShader, state);
+
+		if (boundingBox)
+		{
+			auto box = mesh.GetSubMeshes()[0]->GetBoundingBox();
+			boundingBox->SetPose(box.center() + transform.position, box.size() * transform.scale);
+			boundingBox->Draw(viewId, *debugShader);
+		}
 	});
 
-	_registry.view<const Forest, const Transform>().each([viewId, state, objectShader](const Forest& forest, const Transform& transform) {
+	_registry.view<const Forest, const Transform>().each([viewId, state, objectShader, debugShader, boundingBox](const Forest& forest, const Transform& transform) {
 		glm::mat4 modelMatrix = glm::mat4(1.0f);
 		modelMatrix           = glm::translate(modelMatrix, transform.position);
 		modelMatrix           = glm::rotate(modelMatrix, transform.rotation.x, glm::vec3(1.0f, 0.0f, 0.0f));
@@ -152,9 +193,16 @@ void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager
 		auto meshId         = MeshId::FeatureForest;
 		const L3DMesh& mesh = Game::instance()->GetMeshPack().GetMesh(static_cast<uint32_t>(meshId));
 		mesh.Submit(viewId, modelMatrix, *objectShader, state);
+
+		if (boundingBox)
+		{
+			auto box = mesh.GetSubMeshes()[0]->GetBoundingBox();
+			boundingBox->SetPose(box.center() + transform.position, box.size() * transform.scale);
+			boundingBox->Draw(viewId, *debugShader);
+		}
 	});
 
-	_registry.view<const MobileObject, const Transform>().each([viewId, state, objectShader](const MobileObject& mobileObject, const Transform& transform) {
+	_registry.view<const MobileObject, const Transform>().each([viewId, state, objectShader, debugShader, boundingBox](const MobileObject& mobileObject, const Transform& transform) {
 		glm::mat4 modelMatrix = glm::mat4(1.0f);
 		modelMatrix           = glm::translate(modelMatrix, transform.position);
 		modelMatrix           = glm::rotate(modelMatrix, transform.rotation.x, glm::vec3(1.0f, 0.0f, 0.0f));
@@ -165,6 +213,13 @@ void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager
 		auto meshId         = mobileObjectMeshLookup[mobileObject.type];
 		const L3DMesh& mesh = Game::instance()->GetMeshPack().GetMesh(static_cast<uint32_t>(meshId));
 		mesh.Submit(viewId, modelMatrix, *objectShader, state);
+
+		if (boundingBox)
+		{
+			auto box = mesh.GetSubMeshes()[1]->GetBoundingBox();
+			boundingBox->SetPose(box.center() + transform.position, box.size() * transform.scale);
+			boundingBox->Draw(viewId, *debugShader);
+		}
 	});
 }
 } // namespace openblack::Entities

--- a/src/Entities/Registry.h
+++ b/src/Entities/Registry.h
@@ -1,3 +1,23 @@
+/* openblack - A reimplementation of Lionhead's Black & White.
+ *
+ * openblack is the legal property of its developers, whose names
+ * can be found in the AUTHORS.md file distributed with this source
+ * distribution.
+ *
+ * openblack is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * openblack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with openblack. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include <entt/entt.hpp>
 
 namespace openblack
@@ -7,6 +27,7 @@ class Camera;
 
 namespace openblack::graphics
 {
+class DebugLines;
 class ShaderManager;
 } // namespace openblack::graphics
 
@@ -28,7 +49,7 @@ class Registry
 	}
 
 	void DebugCreateEntities(float x, float y, float z);
-	void DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager) const;
+	void DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager, graphics::DebugLines* boundingBox) const;
 	void Update();
 	decltype(auto) Create() { return _registry.create(); }
 	template <typename Component, typename... Args>

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -254,6 +254,7 @@ void Game::Run()
 			/*drawEntities =*/ _config.drawEntities,
 			/*entities =*/ *_entityRegistry,
 			/*drawDebugCross =*/ _config.drawDebugCross,
+			/*drawBoundingBoxes =*/ _config.drawBoundingBoxes,
 			/*cullBack =*/ true,
 			/*bgfxDebug =*/ _config.bgfxDebug,
 			/*wireframe =*/ _config.wireframe,
@@ -279,6 +280,7 @@ void Game::Run()
 		drawDesc.viewId = 0;
 		drawDesc.drawWater = false;
 		drawDesc.drawDebugCross = false;
+		drawDesc.drawBoundingBoxes = false;
 		drawDesc.cullBack = true;
 		_renderer->DrawScene(drawDesc);
 		_profiler->End(Profiler::Stage::ReflectionPass);
@@ -298,6 +300,7 @@ void Game::Run()
 		drawDesc.viewId = 1;
 		drawDesc.drawWater = _config.drawWater;
 		drawDesc.drawDebugCross = _config.drawDebugCross;
+		drawDesc.drawBoundingBoxes = _config.drawBoundingBoxes;
 		drawDesc.cullBack = false;
 		_renderer->DrawScene(drawDesc);
 		_profiler->End(Profiler::Stage::MainPass);

--- a/src/Game.h
+++ b/src/Game.h
@@ -64,6 +64,7 @@ class Game
 			, drawIsland(true)
 			, drawEntities(true)
 			, drawDebugCross(true)
+			, drawBoundingBoxes(false)
 			, timeOfDay(1.0f)
 			, bumpMapStrength(1.0f)
 			, smallBumpMapStrength(1.0f)
@@ -80,6 +81,7 @@ class Game
 		bool drawIsland;
 		bool drawEntities;
 		bool drawDebugCross;
+		bool drawBoundingBoxes;
 
 		float timeOfDay;
 		float bumpMapStrength;

--- a/src/Graphics/DebugLines.cpp
+++ b/src/Graphics/DebugLines.cpp
@@ -109,9 +109,9 @@ std::unique_ptr<DebugLines> DebugLines::CreateLine(const glm::vec4& from, const 
 	return CreateDebugLines(line.size() * sizeof(line[0]), line.data(), line.size());
 }
 
-void DebugLines::SetPose(const glm::vec3 &center, float size)
+void DebugLines::SetPose(const glm::vec3 &center, const glm::vec3& size)
 {
-	_model = glm::translate(center) * glm::scale(glm::vec3(size, size, size));
+	_model = glm::translate(center) * glm::scale(size);
 }
 
 void DebugLines::Draw(uint8_t viewId, ShaderProgram &program) const

--- a/src/Graphics/DebugLines.h
+++ b/src/Graphics/DebugLines.h
@@ -35,14 +35,14 @@ class DebugLines
 {
   public:
 	static std::unique_ptr<DebugLines> CreateCross();
-	std::unique_ptr<DebugLines> CreateBox(const glm::vec4 &color);
+	static std::unique_ptr<DebugLines> CreateBox(const glm::vec4 &color);
 	static std::unique_ptr<DebugLines> CreateLine(const glm::vec4& from, const glm::vec4& to, const glm::vec4& color);
 
 	virtual ~DebugLines();
 
 	void Draw(uint8_t viewId, ShaderProgram &program) const;
 
-	void SetPose(const glm::vec3 &center, float size);
+	void SetPose(const glm::vec3& center, const glm::vec3& size);
 
   protected:
 	static std::unique_ptr<DebugLines> CreateDebugLines(uint32_t size, const void* data, uint32_t vertexCount);

--- a/src/Gui.cpp
+++ b/src/Gui.cpp
@@ -469,6 +469,7 @@ void Gui::Loop(Game& game)
 		{
 			ImGui::Checkbox("Wireframe", &config.wireframe);
 			ImGui::Checkbox("Water Debug", &config.waterDebug);
+			ImGui::Checkbox("Bounding Boxes", &config.drawBoundingBoxes);
 			ImGui::Checkbox("Profiler", &config.showProfiler);
 			ImGui::EndMenu();
 		}

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -206,7 +206,7 @@ graphics::ShaderManager& Renderer::GetShaderManager() const
 
 void Renderer::UpdateDebugCrossPose(std::chrono::microseconds dt, const glm::vec3 &position, float scale)
 {
-	_debugCross->SetPose(position, scale);
+	_debugCross->SetPose(position, glm::vec3(scale, scale, scale));
 }
 
 void Renderer::UploadUniforms(std::chrono::microseconds dt, uint8_t viewId, const Game &game, const Camera &camera)

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -20,8 +20,6 @@
 
 #include "Renderer.h"
 
-#include <sstream>
-
 #include <bgfx/platform.h>
 #include <SDL_video.h>
 #include <spdlog/spdlog.h>
@@ -179,12 +177,14 @@ Renderer::Renderer(const GameWindow &window, bool vsync)
 
 	// allocate vertex buffers for our debug draw
 	_debugCross = DebugLines::CreateCross();
+	_boundingBox = DebugLines::CreateBox(glm::vec4(1.0f, 0.0f, 0.0f, 0.5f));
 }
 
 Renderer::~Renderer()
 {
 	_shaderManager.reset();
 	_debugCross.reset();
+	_boundingBox.reset();
 	bgfx::shutdown();
 }
 
@@ -268,7 +268,7 @@ void Renderer::DrawScene(const DrawSceneDesc &desc)
 	desc.profiler.Begin(desc.viewId == 0 ? Profiler::Stage::ReflectionDrawModels : Profiler::Stage::MainPassDrawModels);
 	if (desc.drawEntities)
 	{
-		desc.entities.DrawModels(desc.viewId, *_shaderManager);
+		desc.entities.DrawModels(desc.viewId, *_shaderManager, desc.drawBoundingBoxes ? _boundingBox.get() : nullptr);
 	}
 	desc.profiler.End(desc.viewId == 0 ? Profiler::Stage::ReflectionDrawModels : Profiler::Stage::MainPassDrawModels);
 

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -89,6 +89,7 @@ class Renderer {
 		bool drawEntities;
 		const Entities::Registry& entities;
 		bool drawDebugCross;
+		bool drawBoundingBoxes;
 		bool cullBack;
 		bool bgfxDebug;
 		bool wireframe;
@@ -115,5 +116,6 @@ class Renderer {
 	std::unique_ptr<BgfxCallback> _bgfxCallback;
 
 	std::unique_ptr<graphics::DebugLines> _debugCross;
+	std::unique_ptr<graphics::DebugLines> _boundingBox;
 };
 } // namespace openblack


### PR DESCRIPTION
Add bounding boxes to `L3DSubMesh` which can be useful for future culling, picking and physics.

Note that these are axis-aligned and even in the debug view, I don't bother rotating them yet.
They aren't added to the Island blocks either but this can be done at a later time. This would be useful for physics and accelerating ray intersection.

![Screenshot from 2019-10-26 12-18-41](https://user-images.githubusercontent.com/1013356/67618098-bf92fd00-f7ea-11e9-9027-0677fa43ebac.png)
