### PR TITLE
Move bgfx dispatch to its own thread

### DIFF
--- a/src/3D/L3DMesh.cpp
+++ b/src/3D/L3DMesh.cpp
@@ -201,6 +201,7 @@ void L3DMesh::Load(IStream& stream)
 			_subMeshes[i] = std::make_unique<L3DSubMesh>(*this);
 			_subMeshes[i]->Load(stream);
 		}
+		bgfx::frame();
 	}
 
 	/*if (header.pointsCount > 0) {

--- a/src/3D/LandBlock.cpp
+++ b/src/3D/LandBlock.cpp
@@ -110,15 +110,15 @@ void LandBlock::BuildMesh(LandIsland& island)
 
 	auto verts = buildVertexList(island);
 
-	auto vertexBuffer = new VertexBuffer("LandBlock", verts.data(), verts.size(), decl);
+	auto vertexBuffer = new VertexBuffer("LandBlock", verts, decl);
 	_mesh = std::make_unique<Mesh>(vertexBuffer);
 }
 
-std::vector<LandVertex> LandBlock::buildVertexList(LandIsland& island)
+const bgfx::Memory* LandBlock::buildVertexList(LandIsland& island)
 {
 	// reserve 16*16 quads of 2 tris with 3 verts = 1536
-	std::vector<LandVertex> verts;
-	verts.reserve(1536);
+	const bgfx::Memory* verticesMem = bgfx::alloc(sizeof(LandVertex) * 1536);
+	auto vertices = (LandVertex*)verticesMem->data;
 
 	auto countries = island.GetCountries();
 
@@ -131,6 +131,7 @@ std::vector<LandVertex> LandBlock::buildVertexList(LandIsland& island)
 	int bx = _blockPosition.x * 16;
 	int bz = _blockPosition.y * 16;
 
+	uint16_t i = 0;
 	for (int x = 0; x < 16; x++)
 	{
 		for (int z = 0; z < 16; z++)
@@ -167,34 +168,34 @@ std::vector<LandVertex> LandBlock::buildVertexList(LandIsland& island)
 			{
 				// TR/BR/TL  # #
 				//             #
-				verts.push_back(make_vert(pTR, glm::vec3(0, 1, 0), tlMat, trMat, brMat, tr));
-				verts.push_back(make_vert(pBR, glm::vec3(0, 0, 1), tlMat, trMat, brMat, br));
-				verts.push_back(make_vert(pTL, glm::vec3(1, 0, 0), tlMat, trMat, brMat, tl));
+				vertices[i++] = make_vert(pTR, glm::vec3(0, 1, 0), tlMat, trMat, brMat, tr);
+				vertices[i++] = make_vert(pBR, glm::vec3(0, 0, 1), tlMat, trMat, brMat, br);
+				vertices[i++] = make_vert(pTL, glm::vec3(1, 0, 0), tlMat, trMat, brMat, tl);
 
 				// BR/BL/TL  #
 				//           # #
-				verts.push_back(make_vert(pBR, glm::vec3(0, 0, 1), tlMat, blMat, brMat, br));
-				verts.push_back(make_vert(pBL, glm::vec3(0, 1, 0), tlMat, blMat, brMat, bl));
-				verts.push_back(make_vert(pTL, glm::vec3(1, 0, 0), tlMat, blMat, brMat, tl));
+				vertices[i++] = make_vert(pBR, glm::vec3(0, 0, 1), tlMat, blMat, brMat, br);
+				vertices[i++] = make_vert(pBL, glm::vec3(0, 1, 0), tlMat, blMat, brMat, bl);
+				vertices[i++] = make_vert(pTL, glm::vec3(1, 0, 0), tlMat, blMat, brMat, tl);
 			}
 			else
 			{
 				// BL/TL/TR  # #
 				//           #
-				verts.push_back(make_vert(pBL, glm::vec3(1, 0, 0), blMat, tlMat, trMat, bl));
-				verts.push_back(make_vert(pTL, glm::vec3(0, 1, 0), blMat, tlMat, trMat, tl));
-				verts.push_back(make_vert(pTR, glm::vec3(0, 0, 1), blMat, tlMat, trMat, tr));
+				vertices[i++] = make_vert(pBL, glm::vec3(1, 0, 0), blMat, tlMat, trMat, bl);
+				vertices[i++] = make_vert(pTL, glm::vec3(0, 1, 0), blMat, tlMat, trMat, tl);
+				vertices[i++] = make_vert(pTR, glm::vec3(0, 0, 1), blMat, tlMat, trMat, tr);
 
 				// TR/BR/BL    #
 				//           # #
-				verts.push_back(make_vert(pTR, glm::vec3(0, 0, 1), blMat, brMat, trMat, tr));
-				verts.push_back(make_vert(pBR, glm::vec3(0, 1, 0), blMat, brMat, trMat, br));
-				verts.push_back(make_vert(pBL, glm::vec3(1, 0, 0), blMat, brMat, trMat, bl));
+				vertices[i++] = make_vert(pTR, glm::vec3(0, 0, 1), blMat, brMat, trMat, tr);
+				vertices[i++] = make_vert(pBR, glm::vec3(0, 1, 0), blMat, brMat, trMat, br);
+				vertices[i++] = make_vert(pBL, glm::vec3(1, 0, 0), blMat, brMat, trMat, bl);
 			}
 		}
 	}
 
-	return verts;
+	return verticesMem;
 }
 
 void LandBlock::Draw(graphics::RenderPass viewId, const ShaderProgram& program, bool cullBack) const

--- a/src/3D/LandBlock.h
+++ b/src/3D/LandBlock.h
@@ -37,13 +37,13 @@ namespace openblack
 
 struct LandVertex
 {
-	const float position[3];
-	const float weight[3]; // interpolated
-	const uint8_t firstMaterialID[4];  // force alignment 4 bytes to prevent packing
-	const uint8_t secondMaterialID[4];  // force alignment 4 bytes to prevent packing
-	const uint8_t materialBlendCoefficient[4];  // force alignment 4 bytes to prevent packing
-	const uint8_t lightLevel[4];  // aligned to 4 bytes
-	const float waterAlpha;
+	float position[3];
+	float weight[3]; // interpolated
+	uint8_t firstMaterialID[4];  // force alignment 4 bytes to prevent packing
+	uint8_t secondMaterialID[4];  // force alignment 4 bytes to prevent packing
+	uint8_t materialBlendCoefficient[4];  // force alignment 4 bytes to prevent packing
+	uint8_t lightLevel[4];  // aligned to 4 bytes
+	float waterAlpha;
 
 	LandVertex(glm::vec3 _position, glm::vec3 _weight,
 	           uint8_t mat1, uint8_t mat2, uint8_t mat3,
@@ -88,6 +88,6 @@ class LandBlock
 	glm::vec4 _mapPosition; // absolute position in the world
 	std::unique_ptr<graphics::Mesh> _mesh;
 
-	std::vector<LandVertex> buildVertexList(LandIsland& island);
+	const bgfx::Memory* buildVertexList(LandIsland& island);
 };
 } // namespace openblack

--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -134,6 +134,7 @@ void LandIsland::LoadFromFile(IStream& stream)
 	// build the meshes (we could move this elsewhere)
 	for (auto& block : _landBlocks)
 		block.BuildMesh(*this);
+	bgfx::frame();
 }
 
 /*const uint8_t LandIsland::GetAltitudeAt(glm::ivec2 vec) const

--- a/src/Graphics/DebugLines.cpp
+++ b/src/Graphics/DebugLines.cpp
@@ -46,7 +46,9 @@ std::unique_ptr<DebugLines> DebugLines::CreateDebugLines(uint32_t size, const vo
 	decl.emplace_back(VertexAttrib::Attribute::Color0, 4, VertexAttrib::Type::Float);
 
 	auto vertexBuffer = new VertexBuffer("DebugLines", data, vertexCount, decl);
+	bgfx::frame();
 	auto mesh = std::make_unique<Mesh>(vertexBuffer, nullptr, Mesh::Topology::LineList);
+	bgfx::frame();
 
 	return std::unique_ptr<DebugLines>(new DebugLines(std::move(mesh)));
 }

--- a/src/Graphics/IndexBuffer.cpp
+++ b/src/Graphics/IndexBuffer.cpp
@@ -35,7 +35,6 @@ IndexBuffer::IndexBuffer(std::string name, const void* indices, size_t indicesCo
 	auto mem = bgfx::makeRef(indices, indicesCount * GetTypeSize(_type));
 	_handle  = bgfx::createIndexBuffer(mem, type == Type::Uint32 ? BGFX_BUFFER_INDEX32 : 0);
 	bgfx::setName(_handle, _name.c_str());
-	bgfx::frame();
 }
 
 IndexBuffer::IndexBuffer(std::string name, const bgfx::Memory* mem, Type type):
@@ -45,7 +44,6 @@ IndexBuffer::IndexBuffer(std::string name, const bgfx::Memory* mem, Type type):
 
 	_handle = bgfx::createIndexBuffer(mem, type == Type::Uint32 ? BGFX_BUFFER_INDEX32 : 0);
 	bgfx::setName(_handle, _name.c_str());
-	bgfx::frame();
 }
 
 IndexBuffer::~IndexBuffer()

--- a/src/Graphics/RenderPass.h
+++ b/src/Graphics/RenderPass.h
@@ -38,8 +38,8 @@ enum class RenderPass : uint8_t
 };
 
 static constexpr std::array<std::string_view, static_cast<uint8_t>(RenderPass::_count)> RenderPassNames {
-	"Reflection Pass",
 	"Main Pass",
+	"Reflection Pass",
 	"ImGui Pass",
 	"Mesh Viewer Pass",
 };

--- a/src/Graphics/Texture2D.cpp
+++ b/src/Graphics/Texture2D.cpp
@@ -108,6 +108,7 @@ void Texture2D::Create(uint16_t width, uint16_t height, uint16_t layers, Format 
 	bgfx::frame();
 
 	bgfx::calcTextureSize(_info, width, height, 1, false, false, layers, getBgfxTextureFormat(format));
+	bgfx::frame();
 }
 
 void Texture2D::DumpTexture()

--- a/src/Graphics/VertexBuffer.cpp
+++ b/src/Graphics/VertexBuffer.cpp
@@ -90,7 +90,6 @@ VertexBuffer::VertexBuffer(std::string name, const void *vertices, uint32_t vert
 	_handle = bgfx::createVertexBuffer(mem, layout);
 	_layoutHandle = bgfx::createVertexLayout(layout);
 	bgfx::setName(_handle, _name.c_str());
-	bgfx::frame();
 }
 
 VertexBuffer::VertexBuffer(std::string name, const bgfx::Memory* mem, VertexDecl decl)
@@ -125,11 +124,9 @@ VertexBuffer::VertexBuffer(std::string name, const bgfx::Memory* mem, VertexDecl
 
 	_vertexCount = mem->size / _strideBytes;
 
-	// auto mem      = bgfx::makeRef(vertices, vertexCount * layout.m_stride);
 	_handle       = bgfx::createVertexBuffer(mem, layout);
 	_layoutHandle = bgfx::createVertexLayout(layout);
 	bgfx::setName(_handle, _name.c_str());
-	bgfx::frame();
 }
 
 VertexBuffer::~VertexBuffer()


### PR DESCRIPTION
Enable bgfx multi-threaded mode.
Make uploads of texture and mesh data more bgfx friendly with `bgfx::Memory` and sparsely placed `bgfx::frame` calls during loading.