### PR TITLE
Use find_package(bgfx CONFIG) and make Azure Pipelines faster

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,19 +69,42 @@ else()
   endif()
 endif()
 
-find_package(bgfx CONFIG)
-if(NOT DEFINED bgfx_DIR)
-  # error if we're not building ourselves
-  if(NOT OPENBLACK_BUILD_BGFX)
-message(FATAL_ERROR " \
+option(OPENBLACK_BUILD_BGFX
+"Build bgfx alongside project (not advised)" OFF)
+
+if(NOT OPENBLACK_BUILD_BGFX)
+  find_package(bgfx CONFIG)
+  if(NOT bgfx_DIR)
+    message(FATAL_ERROR " \
 Failed to find bgfx, either install from: https://github.com/openblack/bgfx.cmake \
 Or set the variable OPENBLACK_BUILD_BGFX to build it with the project. \
 ")
   endif()
+else()
+  FetchContent_Declare(
+    bgfx
+    GIT_REPOSITORY https://github.com/openblack/bgfx.cmake.git
+    GIT_TAG master
+  )
 
-  # todo: reimplement building of bgfx here
-  # https://github.com/openblack/openblack/blob/2a363d58d213331781ea932c0c0cbb4a6a232994/CMakeLists.txt#L69
+  # don't build anymore targets then what we need
+  set(BGFX_BUILD_EXAMPLES
+      OFF
+      CACHE BOOL "Build bgfx examples.")
+  set(BGFX_INSTALL
+      OFF
+      CACHE BOOL "Create installation target.")
+  set(BGFX_CUSTOM_TARGETS
+      OFF
+      CACHE BOOL "Include convenience custom targets.")
 
