### PR TITLE
streams: Build Streams as a single mesh

### DIFF
--- a/src/Entities/Registry.h
+++ b/src/Entities/Registry.h
@@ -53,8 +53,8 @@ class Registry
 	Registry();
 	virtual ~Registry();
 
-	void PrepareDraw(bool drawBoundingBox);
-	void DrawModels(graphics::RenderPass viewId, const graphics::ShaderManager& shaderManager, const graphics::DebugLines* boundingBox) const;
+	void PrepareDraw(bool drawBoundingBox, bool drawStreams);
+	void DrawModels(graphics::RenderPass viewId, const graphics::ShaderManager& shaderManager) const;
 	decltype(auto) Create() { return _registry.create(); }
 	template <typename Component, typename... Args>
 	decltype(auto) Assign(entt::entity entity, [[maybe_unused]] Args&&... args) { return _registry.assign<Component>(entity, std::forward<Args>(args)...); }
@@ -83,6 +83,9 @@ class Registry
 		uint32_t offset;
 		uint32_t count;
 	};
+
+	std::unique_ptr<graphics::DebugLines> _streams;
+	std::unique_ptr<graphics::DebugLines> _boundingBox;
 
 	/// A list of cpu-side uniforms which is refilled at every \ref PrepareDraw.
 	/// This vector will resize to the number of instances it manages

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -249,7 +249,7 @@ bool Game::Update()
 			auto updateEntities = _profiler->BeginScoped(Profiler::Stage::UpdateEntities);
 			if (_config.drawEntities)
 			{
-				_entityRegistry->PrepareDraw(_config.drawBoundingBoxes);
+				_entityRegistry->PrepareDraw(_config.drawBoundingBoxes, _config.drawStreams);
 			}
 		}
 	}  // Update Uniforms

--- a/src/Game.h
+++ b/src/Game.h
@@ -82,6 +82,7 @@ class Game
 		bool drawEntities;
 		bool drawDebugCross;
 		bool drawBoundingBoxes;
+		bool drawStreams;
 
 		float timeOfDay;
 		float bumpMapStrength;

--- a/src/Graphics/DebugLines.cpp
+++ b/src/Graphics/DebugLines.cpp
@@ -29,16 +29,7 @@
 
 using namespace openblack::graphics;
 
-namespace
-{
-struct Vertex
-{
-  glm::vec4 pos;
-  glm::vec4 col;
-};
-}
-
-std::unique_ptr<DebugLines> DebugLines::CreateDebugLines(uint32_t size, const void* data, uint32_t vertexCount)
+std::unique_ptr<DebugLines> DebugLines::CreateDebugLines(const Vertex* data, uint32_t vertexCount)
 {
 	VertexDecl decl;
 	decl.reserve(2);
@@ -62,7 +53,7 @@ std::unique_ptr<DebugLines> DebugLines::CreateCross()
 		Vertex {glm::vec4(0.0f, 0.0f, -0.5f, 1.0f), glm::vec4(0.0f, 0.0f, 1.0f, 1.0f)},
 	};
 
-	return CreateDebugLines(cross.size() * sizeof(cross[0]), cross.data(), cross.size());
+	return CreateDebugLines(cross.data(), cross.size());
 }
 
 std::unique_ptr<DebugLines> DebugLines::CreateBox(const glm::vec4 &color)
@@ -96,7 +87,7 @@ std::unique_ptr<DebugLines> DebugLines::CreateBox(const glm::vec4 &color)
 		Vertex{glm::vec4(0.5f, -0.5f, 0.5f, 1.0f), color},
 	};
 
-	return CreateDebugLines(box.size() * sizeof(box[0]), box.data(), box.size());
+	return CreateDebugLines(box.data(), box.size());
 }
 
 std::unique_ptr<DebugLines> DebugLines::CreateLine(const glm::vec4& from, const glm::vec4 &to, const glm::vec4 &color)
@@ -106,7 +97,7 @@ std::unique_ptr<DebugLines> DebugLines::CreateLine(const glm::vec4& from, const 
 		Vertex{to, color},
 	};
 
-	return CreateDebugLines(line.size() * sizeof(line[0]), line.data(), line.size());
+	return CreateDebugLines(line.data(), line.size());
 }
 
 void DebugLines::SetPose(const glm::vec3 &center, const glm::vec3& size)
