### PR TITLE
Entities Instance Draw

### DIFF
--- a/assets/shaders/varying.def.sc
+++ b/assets/shaders/varying.def.sc
@@ -7,6 +7,10 @@ vec3 a_color1       : COLOR1;  // firstMaterialID
 vec3 a_color2      : COLOR2;  // secondMaterialID
 vec3 a_indices     : COLOR4;  // material blend coefficient
 float a_color3      : COLOR3;  // water alpha
+vec4 i_data0     : TEXCOORD7;
+vec4 i_data1     : TEXCOORD6;
+vec4 i_data2     : TEXCOORD5;
+vec4 i_data3     : TEXCOORD4;
 
 vec4 v_position    : TEXCOORD1    = vec4(0.0, 0.0, 0.0, 0.0);
 vec4 v_color0    : COLOR0    = vec4(1.0, 0.0, 0.0, 1.0);

--- a/assets/shaders/vs_line_instanced.sc
+++ b/assets/shaders/vs_line_instanced.sc
@@ -1,0 +1,16 @@
+$input a_position, a_color0, i_data0, i_data1, i_data2, i_data3, i_data4
+$output v_color0
+
+#include <bgfx_shader.sh>
+
+void main()
+{
+	mat4 model;
+	model[0] = i_data0;
+	model[1] = i_data1;
+	model[2] = i_data2;
+	model[3] = i_data3;
+
+	gl_Position = mul(u_viewProj, instMul(model, a_position));
+	v_color0 = a_color0;
+}

--- a/assets/shaders/vs_object_instanced.sc
+++ b/assets/shaders/vs_object_instanced.sc
@@ -1,0 +1,19 @@
+$input a_position, a_texcoord0, a_normal, i_data0, i_data1, i_data2, i_data3, i_data4
+$output v_position, v_texcoord0, v_normal
+
+#include <bgfx_shader.sh>
+
+void main()
+{
+	mat4 model;
+	model[0] = i_data0;
+	model[1] = i_data1;
+	model[2] = i_data2;
+	model[3] = i_data3;
+
+	v_position = instMul(model, vec4(a_position.xyz, 1.0f));
+	v_texcoord0 = vec4(a_texcoord0, 0.0f, 0.0f);
+	v_normal = a_normal;
+	gl_Position = mul(u_viewProj, v_position);
+
+}

--- a/src/3D/L3DMesh.cpp
+++ b/src/3D/L3DMesh.cpp
@@ -240,12 +240,21 @@ void L3DMesh::Draw(uint8_t viewId, const glm::mat4& modelMatrix, const ShaderPro
 	_subMeshes[mesh]->Submit(viewId, modelMatrix, program, state, rgba, false);
 }
 
-
 void L3DMesh::Submit(uint8_t viewId, const glm::mat4& modelMatrix, const ShaderProgram& program, uint64_t state, uint32_t rgba) const
 {
 	for (auto it = _subMeshes.begin(); it != _subMeshes.end(); ++it)
 	{
 		const L3DSubMesh& submesh = *it->get();
 		submesh.Submit(viewId, modelMatrix, program, state, rgba, std::next(it) != _subMeshes.end());
+	}
+}
+
+void L3DMesh::Submit(uint8_t viewId, const bgfx::DynamicVertexBufferHandle& instanceBuffer, uint32_t instanceStart, uint32_t instanceCount,
+                     const ShaderProgram& program, uint64_t state, uint32_t rgba) const
+{
+	for (auto it = _subMeshes.begin(); it != _subMeshes.end(); ++it)
+	{
+		const L3DSubMesh& submesh = *it->get();
+		submesh.Submit(viewId, instanceBuffer, instanceStart, instanceCount, program, state, rgba, std::next(it) != _subMeshes.end());
 	}
 }

--- a/src/3D/L3DMesh.h
+++ b/src/3D/L3DMesh.h
@@ -86,6 +86,8 @@ class L3DMesh
 	void Load(IStream& stream);
 	void Draw(uint8_t viewId, const glm::mat4& modelMatrix, const ShaderProgram& program, uint32_t mesh, uint64_t state, uint32_t rgba = 0) const;
 	void Submit(uint8_t viewId, const glm::mat4& modelMatrix, const ShaderProgram& program, uint64_t state, uint32_t rgba = 0) const;