+  # declare this here so bgfx compiles in a reasonable time
+  if(MSVC)
+    add_compile_options(/MP)
+  endif()
+
+  FetchContent_MakeAvailable(bgfx)
+  add_library(bgfx::bgfx ALIAS bgfx)
 endif()
 
 FetchContent_Declare(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,70 +69,19 @@ else()
   endif()
 endif()
 
-# todo: support find_package(bgfx)
-if(NOT bgfx_FOUND)
-  FetchContent_Declare(
-    bgfx
-    GIT_REPOSITORY https://github.com/openblack/bgfx.cmake.git
-    GIT_TAG materials
-  )
-
-  set(BGFX_BUILD_EXAMPLES
-      OFF
-      CACHE BOOL "Build bgfx examples.")
-  set(BGFX_INSTALL
-      OFF
-      CACHE BOOL "Create installation target.")
-  set(BGFX_CUSTOM_TARGETS
-      OFF
-      CACHE BOOL "Include convenience custom targets.")
-  set(BGFX_USE_DEBUG_SUFFIX
-      OFF
-      CACHE BOOL "Add 'd' suffix to debug output targets")
-
-  include(CMakeDependentOption)
-  option(OPENBLACK_BGFX_USE_SYSTEM_DEPS
-         "Search for system libraries for all 3rd parties of bgfx" OFF)
-  cmake_dependent_option(
-    OPENBLACK_BGFX_USE_SYSTEM_SPIRV_TOOLS
-    "Search for system spirv tools instead of building it" ON
-    "OPENBLACK_BGFX_USE_SYSTEM_DEPS" OFF)
-  cmake_dependent_option(
-    OPENBLACK_BGFX_USE_SYSTEM_SPIRV_CROSS
-    "Search for system spirv cross instead of building it" ON
-    "OPENBLACK_BGFX_USE_SYSTEM_DEPS" OFF)
-
-  if(OPENBLACK_BGFX_USE_SYSTEM_SPIRV_TOOLS)
-    find_library(SPIRVTOOLSOPT SPIRV-Tools-opt)
-    find_package(spirv-tools QUIET)
-    if(NOT spirv-tools_FOUND)
-      find_package(PkgConfig REQUIRED)
-      pkg_check_modules(SPIRV_TOOLS REQUIRED IMPORTED_TARGET GLOBAL SPIRV-Tools)
-      add_library(spirv-tools ALIAS PkgConfig::SPIRV_TOOLS)
-    endif()
-  endif()
-  if(OPENBLACK_BGFX_USE_SYSTEM_SPIRV_CROSS)
-    find_package(spirv_cross_core REQUIRED)
-    find_package(spirv_cross_glsl REQUIRED)
-    find_package(spirv_cross_msl REQUIRED)
-    find_package(spirv_cross_reflect REQUIRED)
-    add_library(spirv-cross INTERFACE)
-    target_link_libraries(
-      spirv-cross INTERFACE spirv-cross-core spirv-cross-glsl spirv-cross-msl
-                            spirv-cross-reflect)
-    if(WIN32)
-      find_package(spirv_cross_hlsl REQUIRED)
-      target_link_libraries(spirv-cross INTERFACE spirv-cross-hlsl)
-    endif()
+find_package(bgfx CONFIG)
+if(NOT DEFINED bgfx_DIR)
+  # error if we're not building ourselves
+  if(NOT OPENBLACK_BUILD_BGFX)
+message(FATAL_ERROR " \
+Failed to find bgfx, either install from: https://github.com/openblack/bgfx.cmake \
+Or set the variable OPENBLACK_BUILD_BGFX to build it with the project. \
+")
   endif()
 
-  # declare this here so bgfx compiles in a reasonable time
-  if(MSVC)
-    add_compile_options(/MP)
-  endif()
+  # todo: reimplement building of bgfx here
+  # https://github.com/openblack/openblack/blob/2a363d58d213331781ea932c0c0cbb4a6a232994/CMakeLists.txt#L69
 
-  FetchContent_MakeAvailable(bgfx)
-  add_library(bgfx::bgfx ALIAS bgfx)
 endif()
 
 FetchContent_Declare(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,4 +170,4 @@ add_subdirectory(apps/lndtool)
 # Set openblack project as default startup project in Visual Studio
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT
                                                             openblack)
-# set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,17 +70,23 @@ else()
 endif()
 
 option(OPENBLACK_BUILD_BGFX
-"Build bgfx alongside project (not advised)" OFF)
+"Build bgfx alongside project (only use for developing bgfx)" OFF)
 
 if(NOT OPENBLACK_BUILD_BGFX)
   find_package(bgfx CONFIG)
   if(NOT bgfx_DIR)
+  if (WIN32)
+    message(STATUS "Precompiled bgfx binaries can be found here: https://github.com/openblack/bgfx.cmake/releases/tag/latest")
+  endif()
+
     message(FATAL_ERROR " \
 Failed to find bgfx, either install from: https://github.com/openblack/bgfx.cmake \
 Or set the variable OPENBLACK_BUILD_BGFX to build it with the project. \
 ")
   endif()
 else()