@@ -121,8 +112,8 @@ void DebugLines::Draw(RenderPass viewId, const ShaderProgram &program) const
 	Mesh::DrawDesc desc = {
 		/*viewId =*/ viewId,
 		/*program =*/ program,
-		/*offset =*/ _mesh->GetVertexBuffer().GetCount(),
-		/*start =*/ 0,
+		/*start =*/ _mesh->GetVertexBuffer().GetCount(),
+		/*offset =*/ 0,
 		/*instanceBuffer =*/ nullptr,
 		/*instanceStart =*/ 0,
 		/*instanceCount =*/ 1,
@@ -160,7 +151,7 @@ void DebugLines::Draw(RenderPass viewId, const bgfx::DynamicVertexBufferHandle& 
 
 DebugLines::DebugLines(std::unique_ptr<Mesh> &&mesh)
 	: _mesh(std::move(mesh))
-	, _model()
+	, _model(1.0f)
 {
 }
 

--- a/src/Graphics/DebugLines.h
+++ b/src/Graphics/DebugLines.h
@@ -35,9 +35,16 @@ class Mesh;
 class DebugLines
 {
   public:
+	struct Vertex
+	{
+		glm::vec4 pos;
+		glm::vec4 col;
+	};
+
 	static std::unique_ptr<DebugLines> CreateCross();
 	static std::unique_ptr<DebugLines> CreateBox(const glm::vec4 &color);
 	static std::unique_ptr<DebugLines> CreateLine(const glm::vec4& from, const glm::vec4& to, const glm::vec4& color);
+	static std::unique_ptr<DebugLines> CreateDebugLines(const Vertex* data, uint32_t vertexCount);
 
 	virtual ~DebugLines();
 
@@ -47,7 +54,6 @@ class DebugLines
 	void SetPose(const glm::vec3& center, const glm::vec3& size);
 
   protected:
-	static std::unique_ptr<DebugLines> CreateDebugLines(uint32_t size, const void* data, uint32_t vertexCount);
 	explicit DebugLines(std::unique_ptr<Mesh>&& mesh);
 
 	std::unique_ptr<Mesh> _mesh;

--- a/src/Gui.cpp
+++ b/src/Gui.cpp
@@ -462,6 +462,7 @@ bool Gui::Loop(Game& game)
 			ImGui::Checkbox("Wireframe", &config.wireframe);
 			ImGui::Checkbox("Water Debug", &config.waterDebug);
 			ImGui::Checkbox("Bounding Boxes", &config.drawBoundingBoxes);
+			ImGui::Checkbox("Streams", &config.drawStreams);
 			ImGui::Checkbox("Profiler", &config.showProfiler);
 			ImGui::EndMenu();
 		}

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -171,7 +171,7 @@ Renderer::Renderer(const GameWindow &window, bool vsync)
 
 	// allocate vertex buffers for our debug draw
 	_debugCross = DebugLines::CreateCross();
-	_boundingBox = DebugLines::CreateBox(glm::vec4(1.0f, 0.0f, 0.0f, 0.5f));
+
 
 	// give debug names to views
 	for (bgfx::ViewId i = 0; i < static_cast<bgfx::ViewId>(graphics::RenderPass::_count); ++i)
@@ -184,7 +184,6 @@ Renderer::~Renderer()
 {
 	_shaderManager.reset();
 	_debugCross.reset();
-	_boundingBox.reset();
 	bgfx::shutdown();
 }
 
@@ -300,7 +299,7 @@ void Renderer::DrawPass(const DrawSceneDesc &desc) const
 		auto section = desc.profiler.BeginScoped(desc.viewId == RenderPass::Reflection ? Profiler::Stage::ReflectionDrawModels : Profiler::Stage::MainPassDrawModels);
 		if (desc.drawEntities)
 		{
-			desc.entities.DrawModels(desc.viewId, *_shaderManager, desc.drawBoundingBoxes ? _boundingBox.get() : nullptr);
+			desc.entities.DrawModels(desc.viewId, *_shaderManager);
 		}
 	}
 

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -128,6 +128,5 @@ class Renderer {
 	std::unique_ptr<BgfxCallback> _bgfxCallback;
 
 	std::unique_ptr<graphics::DebugLines> _debugCross;
-	std::unique_ptr<graphics::DebugLines> _boundingBox;
 };
 } // namespace openblack


### PR DESCRIPTION
Re-enable drawing streams with a imgui option.

Move construction of streams to `PrepareDrawUploadUniforms`.
Store mesh of bounding box and stream in Registry.

![Screenshot from 2019-10-29 12-36-58](https://user-images.githubusercontent.com/1013356/67764334-04689f00-fa4a-11e9-80e8-b5f81dd9078a.png)

![Screenshot from 2019-10-29 12-46-31](https://user-images.githubusercontent.com/1013356/67764404-2b26d580-fa4a-11e9-9de2-4c36f231f0fb.png)

