### PR TITLE
sky: inverse culling on reflection

### DIFF
--- a/src/3D/Sky.cpp
+++ b/src/3D/Sky.cpp
@@ -123,7 +123,7 @@ void Sky::CalculateTextures()
 	_texture->Create(256, 256, 1, Format::RGB5A1, Wrapping::ClampEdge, bitmap.data(), bitmap.size() * sizeof(bitmap[0]));
 }
 
-void Sky::Draw(uint8_t viewId, const glm::mat4& modelMatrix, const graphics::ShaderProgram &program) const
+void Sky::Draw(uint8_t viewId, const glm::mat4& modelMatrix, const graphics::ShaderProgram &program, bool cullBack) const
 {
 	program.SetTextureSampler("s_diffuse", 0, *_texture);
 
@@ -132,7 +132,7 @@ void Sky::Draw(uint8_t viewId, const glm::mat4& modelMatrix, const graphics::Sha
 		| BGFX_STATE_WRITE_A
 		| BGFX_STATE_WRITE_Z
 		| BGFX_STATE_DEPTH_TEST_LESS
-		| BGFX_STATE_CULL_CCW
+		| (cullBack ? BGFX_STATE_CULL_CW : BGFX_STATE_CULL_CCW)
 		| BGFX_STATE_MSAA
 	;
 	_model->Draw(viewId, modelMatrix, program, 0, state);

--- a/src/3D/Sky.h
+++ b/src/3D/Sky.h
@@ -45,7 +45,7 @@ class Sky
 	void Interpolate555Texture(uint16_t* bitmap, uint16_t*, uint16_t*, float);
 
 	void CalculateTextures();
-	void Draw(uint8_t viewId, const glm::mat4& modelMatrix, const graphics::ShaderProgram &program) const;
+	void Draw(uint8_t viewId, const glm::mat4& modelMatrix, const graphics::ShaderProgram &program, bool cullBack) const;
 	void SetTime(float time);
 	void Update();
 

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -247,7 +247,7 @@ void Renderer::DrawScene(const DrawSceneDesc &desc)
 	desc.profiler.Begin(desc.viewId == 0 ? Profiler::Stage::ReflectionDrawSky : Profiler::Stage::MainPassDrawSky);
 	if (desc.drawSky)
 	{
-		desc.sky.Draw(desc.viewId, glm::mat4(1.0f), *objectShader);
+		desc.sky.Draw(desc.viewId, glm::mat4(1.0f), *objectShader, desc.cullBack);
 	}
 	desc.profiler.End(desc.viewId == 0 ? Profiler::Stage::ReflectionDrawSky : Profiler::Stage::MainPassDrawSky);
 


### PR DESCRIPTION
The sky was not rendered in the water reflection because due to the inverted camera, the winding order is reversed.
This fixes it by letting sky know which winding order to use.
![Screenshot from 2019-10-26 18-21-48](https://user-images.githubusercontent.com/1013356/67622750-87f17880-f81d-11e9-8fa8-d6e6f727f6f5.png)