+  message(AUTHOR_WARNING "Using OPENBLACK_BUILD_BGFX, if you are not developing use an install target instead.")
+
   FetchContent_Declare(
     bgfx
     GIT_REPOSITORY https://github.com/openblack/bgfx.cmake.git

--- a/CMakeModules/Shaders.cmake
+++ b/CMakeModules/Shaders.cmake
@@ -11,11 +11,9 @@
 
 # find_package(bgfx REQUIRED COMPONENTS shaderc)
 
-# get_target_property(BGFX_INCLUDE_PATH bgfx::bgfx INTERFACE_INCLUDE_DIRECTORIES)
-# set(BGFX_SHADER_INCLUDE_PATH ${BGFX_INCLUDE_PATH}/bgfx)
-
-add_executable(bgfx::shaderc ALIAS shaderc)
-set(BGFX_SHADER_INCLUDE_PATH ${bgfx_SOURCE_DIR}/bgfx/src)
+get_target_property(BGFX_INCLUDE_PATH bgfx::bgfx INTERFACE_INCLUDE_DIRECTORIES)
+list (GET BGFX_INCLUDE_PATH 0 BGFX_INCLUDE_PATH_1) # bgfx::bgfx exports include directory twice?
+set(BGFX_SHADER_INCLUDE_PATH ${BGFX_INCLUDE_PATH_1}/bgfx)
 
 # shaderc_parse(
 #	FILE filename

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ package directories.
 
 * Install [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/)
 * Install [CMake](https://cmake.org/download/)
+* Install [bgfx.cmake](https://github.com/openblack/bgfx.cmake/releases/tag/latest)
 
 You can either:
 
@@ -48,6 +49,8 @@ cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpk
 ```
 
 ## Linux
+
+* Install [bgfx.cmake](https://github.com/openblack/bgfx.cmake)
 
 *Note: These instructions are for Ubuntu, but can be easily applied to other distros.*
 

--- a/apps/g3dtool/CMakeLists.txt
+++ b/apps/g3dtool/CMakeLists.txt
@@ -18,3 +18,5 @@ if(MSVC)
 else()
 	target_compile_options(g3dtool PRIVATE -Wall -Wextra -pedantic -Werror)
 endif()
+
+set_property(TARGET g3dtool PROPERTY FOLDER "tools")

--- a/apps/l3dtool/CMakeLists.txt
+++ b/apps/l3dtool/CMakeLists.txt
@@ -18,3 +18,5 @@ if(MSVC)
 else()
 	target_compile_options(l3dtool PRIVATE -Wall -Wextra -pedantic -Werror)
 endif()
+
+set_property(TARGET l3dtool PROPERTY FOLDER "tools")

--- a/apps/lndtool/CMakeLists.txt
+++ b/apps/lndtool/CMakeLists.txt
@@ -18,3 +18,5 @@ if(MSVC)
 else()
 	target_compile_options(lndtool PRIVATE -Wall -Wextra -pedantic -Werror)
 endif()
+
+set_property(TARGET lndtool PROPERTY FOLDER "tools")

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -22,6 +22,7 @@ jobs:
   - template: azure-pipelines/templates/windows-dependencies.yml
     parameters:
       BuildPlatform: $(BuildPlatform)
+      MSBuildPlatform: $(MSBuildPlatform)
   - template: azure-pipelines/templates/windows-build.yml
     parameters:
       BuildPlatform: $(BuildPlatform)

--- a/azure-pipelines/templates/linux-build.yml
+++ b/azure-pipelines/templates/linux-build.yml
@@ -1,6 +1,6 @@
 steps:
 - bash: |
-    cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-linux -DOPENBLACK_BGFX_USE_SYSTEM_DEPS=ON -G Ninja
+    cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-linux -DOPENBLACK_BGFX_USE_SYSTEM_DEPS=ON -Dbgfx_DIR=/bgfx-install/lib/cmake/bgfx -G Ninja
   displayName: 'CMake'
 - bash: |
     cmake --build build

--- a/azure-pipelines/templates/windows-build.yml
+++ b/azure-pipelines/templates/windows-build.yml
@@ -9,7 +9,7 @@ steps:
   - task: CMake@1
     inputs:
       workingDirectory: 'build'
-      cmakeArgs: '-DCMAKE_TOOLCHAIN_FILE=c:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=${{ parameters.BuildPlatform }}-windows -A ${{ parameters.MSBuildPlatform }} ..'
+      cmakeArgs: '-DCMAKE_TOOLCHAIN_FILE=c:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=${{ parameters.BuildPlatform }}-windows -A ${{ parameters.MSBuildPlatform }} -Dbgfx_DIR=c:/bgfx-windows/lib/cmake/bgfx ..'
   - task: VSBuild@1
     displayName: 'Build'
     inputs:

--- a/azure-pipelines/templates/windows-build.yml
+++ b/azure-pipelines/templates/windows-build.yml
@@ -9,7 +9,7 @@ steps:
   - task: CMake@1
     inputs:
       workingDirectory: 'build'
-      cmakeArgs: '-DCMAKE_TOOLCHAIN_FILE=c:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=${{ parameters.BuildPlatform }}-windows -A ${{ parameters.MSBuildPlatform }} -Dbgfx_DIR=c:/bgfx-windows/lib/cmake/bgfx ..'
+      cmakeArgs: '-DCMAKE_TOOLCHAIN_FILE=c:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=${{ parameters.BuildPlatform }}-windows -A ${{ parameters.MSBuildPlatform }} -Dbgfx_DIR=c:/bgfx/lib/cmake/bgfx ..'
   - task: VSBuild@1
     displayName: 'Build'
     inputs:

--- a/azure-pipelines/templates/windows-dependencies.yml
+++ b/azure-pipelines/templates/windows-dependencies.yml
@@ -9,7 +9,15 @@ steps:
     rm -f windows-dependencies.7z
     mv windows-dependencies/installed /c/vcpkg/
     rm -rf windows-dependencies
-  displayName: 'Install dependencies'
+  displayName: 'Install vcpkg dependencies'
   workingDirectory: $(Build.ArtifactStagingDirectory)
 - script: c:\vcpkg\vcpkg.exe integrate install
   displayName: 'Integrate vcpkg'
+- bash: |
+    set -ex
+    curl -L https://github.com/openblack/bgfx.cmake/releases/download/latest/bgfx-windows-${{ parameters.BuildPlatform }}.7z > bgfx-windows.7z
+    7z x bgfx-windows.7z
+    rm -f bgfx-windows.7z
+    mv bgfx-windows /c
+  displayName: 'Download precompiled bgfx'
+  workingDirectory: $(Build.ArtifactStagingDirectory)

--- a/azure-pipelines/templates/windows-dependencies.yml
+++ b/azure-pipelines/templates/windows-dependencies.yml
@@ -1,5 +1,6 @@
 parameters:
   BuildPlatform: ''
+  MSBuildPlatform: ''
 
 steps:
 - bash: |
@@ -15,9 +16,8 @@ steps:
   displayName: 'Integrate vcpkg'
 - bash: |
     set -ex
-    curl -L https://github.com/openblack/bgfx.cmake/releases/download/latest/bgfx-windows-${{ parameters.BuildPlatform }}.7z > bgfx-windows.7z
-    7z x bgfx-windows.7z
+    curl -L https://github.com/openblack/bgfx.cmake/releases/download/latest/bgfx-windows-${{ parameters.MSBuildPlatform }}.7z > bgfx-windows.7z
+    7z x bgfx-windows.7z -oc:/bgfx
     rm -f bgfx-windows.7z
-    mv bgfx-windows /c
   displayName: 'Download precompiled bgfx'
   workingDirectory: $(Build.ArtifactStagingDirectory)

--- a/components/ScriptLibrary/CMakeLists.txt
+++ b/components/ScriptLibrary/CMakeLists.txt
@@ -15,3 +15,5 @@ target_include_directories(ScriptLibrary
 )
 
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} FILES ${SCRIPTLIBRARY_SOURCES} ${SCRIPTLIBRARY_HEADERS})
+
+set_property(TARGET ScriptLibrary PROPERTY FOLDER "components")

--- a/components/g3d/CMakeLists.txt
+++ b/components/g3d/CMakeLists.txt
@@ -13,3 +13,5 @@ if(MSVC)
 else()
 	target_compile_options(g3d PRIVATE -Wall -Wextra -pedantic -Werror)
 endif()
+
+set_property(TARGET g3d PROPERTY FOLDER "components")

--- a/components/l3d/CMakeLists.txt
+++ b/components/l3d/CMakeLists.txt
@@ -13,3 +13,5 @@ if(MSVC)
 else()
 	target_compile_options(l3d PRIVATE -Wall -Wextra -pedantic -Werror)
 endif()
+
+set_property(TARGET l3d PROPERTY FOLDER "components")

--- a/components/lnd/CMakeLists.txt
+++ b/components/lnd/CMakeLists.txt
@@ -13,3 +13,5 @@ if(MSVC)
 else()
 	target_compile_options(lnd PRIVATE -Wall -Wextra -pedantic -Werror)
 endif()
+
+set_property(TARGET lnd PROPERTY FOLDER "components")

--- a/external/imgui/CMakeLists.txt
+++ b/external/imgui/CMakeLists.txt
@@ -22,3 +22,5 @@ add_library(imgui STATIC
 target_include_directories(imgui PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 
 target_link_libraries(imgui PUBLIC SDL2::SDL2)
+
+set_property(TARGET imgui PROPERTY FOLDER "thirdparty")

--- a/src/Gui.cpp
+++ b/src/Gui.cpp
@@ -882,9 +882,9 @@ void Gui::ShowProfilerWindow(Game& game)
 
 			for (uint8_t i = 0; i < stats->numViews; ++i)
 			{
-				ImGui::Text("    %s: %0.3f", stats->viewStats[i].name,
-				            1000.0f * stats->viewStats[i].gpuTimeElapsed / (double)stats->gpuTimerFreq);
-				frameDuration -= stats->viewStats[i].gpuTimeElapsed;
+				// ImGui::Text("    %s: %0.3f", stats->viewStats[i].name,
+				//             1000.0f * stats->viewStats[i].gpuTimeElapsed / (double)stats->gpuTimerFreq);
+				// frameDuration -= stats->viewStats[i].gpuTimeElapsed;
 			}
 			ImGui::Text("    Unaccounted: %0.3f", 1000.0f * frameDuration / (double)stats->gpuTimerFreq);
 		}

--- a/src/Gui.cpp
+++ b/src/Gui.cpp
@@ -882,9 +882,11 @@ void Gui::ShowProfilerWindow(Game& game)
 
 			for (uint8_t i = 0; i < stats->numViews; ++i)
 			{
-				// ImGui::Text("    %s: %0.3f", stats->viewStats[i].name,
-				//             1000.0f * stats->viewStats[i].gpuTimeElapsed / (double)stats->gpuTimerFreq);
-				// frameDuration -= stats->viewStats[i].gpuTimeElapsed;
+				auto const& viewStat = stats->viewStats[i];
+				int64_t gpuTimeElapsed = viewStat.gpuTimeEnd - viewStat.gpuTimeBegin;
+
+				ImGui::Text("    %s: %0.3f", viewStat.name, 1000.0f * gpuTimeElapsed / (double)stats->gpuTimerFreq);
+				frameDuration -= gpuTimeElapsed;
 			}
 			ImGui::Text("    Unaccounted: %0.3f", 1000.0f * frameDuration / (double)stats->gpuTimerFreq);
 		}


### PR DESCRIPTION
depend on bgfx's install target from: https://github.com/openblack/bgfx.cmake

this is now baked into the compile farm docker image for Linux builds, and for Windows builds precompiled binaries are pulled from here: https://github.com/openblack/bgfx.cmake/releases/tag/latest

our current version of bgfx is forked here: https://github.com/openblack/bgfx and includes some changes by @bwrsandman  https://github.com/bkaradzic/bgfx/compare/master...openblack:master

with no longer needing to build bgfx alongside openblack we have cut CI times down to 2 minutes:
![image](https://user-images.githubusercontent.com/1388267/69435591-c18fa380-0d37-11ea-88fc-3df7836e7db8.png)

couple of things before merging this:
* ~~need to add option `OPENBLACK_BUILD_BGFX` to build bgfx if people don't want to make bgfx for whatever reason~~ 
001d3a1
* ~~weird graphical bugs with latest bgfx~~ (specifically https://github.com/bkaradzic/bgfx/pull/1919 fixed by reverting and reapplying always bind)
* ~~need to rework `gpuTimeElapsed` as it's different in bgfx then our previous fork~~ 
d44a65c 