+	void Submit(uint8_t viewId, const bgfx::DynamicVertexBufferHandle& instanceBuffer, uint32_t instanceStart, uint32_t instanceCount,
+	            const ShaderProgram& program, uint64_t state, uint32_t rgba = 0) const;
 
 	[[nodiscard]] uint8_t GetNumSubMeshes() const { return _subMeshes.size(); }
 	const std::vector<std::unique_ptr<L3DSubMesh>>& GetSubMeshes() const { return _subMeshes; }

--- a/src/3D/L3DSubMesh.h
+++ b/src/3D/L3DSubMesh.h
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include <glm/fwd.hpp>
+#include <bgfx/bgfx.h>
 
 #include "AxisAlignedBoundingBox.h"
 
@@ -60,6 +61,8 @@ class L3DSubMesh
 
 	void Load(IStream& stream);
 	void Submit(uint8_t viewId, const glm::mat4& modelMatrix, const graphics::ShaderProgram& program, uint64_t state, uint32_t rgba = 0, bool preserveState = false) const;
+	void Submit(uint8_t viewId, const bgfx::DynamicVertexBufferHandle& instanceBuffer, uint32_t instanceStart, uint32_t instanceCount,
+                const graphics::ShaderProgram& program, uint64_t state, uint32_t rgba = 0, bool preserveState = false) const;
 
 	[[ nodiscard ]] uint8_t GetLOD() const { return static_cast<uint8_t>(_flags & 0x7u); } // 29-32 (3)
 	[[ nodiscard ]] uint8_t GetStatus() const { return static_cast<uint8_t>((_flags >> 3u) & 0x3Fu); } // 22-28 (6)
@@ -70,6 +73,10 @@ class L3DSubMesh
 	[[ nodiscard ]] AxisAlignedBoundingBox GetBoundingBox() const { return _boundingBox; }
 
   private:
+	void Submit_(uint8_t viewId, const glm::mat4* modelMatrix,
+	             const bgfx::DynamicVertexBufferHandle* instanceBuffer, uint32_t instanceStart, uint32_t instanceCount,
+	             const graphics::ShaderProgram& program, uint64_t state, uint32_t rgba = 0, bool preserveState = false) const;
+
 	L3DMesh& _l3dMesh;
 
 	uint32_t _flags;

--- a/src/Entities/Components/Transform.h
+++ b/src/Entities/Components/Transform.h
@@ -30,6 +30,17 @@ struct Transform
 	glm::vec3 position;
 	glm::vec3 rotation;
 	glm::vec3 scale;
+
+	explicit operator glm::mat4() const
+	{
+		glm::mat4 modelMatrix = glm::mat4(1.0f);
+		modelMatrix           = glm::translate(modelMatrix, position);
+		modelMatrix           = glm::rotate(modelMatrix, rotation.x, glm::vec3(1.0f, 0.0f, 0.0f));
+		modelMatrix           = glm::rotate(modelMatrix, rotation.y, glm::vec3(0.0f, 1.0f, 0.0f));
+		modelMatrix           = glm::rotate(modelMatrix, rotation.z, glm::vec3(0.0f, 0.0f, 1.0f));
+		modelMatrix           = glm::scale(modelMatrix, scale);
+		return modelMatrix;
+	}
 };
 
 }

--- a/src/Entities/Registry.cpp
+++ b/src/Entities/Registry.cpp
@@ -19,6 +19,8 @@ namespace openblack::Entities
 
 Registry::Registry()
 	: _instanceUniformBuffer(BGFX_INVALID_HANDLE)
+	, _dirty(true)
+	, _hasBoundingBoxes(false)
 {
 	_registry.set<RegistryContext>();
 }
@@ -269,8 +271,14 @@ void Registry::PrepareDrawUploadUniforms(bool drawBoundingBox)
 
 void Registry::PrepareDraw(bool drawBoundingBox)
 {
-	PrepareDrawDescs(drawBoundingBox);
-	PrepareDrawUploadUniforms(drawBoundingBox);
+	if (_dirty || _hasBoundingBoxes != drawBoundingBox)
+	{
+		PrepareDrawDescs(drawBoundingBox);
+		PrepareDrawUploadUniforms(drawBoundingBox);
+
+		_dirty = false;
+		_hasBoundingBoxes = drawBoundingBox;
+	}
 }
 
 void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager, graphics::DebugLines* boundingBox) const

