### PR TITLE
DirectX support

### DIFF
--- a/CMakeModules/Shaders.cmake
+++ b/CMakeModules/Shaders.cmake
@@ -273,6 +273,7 @@ function(mark_shaders_for_compilation)
 				INCLUDES ${BGFX_SHADER_INCLUDE_PATH}
 				BIN2C BIN2C ${SHADER_FILE_NAME_WE}_${PROFILE_EXT}
 				WERROR
+				"$<$<CONFIG:debug>:DEBUG>$<$<CONFIG:relwithdebinfo>:DEBUG>"
 			)
 			list(APPEND OUTPUTS ${OUTPUT})
 			list(APPEND COMMANDS COMMAND bgfx::shaderc ${CLI})

--- a/assets/shaders/fs_object.sc
+++ b/assets/shaders/fs_object.sc
@@ -4,13 +4,13 @@ $input v_position, v_texcoord0, v_normal
 
 SAMPLER2D(s_diffuse, 0);
 
-float alphaThreshold = 1.0 / 255.0;
-vec3 lightColor = vec3(1.0f, 1.0f, 1.0f);
-vec4 lightPos = vec4(-4000, 1300, -1435, 1.0f);
-float ambientStrength = 0.5;
-
 void main()
 {
+	// constants
+	const vec3 lightColor = vec3(1.0f, 1.0f, 1.0f);
+	const vec4 lightPos = vec4(-4000.0f, 1300.0f, -1435.0f, 1.0f);
+	const float ambientStrength = 0.5f;
+	const float alphaThreshold = 1.0f / 255.0f;
 	// ambient
 	vec3 ambient = ambientStrength * lightColor;
 

--- a/assets/shaders/fs_terrain.sc
+++ b/assets/shaders/fs_terrain.sc
@@ -42,7 +42,7 @@ void main()
 	// apply light map
 	col = col * mix(.25f, clamp(v_lightLevel * 2, 0.5, 1), u_timeOfDay.r);
 
-	gl_FragColor = vec4(col.r, col.g, col.b, v_waterAlpha);
+	gl_FragColor = vec4(col.rgb, v_waterAlpha);
 
 	if (v_waterAlpha == 0.0) {
 		discard;

--- a/assets/shaders/varying.def.sc
+++ b/assets/shaders/varying.def.sc
@@ -1,24 +1,24 @@
-vec4 a_position     : POSITION;
-vec2 a_texcoord0    : TEXCOORD0;
-vec3 a_normal    : NORMAL;
-vec4 a_color0       : COLOR0;
-vec3 a_weight       : COLOR5;
-vec3 a_color1       : COLOR1;  // firstMaterialID
-vec3 a_color2      : COLOR2;  // secondMaterialID
-vec3 a_indices     : COLOR4;  // material blend coefficient
-float a_color3      : COLOR3;  // water alpha
-vec4 i_data0     : TEXCOORD7;
-vec4 i_data1     : TEXCOORD6;
-vec4 i_data2     : TEXCOORD5;
-vec4 i_data3     : TEXCOORD4;
+vec4 a_position          : POSITION;
+vec3 a_normal            : NORMAL;
+vec4 a_color0            : COLOR0;     // time of day
+vec3 a_color1            : COLOR1;     // firstMaterialID
+vec3 a_color2            : COLOR2;     // secondMaterialID
+float a_color3           : COLOR3;     // water alpha
+vec2 a_texcoord0         : TEXCOORD0;
+vec3 a_texcoord1         : TEXCOORD1;  // weight
+vec3 a_texcoord2         : TEXCOORD2;  // material blend coefficient
+vec4 i_data0             : TEXCOORD7;
+vec4 i_data1             : TEXCOORD6;
+vec4 i_data2             : TEXCOORD5;
+vec4 i_data3             : TEXCOORD4;
 
-vec4 v_position    : TEXCOORD1    = vec4(0.0, 0.0, 0.0, 0.0);
-vec4 v_color0    : COLOR0    = vec4(1.0, 0.0, 0.0, 1.0);
-vec4 v_texcoord0 : TEXCOORD0 = vec4(0.0, 0.0, 0.0, 1.0);
-vec3 v_normal    : NORMAL;
-vec3 v_weight    : COLOR5;
+vec4 v_position          : TEXCOORD1 = vec4(0.0, 0.0, 0.0, 0.0);
+vec4 v_color0            : COLOR0    = vec4(1.0, 0.0, 0.0, 1.0);
+vec4 v_texcoord0         : TEXCOORD0 = vec4(0.0, 0.0, 0.0, 1.0);
+vec3 v_normal            : NORMAL;
+vec3 v_weight            : COLOR5;
 flat ivec3 v_materialID0 : COLOR0;
 flat ivec3 v_materialID1 : COLOR1;
-vec3 v_materialBlend : COLOR2;
-float v_lightLevel : COLOR3;
-float v_waterAlpha : COLOR4;
+vec3 v_materialBlend     : COLOR2;
+float v_lightLevel       : COLOR3;
+float v_waterAlpha       : COLOR4;

--- a/assets/shaders/vs_terrain.sc
+++ b/assets/shaders/vs_terrain.sc
@@ -1,17 +1,23 @@
-$input a_position, a_weight, a_color1, a_color2, a_indices, a_color0, a_color3
+$input a_position, a_texcoord1, a_color1, a_color2, a_texcoord2, a_color0, a_color3
 $output v_texcoord0, v_weight, v_materialID0, v_materialID1, v_materialBlend, v_lightLevel, v_waterAlpha
 
 #include <bgfx_shader.sh>
+
+#if BGFX_SHADER_LANGUAGE_HLSL > 3
+#   define materialIdFix(x) (floatBitsToInt(x))
+#else
+#   define materialIdFix(x) (ivec3(x))
+#endif
 
 uniform vec4 u_blockPosition;
 
 void main()
 {
 	v_texcoord0 = vec4(a_position.z / 160.0f, a_position.x / 160.0f, 0.0f, 0.0f);
-	v_weight = a_weight;
-	v_materialID0 = ivec3(a_color1);
-	v_materialID1 = ivec3(a_color2);
-	v_materialBlend = a_indices;
+	v_weight = a_texcoord1;
+	v_materialID0 = materialIdFix(a_color1);
+	v_materialID1 = materialIdFix(a_color2);
+	v_materialBlend = a_texcoord2;
 	v_lightLevel = a_color0.x;
 	v_waterAlpha = a_color3;
 

--- a/src/3D/LandBlock.cpp
+++ b/src/3D/LandBlock.cpp
@@ -101,10 +101,10 @@ void LandBlock::BuildMesh(LandIsland& island)
 	VertexDecl decl;
 	decl.reserve(7);
 	decl.emplace_back(VertexAttrib::Attribute::Position, 3, VertexAttrib::Type::Float);
-	decl.emplace_back(VertexAttrib::Attribute::Weight, 3, VertexAttrib::Type::Float);  // weight
+	decl.emplace_back(VertexAttrib::Attribute::TexCoord1, 3, VertexAttrib::Type::Float);  // weight
 	decl.emplace_back(VertexAttrib::Attribute::Color1, 3, VertexAttrib::Type::Uint8);  // first material id
 	decl.emplace_back(VertexAttrib::Attribute::Color2, 3, VertexAttrib::Type::Uint8);  // second material id
-	decl.emplace_back(VertexAttrib::Attribute::Indices, 3, VertexAttrib::Type::Uint8, true);  // material blend coefficient
+	decl.emplace_back(VertexAttrib::Attribute::TexCoord2, 3, VertexAttrib::Type::Uint8, true); // material blend coefficient
 	decl.emplace_back(VertexAttrib::Attribute::Color0, 4, VertexAttrib::Type::Uint8, true);  // light level, align to 4 bytes
 	decl.emplace_back(VertexAttrib::Attribute::Color3, 1, VertexAttrib::Type::Float, true);  // water alpha
 

--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -137,6 +137,13 @@ void LandIsland::LoadFromFile(IStream& stream)
 	bgfx::frame();
 }
 
+void openblack::LandIsland::Update(float timeOfDay, float bumpMapStrength, float smallBumpMapStrength)
+{
+	_timeOfDay = timeOfDay;
+	_bumpMapStrength = bumpMapStrength;
+	_smallBumpMapStrength = smallBumpMapStrength;
+}
+
 /*const uint8_t LandIsland::GetAltitudeAt(glm::ivec2 vec) const
 {
 	return uint8_t();
@@ -183,12 +190,16 @@ const LandCell& LandIsland::GetCell(int x, int z) const
 
 void LandIsland::Draw(graphics::RenderPass viewId, const ShaderProgram& program, bool cullBack) const
 {
-	program.SetTextureSampler("s_materials", 0, *_materialArray);
-	program.SetTextureSampler("s_bump", 1, *_textureBumpMap);
-	program.SetTextureSampler("s_smallBump", 2, *_textureSmallBump);
-
 	for (auto& block : _landBlocks)
+	{
+		program.SetTextureSampler("s_materials", 0, *_materialArray);
+		program.SetTextureSampler("s_bump", 1, *_textureBumpMap);
+		program.SetTextureSampler("s_smallBump", 2, *_textureSmallBump);
+		program.SetUniformValue("u_timeOfDay", &_timeOfDay);
+		program.SetUniformValue("u_bumpmapStrength", &_bumpMapStrength);
+		program.SetUniformValue("u_smallBumpmapStrength", &_smallBumpMapStrength);
 		block.Draw(viewId, program, cullBack);
+	}
 }
 
 void LandIsland::convertRGB5ToRGB8(uint16_t* rgba5, uint32_t* rgba8, size_t pixels)

--- a/src/3D/LandIsland.h
+++ b/src/3D/LandIsland.h
@@ -57,6 +57,8 @@ class LandIsland
 
 	void LoadFromFile(IStream& file);
 
+	void Update(float timeOfDay, float bumpMapStrength, float smallBumpMapStrength);
+
 	// const uint8_t GetAltitudeAt(glm::ivec2) const;
 
 	float GetHeightAt(glm::vec2) const;
@@ -97,6 +99,10 @@ class LandIsland
 	std::unique_ptr<graphics::Texture2D> _textureSmallBump;
 
 	std::array<uint8_t, 256 * 256> _noiseMap;
+
+	float _timeOfDay;
+	float _bumpMapStrength;
+	float _smallBumpMapStrength;
 };
 } // namespace openblack
 

--- a/src/3D/Sky.cpp
+++ b/src/3D/Sky.cpp
@@ -102,7 +102,7 @@ void Sky::Interpolate555Texture(uint16_t* bitmap, uint16_t* bitmap1, uint16_t* b
 		uint16_t g = (g1 * interpolate) + (g2 * (1.0f - interpolate));
 		uint16_t b = (b1 * interpolate) + (b2 * (1.0f - interpolate));
 
-		bitmap[i] = (b << 10) | (g << 5) | r;
+		bitmap[i] = (r << 10) | (g << 5) | b;
 	}
 }
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -211,6 +211,11 @@ bool Game::Update()
 		_modelRotation.y = fmod(_modelRotation.y + float(deltaTime.count())*.0001f, 360.f);
 	}
 
+	// Update Terrain
+	{
+		_landIsland->Update(_config.timeOfDay, _config.bumpMapStrength, _config.smallBumpMapStrength);
+	}
+
 	// Update Uniforms
 	{
 		auto profilerScopedUpdateUniforms = _profiler->BeginScoped(Profiler::Stage::UpdateUniforms);
@@ -237,11 +242,6 @@ bool Game::Update()
 			_intersection.y = _landIsland->GetHeightAt(glm::vec2(_intersection.x, _intersection.z));
 
 			_renderer->UpdateDebugCrossUniforms(_intersection, 50.0f);
-		}
-
-		// Update Terrain
-		{
-			_renderer->UpdateTerrainUniforms(_config.timeOfDay, _config.bumpMapStrength, _config.smallBumpMapStrength);
 		}
 
 		// Update Entities

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -72,6 +72,7 @@ Game::Game(int argc, char** argv)
 	bool vsync = false;
 	bool fullscreen = false;
 	bool borderless = false;
+	std::string rendererTypeStr;
 
 	auto args = CmdLineArgs(argc, argv);
 	args.Get("w", windowWidth);
@@ -79,6 +80,54 @@ Game::Game(int argc, char** argv)
 	args.Get("v", vsync);
 	args.Get("f", fullscreen);
 	args.Get("b", borderless);
+	args.Get("r", rendererTypeStr);
+
+	auto rendererType = bgfx::RendererType::OpenGL;
+
+	if (rendererTypeStr.compare("OpenGL") == 0)
+	{
+		rendererType = bgfx::RendererType::OpenGL;
+	}
+	else if (rendererTypeStr.compare("OpenGLES") == 0)
+	{
+		rendererType = bgfx::RendererType::OpenGLES;
+	}
+	else if (rendererTypeStr.compare("Vulkan") == 0)
+	{
+		rendererType = bgfx::RendererType::Vulkan;
+	}
+	else if (rendererTypeStr.compare("Direct3D9") == 0)
+	{
+		rendererType = bgfx::RendererType::Direct3D9;
+	}
+	else if (rendererTypeStr.compare("Direct3D11") == 0)
+	{
+		rendererType = bgfx::RendererType::Direct3D11;
+	}
+	else if (rendererTypeStr.compare("Direct3D12") == 0)
+	{
+		rendererType = bgfx::RendererType::Direct3D12;
+	}
+	else if (rendererTypeStr.compare("Metal") == 0)
+	{
+		rendererType = bgfx::RendererType::Metal;
+	}
+	else if (rendererTypeStr.compare("Gnm") == 0)
+	{
+		rendererType = bgfx::RendererType::Gnm;
+	}
+	else if (rendererTypeStr.compare("Nvn") == 0)
+	{
+		rendererType = bgfx::RendererType::Nvn;
+	}
+	else if (rendererTypeStr.compare("Noop") == 0)
+	{
+		rendererType = bgfx::RendererType::Noop;
+	}
+	else
+	{
+		rendererType = bgfx::RendererType::OpenGL;
+	}
 
 	DisplayMode displayMode = borderless ? DisplayMode::Borderless : (fullscreen ? DisplayMode::Fullscreen : DisplayMode::Windowed);
 
@@ -92,7 +141,7 @@ Game::Game(int argc, char** argv)
 
 	_window = std::make_unique<GameWindow>(kWindowTitle + " [" + kBuildStr + "]", windowWidth, windowHeight, displayMode);
 
-	_renderer = std::make_unique<Renderer>(*_window, vsync);
+	_renderer = std::make_unique<Renderer>(*_window, rendererType, vsync);
 
 	_fileSystem->SetGamePath(GetGamePath());
 	spdlog::debug("The GamePath is \"{}\".", _fileSystem->GetGamePath().generic_string());
@@ -292,7 +341,7 @@ void Game::Run()
 
 	{
 		int width, height;
-		_window->GetDrawableSize(width, height);
+		_window->GetSize(width, height);
 		_renderer->ConfigureView(graphics::RenderPass::Main, width, height);
 	}
 	{

--- a/src/GameWindow.cpp
+++ b/src/GameWindow.cpp
@@ -26,9 +26,6 @@
 #if defined(SDL_VIDEO_DRIVER_WAYLAND)
 #include <wayland-egl.h>
 #endif // defined(SDL_VIDEO_DRIVER_WAYLAND)
-#if USE_VULKAN
-#include <SDL_vulkan.h>
-#endif // USE_VULKAN
 
 #include "Renderer.h"
 
@@ -263,16 +260,6 @@ void GameWindow::SetSize(int width, int height)
 void GameWindow::GetSize(int& width, int& height) const
 {
 	SDL_GetWindowSize(_window.get(), &width, &height);
-}
-
-void GameWindow::GetDrawableSize(int& width, int& height) const
-{
-	// TODO(bwrsandman): Make this a runtime branch
-#if USE_VULKAN
-	SDL_Vulkan_GetDrawableSize(_window.get(), &width, &height);
-#else
-	SDL_GL_GetDrawableSize(_window.get(), &width, &height);
-#endif // USE_VULKAN
 }
 
 void GameWindow::Show()

--- a/src/GameWindow.h
+++ b/src/GameWindow.h
@@ -73,7 +73,6 @@ class GameWindow
 	void GetMinimumSize(int& width, int& height) const;
 	void SetMaximumSize(int width, int height);
 	void GetMaximumSize(int& width, int& height) const;
-	void GetDrawableSize(int& width, int& height) const;
 
 	void Minimise();
 	void Maximise();

--- a/src/Graphics/FrameBuffer.cpp
+++ b/src/Graphics/FrameBuffer.cpp
@@ -48,8 +48,8 @@ FrameBuffer::FrameBuffer(std::string name, uint16_t width, uint16_t height, Form
 	if (depthStencilFormat)
 	{
 		std::array<bgfx::TextureHandle, 2> textures = {
-			bgfx::createTexture2D(width, height, false, 1, getBgfxTextureFormat(colorFormat)),
-			bgfx::createTexture2D(width, height, false, 1, getBgfxTextureFormat(depthStencilFormat.value())),
+			bgfx::createTexture2D(width, height, false, 1, getBgfxTextureFormat(colorFormat), BGFX_TEXTURE_RT),
+			bgfx::createTexture2D(width, height, false, 1, getBgfxTextureFormat(depthStencilFormat.value()), BGFX_TEXTURE_RT),
 		};
 		_handle = bgfx::createFrameBuffer(textures.size(), textures.data());
 		_colorAttachment._handle = bgfx::getTexture(_handle, 0);
@@ -57,7 +57,7 @@ FrameBuffer::FrameBuffer(std::string name, uint16_t width, uint16_t height, Form
 	}
 	else
 	{
-		_handle = bgfx::createFrameBuffer(_width, _height, getBgfxTextureFormat(colorFormat));
+		_handle = bgfx::createFrameBuffer(_width, _height, getBgfxTextureFormat(colorFormat), BGFX_TEXTURE_RT);
 		_colorAttachment._handle = bgfx::getTexture(_handle, 0);
 	}
 

--- a/src/Graphics/Mesh.cpp
+++ b/src/Graphics/Mesh.cpp
@@ -69,5 +69,5 @@ void Mesh::Draw(const DrawDesc& desc) const
 		bgfx::setState(desc.state, desc.rgba);
 	}
 
-	bgfx::submit(static_cast<bgfx::ViewId>(desc.viewId), desc.program.GetRawHandle(), desc.preserveState);
+	bgfx::submit(static_cast<bgfx::ViewId>(desc.viewId), desc.program.GetRawHandle(), 0, desc.preserveState);
 }

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -118,21 +118,17 @@ struct BgfxCallback : public bgfx::CallbackI
 
 }  // namespace openblack
 
-Renderer::Renderer(const GameWindow &window, bool vsync)
+Renderer::Renderer(const GameWindow& window, bgfx::RendererType::Enum rendererType, bool vsync)
 	: _shaderManager(std::make_unique<ShaderManager>())
 	, _bgfxCallback(std::make_unique<BgfxCallback>())
 {
 	bgfx::Init init {};
-#if USE_VULKAN
-	init.type = bgfx::RendererType::Vulkan;
-#else
-	init.type = bgfx::RendererType::OpenGL;
-#endif  // USE_VULKAN
+	init.type = rendererType;
 
 	// Get render area size
 	int drawable_width;
 	int drawable_height;
-	window.GetDrawableSize(drawable_width, drawable_height);
+	window.GetSize(drawable_width, drawable_height);
 	init.resolution.width = (uint32_t)drawable_width;
 	init.resolution.height = (uint32_t)drawable_height;
 

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -203,14 +203,6 @@ void Renderer::UpdateDebugCrossUniforms(const glm::vec3 &position, float scale)
 	_debugCross->SetPose(position, glm::vec3(scale, scale, scale));
 }
 
-void Renderer::UpdateTerrainUniforms(float timeOfDay, float bumpMapStrength, float smallBumpMapStrength)
-{
-	auto terrainShader = _shaderManager->GetShader("Terrain");
-	terrainShader->SetUniformValue("u_timeOfDay", &timeOfDay);
-	terrainShader->SetUniformValue("u_bumpmapStrength", &bumpMapStrength);
-	terrainShader->SetUniformValue("u_smallBumpmapStrength", &smallBumpMapStrength);
-}
-
 void Renderer::DrawScene(const DrawSceneDesc &drawDesc) const
 {
 	// Reflection Pass

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -114,7 +114,6 @@ class Renderer {
 	[[nodiscard]] graphics::ShaderManager& GetShaderManager() const;
 
 	void UpdateDebugCrossUniforms(const glm::vec3 &position, float scale);
-	void UpdateTerrainUniforms(float timeOfDay, float bumpMapStrength, float smallBumpMapStrength);
 
 	void ConfigureView(graphics::RenderPass viewId, uint16_t width, uint16_t height) const;
 

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include <SDL.h>
+#include <bgfx/bgfx.h>
 #include <glm/fwd.hpp>
 
 #include <Graphics/RenderPass.h>
@@ -106,7 +107,7 @@ class Renderer {
 	};
 
 	Renderer() = delete;
-	explicit Renderer(const GameWindow& window, bool vsync);
+	explicit Renderer(const GameWindow& window, bgfx::RendererType::Enum rendererType, bool vsync);
 
 	virtual ~Renderer();
 


### PR DESCRIPTION
These changes add DirectX support. I was adding D3D11 only but it seems to fix D3D12 too.
You can now start openblack with `-r` to select the backend api.
This does break the sky on OpenGL since it seems bgfx has a bug for the RGB5A1 textures by having the colors in the wrong order (https://github.com/bkaradzic/bgfx/pull/1932).
Other than that, it seems to be feature parity.
D3D9 still has bugs but is not a priority

![image](https://user-images.githubusercontent.com/1013356/68078536-93254500-fdd7-11e9-8e9e-08733cfdabf4.png)

![image](https://user-images.githubusercontent.com/1013356/68078549-f9aa6300-fdd7-11e9-8876-93c22fc1e985.png)
