### PR TITLE
Specify 64 bit triplet for vcpkg on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Clone the code using: `git clone --recursive https://github.com/openblack/openbl
 The simplest way to obtain all the required dependencies is through [vcpkg](https://github.com/Microsoft/vcpkg).
 
 ```bash
-PS> .\vcpkg install sdl2 spdlog glm entt
+PS> .\vcpkg install --triplet x64-windows sdl2 spdlog glm entt
 Linux:~/$ ./vcpkg install sdl2 spdlog glm entt
 ```
 


### PR DESCRIPTION
By default on windows the vcpkg triplet is 32-bit and this can confuse new devs.
On Linux it is 64 bit so the flag is not needed.