--- a/src/Entities/Registry.cpp
+++ b/src/Entities/Registry.cpp
@@ -20,8 +20,10 @@ namespace openblack::Entities
 
 void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager, graphics::DebugLines* boundingBox) const
 {
-	graphics::ShaderProgram* debugShader            = shaderManager.GetShader("DebugLine");
+	graphics::ShaderProgram* debugShader = shaderManager.GetShader("DebugLine");
+	graphics::ShaderProgram* debugShaderInstanced = shaderManager.GetShader("DebugLineInstanced");
 	graphics::ShaderProgram* objectShader = shaderManager.GetShader("Object");
+	graphics::ShaderProgram* objectShaderInstanced = shaderManager.GetShader("ObjectInstanced");
 
 	uint64_t state = 0u
 		| BGFX_STATE_WRITE_MASK

--- a/src/Entities/Registry.cpp
+++ b/src/Entities/Registry.cpp
@@ -277,7 +277,6 @@ void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager
 {
 	graphics::ShaderProgram* debugShader = shaderManager.GetShader("DebugLine");
 	graphics::ShaderProgram* debugShaderInstanced = shaderManager.GetShader("DebugLineInstanced");
-	graphics::ShaderProgram* objectShader = shaderManager.GetShader("Object");
 	graphics::ShaderProgram* objectShaderInstanced = shaderManager.GetShader("ObjectInstanced");
 
 	uint64_t state = 0u

--- a/src/Entities/Registry.cpp
+++ b/src/Entities/Registry.cpp
@@ -35,6 +35,14 @@ void Registry::PrepareDrawDescs(bool drawBoundingBox)
 	uint32_t instanceCount = 0;
 	std::map<MeshId, uint32_t> meshIds;
 
+	// Features
+	_registry.view<const Feature, const Transform>().each([&meshIds, &instanceCount](const Feature& entity, const Transform& transform) {
+		const auto meshId = featureMeshLookup[entity.type];
+		auto count = meshIds.insert(std::make_pair(meshId, 0));
+		count.first->second++;
+		instanceCount++;
+	});
+
 	// Fields
 	_registry.view<const Field, const Transform>().each([&meshIds, &instanceCount](const Field& entity, const Transform& transform) {
 		const auto meshId = MeshId::TreeWheat;
@@ -114,6 +122,16 @@ void Registry::PrepareDrawUploadUniforms(bool drawBoundingBox)
 	};
 	// Store offsets of uniforms for descs
 	std::map<MeshId, uint32_t> uniformOffsets;
+
+	// Features
+	_registry.view<const Feature, const Transform>().each([this, &uniformOffsets, prepareDrawBoundingBox](const Feature& entity, const Transform& transform) {
+		const auto meshId = featureMeshLookup[entity.type];
+		auto offset = uniformOffsets.insert(std::make_pair(meshId, 0));
+		auto desc = _instancedDrawDescs.find(meshId);
+		_instanceUniforms[desc->second.offset + offset.first->second] = static_cast<glm::mat4>(transform);
+		prepareDrawBoundingBox(desc->second.offset + offset.first->second, transform, meshId, 1);
+		offset.first->second++;
+	});
 
 	// Fields
 	_registry.view<const Field, const Transform>().each([this, &uniformOffsets, prepareDrawBoundingBox](const Field& entity, const Transform& transform) {
@@ -246,21 +264,6 @@ void Registry::DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager
 		auto modelMatrix = static_cast<const glm::mat4>(transform);
 
 		auto meshId = mobileStaticMeshLookup[entity.type];
-		const L3DMesh& mesh = Game::instance()->GetMeshPack().GetMesh(static_cast<uint32_t>(meshId));
-		mesh.Submit(viewId, modelMatrix, *objectShader, state);
-
-		if (boundingBox)
-		{
-			auto box = mesh.GetSubMeshes()[1]->GetBoundingBox();
-			boundingBox->SetPose(box.center() + transform.position, box.size() * transform.scale);
-			boundingBox->Draw(viewId, *debugShader);
-		}
-	});
-
-	_registry.view<const Feature, const Transform>().each([viewId, state, objectShader, debugShader, boundingBox](const Feature& entity, const Transform& transform) {
-		auto modelMatrix = static_cast<const glm::mat4>(transform);
-
-		auto meshId = featureMeshLookup[entity.type];
 		const L3DMesh& mesh = Game::instance()->GetMeshPack().GetMesh(static_cast<uint32_t>(meshId));
 		mesh.Submit(viewId, modelMatrix, *objectShader, state);
 

--- a/src/Entities/Registry.h
+++ b/src/Entities/Registry.h
@@ -62,6 +62,7 @@ class Registry
 		_registry.reset();
 		_registry.unset<RegistryContext>();
 		_registry.set<RegistryContext>();
+		_dirty = true;
 	};
 	template <typename Component>
 	size_t Size() { return _registry.size<Component>(); }
@@ -98,6 +99,9 @@ class Registry
 	/// The values stored are a list of uniforms (model matrix) needed for both
 	/// the instances of entities and their bounding boxes.
 	bgfx::DynamicVertexBufferHandle _instanceUniformBuffer;
+
+	bool _dirty;
+	bool _hasBoundingBoxes;
 };
 
 } // namespace openblack::Entities

--- a/src/Entities/Registry.h
+++ b/src/Entities/Registry.h
@@ -43,14 +43,10 @@ class RegistryContext
 class Registry
 {
   public:
-	Registry()
-	{
-		_registry.set<RegistryContext>();
-	}
+	Registry();
+	virtual ~Registry();
 
-	void DebugCreateEntities(float x, float y, float z);
 	void DrawModels(uint8_t viewId, graphics::ShaderManager &shaderManager, graphics::DebugLines* boundingBox) const;
-	void Update();
 	decltype(auto) Create() { return _registry.create(); }
 	template <typename Component, typename... Args>
 	decltype(auto) Assign(entt::entity entity, [[maybe_unused]] Args&&... args) { return _registry.assign<Component>(entity, std::forward<Args>(args)...); }

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -110,6 +110,7 @@ Game::~Game()
 	_testModel.reset();
 	_meshPack.reset();
 	_landIsland.reset();
+	_entityRegistry.reset();
 	_gui.reset();
 	_renderer.reset();
 	_window.reset();

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -237,6 +237,14 @@ void Game::Run()
 		_modelRotation.y = fmod(_modelRotation.y + float(deltaTime.count()) * .0001f, 360.f);
 
 		_renderer->UpdateDebugCrossPose(deltaTime, _intersection, 50.0f);
+
+		_profiler->Begin(Profiler::Stage::UpdateEntities);
+		if (_config.drawEntities)
+		{
+			_entityRegistry->PrepareDraw(_config.drawBoundingBoxes);
+		}
+		_profiler->End(Profiler::Stage::UpdateEntities);
+
 		_profiler->End(Profiler::Stage::UpdatePositions);
 
 		_profiler->Begin(Profiler::Stage::GuiLoop);

--- a/src/Graphics/DebugLines.cpp
+++ b/src/Graphics/DebugLines.cpp
@@ -125,6 +125,16 @@ void DebugLines::Draw(uint8_t viewId, ShaderProgram &program) const
 	_mesh->Draw(viewId, program, state, 0);
 }
 
+void DebugLines::Draw(uint8_t viewId, const bgfx::DynamicVertexBufferHandle& instanceBuffer, uint32_t instanceStart, uint32_t instanceCount, ShaderProgram &program) const
+{
+	uint64_t state = 0u
+		| BGFX_STATE_DEFAULT
+		| BGFX_STATE_PT_LINES
+	;
+	// Don't set transform since it's in instanceBuffer
+	_mesh->Draw(viewId, program, instanceBuffer, instanceStart, instanceCount, state, 0);
+}
+
 DebugLines::DebugLines(std::unique_ptr<Mesh> &&mesh)
 	: _mesh(std::move(mesh))
 	, _model()

--- a/src/Graphics/DebugLines.h
+++ b/src/Graphics/DebugLines.h
@@ -41,6 +41,7 @@ class DebugLines
 	virtual ~DebugLines();
 
 	void Draw(uint8_t viewId, ShaderProgram &program) const;
+	void Draw(uint8_t viewId, const bgfx::DynamicVertexBufferHandle& instanceBuffer, uint32_t instanceStart, uint32_t instanceCount, ShaderProgram &program) const;
 
 	void SetPose(const glm::vec3& center, const glm::vec3& size);
 

--- a/src/Graphics/Mesh.cpp
+++ b/src/Graphics/Mesh.cpp
@@ -60,6 +60,12 @@ void Mesh::Draw(uint8_t viewId, const openblack::graphics::ShaderProgram &progra
 	}
 }
 
+void Mesh::Draw(uint8_t viewId, const openblack::graphics::ShaderProgram& program, const bgfx::DynamicVertexBufferHandle& instanceBuffer, uint32_t instanceStart, uint32_t instanceCount, uint64_t state, uint32_t rgba) const
+{
+	bgfx::setInstanceDataBuffer(instanceBuffer, instanceStart, instanceCount);
+	Draw(viewId, program, state, rgba);
+}
+
 void Mesh::Draw(uint8_t viewId, const openblack::graphics::ShaderProgram &program, uint32_t count, uint32_t startIndex, uint64_t state, uint32_t rgba) const
 {
 	if (_indexBuffer != nullptr && _indexBuffer->GetCount() > 0)

--- a/src/Graphics/Mesh.h
+++ b/src/Graphics/Mesh.h
@@ -53,6 +53,7 @@ class Mesh
 	[[nodiscard]] Topology GetTopology() const noexcept;
 
 	void Draw(uint8_t viewId, const openblack::graphics::ShaderProgram &program, uint64_t state, uint32_t rgba = 0) const;
+	void Draw(uint8_t viewId, const openblack::graphics::ShaderProgram &program, const bgfx::DynamicVertexBufferHandle& instanceBuffer, uint32_t instanceStart, uint32_t instanceCount, uint64_t state, uint32_t rgba = 0) const;
 	void Draw(uint8_t viewId, const openblack::graphics::ShaderProgram &program, uint32_t count, uint32_t startIndex, uint64_t state, uint32_t rgba = 0) const;
 
   protected:

--- a/src/Graphics/ShaderManager.cpp
+++ b/src/Graphics/ShaderManager.cpp
@@ -25,8 +25,10 @@
 #include <3D/Camera.h>
 
 #include "Shaders/vs_line.bin.h"
+#include "Shaders/vs_line_instanced.bin.h"
 #include "Shaders/fs_line.bin.h"
 #include "Shaders/vs_object.bin.h"
+#include "Shaders/vs_object_instanced.bin.h"
 #include "Shaders/fs_object.bin.h"
 #include "Shaders/vs_terrain.bin.h"
 #include "Shaders/fs_terrain.bin.h"
@@ -39,9 +41,11 @@ namespace openblack::graphics
 const bgfx::EmbeddedShader s_embeddedShaders[] =
 	{
 		BGFX_EMBEDDED_SHADER(vs_line),
+		BGFX_EMBEDDED_SHADER(vs_line_instanced),
 		BGFX_EMBEDDED_SHADER(fs_line),
 
 		BGFX_EMBEDDED_SHADER(vs_object),
+		BGFX_EMBEDDED_SHADER(vs_object_instanced),
 		BGFX_EMBEDDED_SHADER(fs_object),
 
 		BGFX_EMBEDDED_SHADER(vs_terrain),

--- a/src/Graphics/Shaders/vs_line_instanced.bin.h
+++ b/src/Graphics/Shaders/vs_line_instanced.bin.h
@@ -1,0 +1,12 @@
+#pragma once
+
+// Generated compiled shaders using shaderc with the bin2c option
+#include <generated/shaders/vs_line_instanced.sc.glsl.bin.h>
+#include <generated/shaders/vs_line_instanced.sc.spv.bin.h>
+#if defined(_WIN32)
+#include <generated/shaders/vs_line_instanced.sc.dx9.bin.h>
+#include <generated/shaders/vs_line_instanced.sc.dx11.bin.h>
+#endif  //  defined(_WIN32)
+#if __APPLE__
+#include <generated/shaders/vs_line_instanced.sc.mtl.bin.h>
+#endif // __APPLE__

--- a/src/Graphics/Shaders/vs_object_instanced.bin.h
+++ b/src/Graphics/Shaders/vs_object_instanced.bin.h
@@ -1,0 +1,12 @@
+#pragma once
+
+// Generated compiled shaders using shaderc with the bin2c option
+#include <generated/shaders/vs_object_instanced.sc.glsl.bin.h>
+#include <generated/shaders/vs_object_instanced.sc.spv.bin.h>
+#if defined(_WIN32)
+#include <generated/shaders/vs_object_instanced.sc.dx9.bin.h>
+#include <generated/shaders/vs_object_instanced.sc.dx11.bin.h>
+#endif  //  defined(_WIN32)
+#if __APPLE__
+#include <generated/shaders/vs_object_instanced.sc.mtl.bin.h>
+#endif // __APPLE__

--- a/src/Profiler.h
+++ b/src/Profiler.h
@@ -38,6 +38,7 @@ public:
 	{
 		SdlInput,
 		UpdatePositions,
+		UpdateEntities,
 		GuiLoop,
 		ReflectionPass,
 		ReflectionUploadUniforms,
@@ -72,6 +73,7 @@ public:
 	static constexpr std::array<std::string_view, static_cast<uint8_t>(Stage::_count)> stageNames = {
 		"SDL Input",
 		"Update Positions",
+		"Entities",
 		"GUI Loop",
 		"Reflection Pass",
 		"Upload Uniforms",

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -61,8 +61,10 @@ struct ShaderDefinition {
 
 constexpr std::array Shaders {
 	ShaderDefinition{"DebugLine", "vs_line", "fs_line"},
+	ShaderDefinition{"DebugLineInstanced", "vs_line_instanced", "fs_line"},
 	ShaderDefinition{"Terrain", "vs_terrain", "fs_terrain"},
 	ShaderDefinition{"Object", "vs_object", "fs_object"},
+	ShaderDefinition{"ObjectInstanced", "vs_object_instanced", "fs_object"},
 	ShaderDefinition{"Water", "vs_water", "fs_water"},
 };
 


### PR DESCRIPTION
Major re-write and optimization of registry draw models code.

An option to draw instanced was added to Debug Lines and `L3DMesh`/`L3DSubMesh`.
The traversal of entities is now done in `PrepareDraw` and it does this to count the number of different meshes ids.

Once that's done, a single buffer in allocated (and reallocated only if more meshes need to be drawn that the buffer has room for).

A second traversal populates this buffer with uniforms for all the entities grouped by mesh ids. This means that this buffer will have all the transforms of one type of tree mesh followed by all the transforms of another mesh etc.

The call to `PrepareDraw` is only done when necessary. This means if nothing changes in the scene (for the entities), then no update is done. This is implemented with a `dirty` boolean but can be expanded to a map of booleans per mesh id. Even if `PrepareDraw` is called every frame, the performance is much better than upstream.

Additionally, since all this traversal is done once before actual drawing, it is done once. Prior to this PR the traversal and uniform upload were done once per pass. That's twice per frame. Now it is only once per frame where things have moved.

The intermediate results from `PrepareDraw` are stored. This is mainly offsets in the uniform buffer for each mesh id. This lets DrawModels to loop through mesh ids instead of every entity and dispatch instance draws. This reduces the amount of encode to bgfx and dispatches from bgfx from a few thousand to less than one hundred.

The bounding boxes are also optimized. Since there are as many bounding boxes as entities, the second half of the dynamic buffer is reserved for the bounding boxes matrices. They can't be the same as the entities because the bound boxes are all instanced of the same mesh with scaling applied to them. Doing this means instead of a draw call of the box per entity or even per mesh id, there is only one instance draw call encoded.

Lastly, instanced drawing requires a slightly modified vertex shader, so two new programs were added `DebugLineInstanced` and `ObjectInstanced`. They re-use the fragment shaders and use an instanced version of the vertex shader.

With all that said, here's the screencap of the new performance at 3.4ms:
![Instanced drawing](https://user-images.githubusercontent.com/1013356/67618535-0a177800-f7f1-11e9-8e4a-0d5c8d71b3d3.png)

Compare that with the same scene on master at 11ms:
![Screenshot from 2019-10-26 18-09-02](https://user-images.githubusercontent.com/1013356/67622590-d9990380-f81b-11e9-9ee6-7d58e4de429e.png)

