### PR TITLE
Clang format changes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,7 +10,7 @@ AlignTrailingComments: true
 AllowAllConstructorInitializersOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: true
-AllowShortCaseLabelsOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: true

--- a/.clang-format
+++ b/.clang-format
@@ -21,7 +21,7 @@ BinPackArguments: true
 BinPackParameters: true
 BreakBeforeBraces: Allman
 BreakBeforeTernaryOperators: true
-BreakConstructorInitializers: BeforeColon
+BreakConstructorInitializers: BeforeComma
 BreakInheritanceList: AfterColon
 ColumnLimit: 128
 CompactNamespaces: false

--- a/.clang-format
+++ b/.clang-format
@@ -9,7 +9,7 @@ AlignOperands: true
 AlignTrailingComments: true
 AllowAllConstructorInitializersOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: true
+AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: Never

--- a/apps/l3dtool/l3dtool.cpp
+++ b/apps/l3dtool/l3dtool.cpp
@@ -477,32 +477,32 @@ void copyBufferView(desT* dst, const uint8_t* src, size_t count, uint32_t compon
 {
 	switch (componentType)
 	{
-		case TINYGLTF_COMPONENT_TYPE_BYTE:
-			details::copyBufferView<desT, int8_t>(dst, src, count);
-			break;
-		case TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE:
-			details::copyBufferView<desT, uint8_t>(dst, src, count);
-			break;
-		case TINYGLTF_COMPONENT_TYPE_SHORT:
-			details::copyBufferView<desT, int16_t>(dst, src, count);
-			break;
-		case TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT:
-			details::copyBufferView<desT, uint16_t>(dst, src, count);
-			break;
-		case TINYGLTF_COMPONENT_TYPE_INT:
-			details::copyBufferView<desT, int32_t>(dst, src, count);
-			break;
-		case TINYGLTF_COMPONENT_TYPE_UNSIGNED_INT:
-			details::copyBufferView<desT, uint32_t>(dst, src, count);
-			break;
-		case TINYGLTF_COMPONENT_TYPE_FLOAT:
-			details::copyBufferView<desT, float>(dst, src, count);
-			break;
-		case TINYGLTF_COMPONENT_TYPE_DOUBLE:
-			details::copyBufferView<desT, double>(dst, src, count);
-			break;
-		default:
-			throw std::runtime_error("Unsupported component type");
+	case TINYGLTF_COMPONENT_TYPE_BYTE:
+		details::copyBufferView<desT, int8_t>(dst, src, count);
+		break;
+	case TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE:
+		details::copyBufferView<desT, uint8_t>(dst, src, count);
+		break;
+	case TINYGLTF_COMPONENT_TYPE_SHORT:
+		details::copyBufferView<desT, int16_t>(dst, src, count);
+		break;
+	case TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT:
+		details::copyBufferView<desT, uint16_t>(dst, src, count);
+		break;
+	case TINYGLTF_COMPONENT_TYPE_INT:
+		details::copyBufferView<desT, int32_t>(dst, src, count);
+		break;
+	case TINYGLTF_COMPONENT_TYPE_UNSIGNED_INT:
+		details::copyBufferView<desT, uint32_t>(dst, src, count);
+		break;
+	case TINYGLTF_COMPONENT_TYPE_FLOAT:
+		details::copyBufferView<desT, float>(dst, src, count);
+		break;
+	case TINYGLTF_COMPONENT_TYPE_DOUBLE:
+		details::copyBufferView<desT, double>(dst, src, count);
+		break;
+	default:
+		throw std::runtime_error("Unsupported component type");
 	}
 }
 

--- a/apps/l3dtool/l3dtool.cpp
+++ b/apps/l3dtool/l3dtool.cpp
@@ -298,7 +298,10 @@ int PrintPoints(openblack::l3d::L3DFile& l3d)
 	auto& points = l3d.GetPoints();
 	std::printf("file: %s\n", l3d.GetFilename().c_str());
 
-	for (auto& point : points) { std::printf("(%.3f, %.3f, %.3f)\n", point.x, point.y, point.z); }
+	for (auto& point : points)
+	{
+		std::printf("(%.3f, %.3f, %.3f)\n", point.x, point.y, point.z);
+	}
 
 	return EXIT_SUCCESS;
 }

--- a/components/ScriptLibrary/include/LHVM/VMInstruction.h
+++ b/components/ScriptLibrary/include/LHVM/VMInstruction.h
@@ -73,7 +73,11 @@ public:
 
 	VMInstruction() = delete;
 	VMInstruction(Opcode code, Access access, DataType type, uint32_t data, uint32_t line)
-	    : _code(code), _access(access), _type(type), _data(data), _line(line)
+	    : _code(code)
+	    , _access(access)
+	    , _type(type)
+	    , _data(data)
+	    , _line(line)
 	{
 	}
 	~VMInstruction() = default;

--- a/components/ScriptLibrary/include/LHVM/VMScript.h
+++ b/components/ScriptLibrary/include/LHVM/VMScript.h
@@ -23,8 +23,14 @@ public:
 	VMScript() = delete;
 	VMScript(const std::string& name, const std::string& filename, uint32_t type, uint32_t var_offset,
 	         std::vector<std::string> variables, uint32_t instruction_address, uint32_t parameter_count, uint32_t script_id)
-	    : _name(name), _filename(filename), _type(type), _variables(std::move(variables)), _variables_offset(var_offset),
-	      _instruction_address(instruction_address), _parameter_count(parameter_count), _script_id(script_id)
+	    : _name(name)
+	    , _filename(filename)
+	    , _type(type)
+	    , _variables(std::move(variables))
+	    , _variables_offset(var_offset)
+	    , _instruction_address(instruction_address)
+	    , _parameter_count(parameter_count)
+	    , _script_id(script_id)
 	{
 	}
 	~VMScript() = default;

--- a/components/ScriptLibrary/src/LHVM.cpp
+++ b/components/ScriptLibrary/src/LHVM.cpp
@@ -68,7 +68,10 @@ void LHVM::loadVariables(std::FILE* file, std::vector<std::string>& variables)
 		// reset cur pointer to 0
 		char* cur = &buffer[0];
 
-		while (*(cur - 1) != '\0') { std::fread(cur++, 1, 1, file); }
+		while (*(cur - 1) != '\0')
+		{
+			std::fread(cur++, 1, 1, file);
+		}
 
 		// throw it into the std::string vector
 		variables.emplace_back(buffer);
@@ -126,10 +129,16 @@ void LHVM::loadScripts(std::FILE* file)
 	for (int32_t i = 0; i < count; i++)
 	{
 		char* cur = &script_name[0];
-		while (*(cur - 1) != '\0') { std::fread(cur++, 1, 1, file); }
+		while (*(cur - 1) != '\0')
+		{
+			std::fread(cur++, 1, 1, file);
+		}
 
 		cur = &file_name[0];
-		while (*(cur - 1) != '\0') { std::fread(cur++, 1, 1, file); }
+		while (*(cur - 1) != '\0')
+		{
+			std::fread(cur++, 1, 1, file);
+		}
 
 		uint32_t script_type, shit;
 		std::fread(&script_type, 4, 1, file);

--- a/components/g3d/src/g3d_file.cpp
+++ b/components/g3d/src/g3d_file.cpp
@@ -107,7 +107,11 @@ struct membuf: std::streambuf
 };
 struct imemstream: virtual membuf, public std::istream
 {
-	imemstream(char const* base, size_t size): membuf(base, size), std::istream(dynamic_cast<std::streambuf*>(this)) {}
+	imemstream(char const* base, size_t size)
+	    : membuf(base, size)
+	    , std::istream(dynamic_cast<std::streambuf*>(this))
+	{
+	}
 };
 
 struct G3DBlockHeader
@@ -367,7 +371,10 @@ void G3DFile::CreateInfoBlock()
 	_blocks["INFO"] = std::move(contents);
 }
 
-G3DFile::G3DFile() : _isLoaded(false) {}
+G3DFile::G3DFile()
+    : _isLoaded(false)
+{
+}
 
 void G3DFile::Open(const std::string& file)
 {

--- a/components/g3d/src/g3d_file.cpp
+++ b/components/g3d/src/g3d_file.cpp
@@ -338,7 +338,9 @@ void G3DFile::CreateMeshBlock()
 		}
 		contents.resize(offset);
 		for (size_t i = 0; i < _meshes.size(); ++i)
-		{ std::memcpy(&contents[meshOffsets[i]], _meshes[i].data(), _meshes[i].size() * sizeof(_meshes[i][0])); }
+		{
+			std::memcpy(&contents[meshOffsets[i]], _meshes[i].data(), _meshes[i].size() * sizeof(_meshes[i][0]));
+		}
 	}
 
 	_blocks["MESHES"] = std::move(contents);

--- a/components/l3d/include/l3d_file.h
+++ b/components/l3d/include/l3d_file.h
@@ -26,9 +26,9 @@ class Span
 
 public:
 	Span(std::vector<N>& original, uint32_t start, uint32_t length)
-		: original(original)
-		, start(start)
-		, length(length)
+	    : original(original)
+	    , start(start)
+	    , length(length)
 	{
 	}
 

--- a/components/l3d/src/l3d_file.cpp
+++ b/components/l3d/src/l3d_file.cpp
@@ -177,7 +177,10 @@ void L3DFile::Fail(const std::string& msg)
 	throw std::runtime_error("L3D Error: " + msg + "\nFilename: " + _filename);
 }
 
-L3DFile::L3DFile() : _isLoaded(false) {}
+L3DFile::L3DFile()
+    : _isLoaded(false)
+{
+}
 
 void L3DFile::ReadFile(std::istream& stream)
 {

--- a/components/lnd/src/lnd_file.cpp
+++ b/components/lnd/src/lnd_file.cpp
@@ -110,7 +110,11 @@
 
 using namespace openblack::lnd;
 
-LNDFile::LNDFile(): _isLoaded(false), _header{} {}
+LNDFile::LNDFile()
+    : _isLoaded(false)
+    , _header {}
+{
+}
 
 /// Error handling
 void LNDFile::Fail(const std::string& msg)

--- a/src/3D/Camera.h
+++ b/src/3D/Camera.h
@@ -25,11 +25,18 @@ class Camera
 
 public:
 	Camera(glm::vec3 position, glm::vec3 rotation)
-	    : _position(position), _rotation(glm::radians(rotation)), _projectionMatrix(1.0f), _velocity(0.0f, 0.0f, 0.0f),
-	      _movementSpeed(0.0005f), _freeLookSensitivity(1.0f)
+	    : _position(position)
+	    , _rotation(glm::radians(rotation))
+	    , _projectionMatrix(1.0f)
+	    , _velocity(0.0f, 0.0f, 0.0f)
+	    , _movementSpeed(0.0005f)
+	    , _freeLookSensitivity(1.0f)
 	{
 	}
-	Camera(): Camera(glm::vec3(0.0f), glm::vec3(0.0f)) {}
+	Camera()
+	    : Camera(glm::vec3(0.0f), glm::vec3(0.0f))
+	{
+	}
 
 	virtual ~Camera() = default;
 
@@ -77,9 +84,13 @@ protected:
 class ReflectionCamera: public Camera
 {
 public:
-	ReflectionCamera(): ReflectionCamera(glm::vec3(0.0f), glm::vec3(0.0f), glm::vec4(0.0f)) {}
+	ReflectionCamera()
+	    : ReflectionCamera(glm::vec3(0.0f), glm::vec3(0.0f), glm::vec4(0.0f))
+	{
+	}
 	ReflectionCamera(glm::vec3 position, glm::vec3 rotation, glm::vec4 reflectionPlane)
-	    : Camera(position, rotation), _reflectionPlane(reflectionPlane)
+	    : Camera(position, rotation)
+	    , _reflectionPlane(reflectionPlane)
 	{
 	}
 	[[nodiscard]] glm::mat4 GetViewMatrix() const override;

--- a/src/3D/L3DMesh.cpp
+++ b/src/3D/L3DMesh.cpp
@@ -38,7 +38,11 @@ struct L3DModel_Vertex
 	uint32_t bone;
 };
 
-L3DMesh::L3DMesh(const std::string& debugName): _flags(static_cast<l3d::L3DMeshFlags>(0)), _debugName(debugName) {}
+L3DMesh::L3DMesh(const std::string& debugName)
+    : _flags(static_cast<l3d::L3DMeshFlags>(0))
+    , _debugName(debugName)
+{
+}
 
 void L3DMesh::Load(const l3d::L3DFile& l3d)
 {

--- a/src/3D/L3DSubMesh.cpp
+++ b/src/3D/L3DSubMesh.cpp
@@ -31,7 +31,10 @@ struct L3DVertex
 	glm::vec3 norm;
 };
 
-L3DSubMesh::L3DSubMesh(L3DMesh& mesh): _l3dMesh(mesh) {}
+L3DSubMesh::L3DSubMesh(L3DMesh& mesh)
+    : _l3dMesh(mesh)
+{
+}
 
 L3DSubMesh::~L3DSubMesh() {}
 

--- a/src/3D/LandBlock.cpp
+++ b/src/3D/LandBlock.cpp
@@ -20,13 +20,15 @@
 using namespace openblack;
 using namespace openblack::graphics;
 
-LandVertex::LandVertex(const glm::vec3& _position, const glm::vec3& _weight, uint32_t mat[8], uint32_t blend[3], uint8_t _lightLevel, float _alpha)
-	: position {_position.x, _position.y, _position.z}
-	, weight {_weight.x, _weight.y, _weight.z}
-	, firstMaterialID {static_cast<uint8_t>(mat[0]), static_cast<uint8_t>(mat[1]), static_cast<uint8_t>(mat[2])}
-	, secondMaterialID {static_cast<uint8_t>(mat[3]), static_cast<uint8_t>(mat[4]), static_cast<uint8_t>(mat[5])}
-	, materialBlendCoefficient {static_cast<uint8_t>(blend[0]), static_cast<uint8_t>(blend[1]), static_cast<uint8_t>(blend[2])}
-	, lightLevel {_lightLevel}, waterAlpha {_alpha}
+LandVertex::LandVertex(const glm::vec3& _position, const glm::vec3& _weight, uint32_t mat[8], uint32_t blend[3],
+                       uint8_t _lightLevel, float _alpha)
+    : position {_position.x, _position.y, _position.z}
+    , weight {_weight.x, _weight.y, _weight.z}
+    , firstMaterialID {static_cast<uint8_t>(mat[0]), static_cast<uint8_t>(mat[1]), static_cast<uint8_t>(mat[2])}
+    , secondMaterialID {static_cast<uint8_t>(mat[3]), static_cast<uint8_t>(mat[4]), static_cast<uint8_t>(mat[5])}
+    , materialBlendCoefficient {static_cast<uint8_t>(blend[0]), static_cast<uint8_t>(blend[1]), static_cast<uint8_t>(blend[2])}
+    , lightLevel {_lightLevel}
+    , waterAlpha {_alpha}
 {
 }
 

--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -26,7 +26,8 @@ using namespace openblack::graphics;
 const float LandIsland::HeightUnit = 0.67f;
 const float LandIsland::CellSize = 10.0f;
 
-LandIsland::LandIsland(): _blockIndexLookup {0}
+LandIsland::LandIsland()
+    : _blockIndexLookup {0}
 {
 	auto file = Game::instance()->GetFileSystem().Open("Data/Textures/smallbumpa.raw", FileMode::Read);
 	auto* smallbumpa = new uint8_t[file->Size()];

--- a/src/3D/MeshLookup.h
+++ b/src/3D/MeshLookup.h
@@ -25,7 +25,10 @@ template <typename T, typename K = std::hash<T>>
 class MeshLookup
 {
 public:
-	MeshLookup(std::initializer_list<typename std::unordered_map<T, MeshId, K>::value_type> init): lookup(init) {}
+	MeshLookup(std::initializer_list<typename std::unordered_map<T, MeshId, K>::value_type> init)
+	    : lookup(init)
+	{
+	}
 
 	MeshId operator[](T key)
 	{

--- a/src/Common/FileStream.cpp
+++ b/src/Common/FileStream.cpp
@@ -17,7 +17,9 @@
 namespace openblack
 {
 
-FileStream::FileStream(const fs::path& path, FileMode mode) : _file(nullptr), _fileSize(0)
+FileStream::FileStream(const fs::path& path, FileMode mode)
+    : _file(nullptr)
+    , _fileSize(0)
 {
     std::wstring recognisedMode;
 

--- a/src/Common/FileStream.cpp
+++ b/src/Common/FileStream.cpp
@@ -23,14 +23,14 @@ FileStream::FileStream(const fs::path& path, FileMode mode) : _file(nullptr), _f
 
 	switch (mode)
 	{
-	    case FileMode::Read:
-            recognisedMode = L"rb";
-	        break;
-	    case FileMode::Write:
-	        recognisedMode = L"wb";
-	        break;
-	    case FileMode::Append:
-	        recognisedMode = L"ab";
+	case FileMode::Read:
+		recognisedMode = L"rb";
+		break;
+	case FileMode::Write:
+		recognisedMode = L"wb";
+		break;
+	case FileMode::Append:
+		recognisedMode = L"ab";
 	}
 
 #ifdef _WIN32
@@ -67,9 +67,15 @@ void FileStream::Seek(std::size_t position, SeekMode seek)
 {
 	switch (seek)
 	{
-	case SeekMode::Begin: std::fseek(_file, static_cast<long>(position), SEEK_SET); break;
-	case SeekMode::Current: std::fseek(_file, static_cast<long>(position), SEEK_CUR); break;
-	case SeekMode::End: std::fseek(_file, static_cast<long>(position), SEEK_END); break;
+	case SeekMode::Begin:
+		std::fseek(_file, static_cast<long>(position), SEEK_SET);
+		break;
+	case SeekMode::Current:
+		std::fseek(_file, static_cast<long>(position), SEEK_CUR);
+		break;
+	case SeekMode::End:
+		std::fseek(_file, static_cast<long>(position), SEEK_END);
+		break;
 	}
 }
 

--- a/src/Common/FileSystem.cpp
+++ b/src/Common/FileSystem.cpp
@@ -35,7 +35,10 @@ std::string FileSystem::FixPath(const std::string& path)
 		}
 	}
 
-	for (auto pos = result.find('\\'); pos != std::string::npos; pos = result.find('\\', pos + 1)) { result[pos] = '/'; }
+	for (auto pos = result.find('\\'); pos != std::string::npos; pos = result.find('\\', pos + 1))
+	{
+		result[pos] = '/';
+	}
 
 	return result;
 }

--- a/src/Common/MemoryStream.cpp
+++ b/src/Common/MemoryStream.cpp
@@ -37,9 +37,15 @@ void MemoryStream::Seek(std::size_t position, SeekMode seek)
 {
 	switch (seek)
 	{
-	case SeekMode::Begin: _position = position; break;
-	case SeekMode::Current: _position += position; break;
-	case SeekMode::End: _position = _size + position; break;
+	case SeekMode::Begin:
+		_position = position;
+		break;
+	case SeekMode::Current:
+		_position += position;
+		break;
+	case SeekMode::End:
+		_position = _size + position;
+		break;
 	}
 }
 

--- a/src/Entities/Components/Stream.h
+++ b/src/Entities/Components/Stream.h
@@ -26,7 +26,8 @@ public:
 	glm::vec3 position;
 	std::vector<StreamNode> edges;
 
-	StreamNode(const glm::vec3 position, const std::vector<StreamNode>& streamNodes): position(position)
+	StreamNode(const glm::vec3 position, const std::vector<StreamNode>& streamNodes)
+	    : position(position)
 	{
 		if (streamNodes.empty())
 		{

--- a/src/Entities/Components/Villager.cpp
+++ b/src/Entities/Components/Villager.cpp
@@ -72,8 +72,10 @@ bool Villager::IsImportantRole(VillagerRoles role)
 	case VillagerRoles::Healer:
 	case VillagerRoles::Sculptor:
 	case VillagerRoles::Crusader:
-	case VillagerRoles::SailorAccordian: return true;
-	default: return false;
+	case VillagerRoles::SailorAccordian:
+		return true;
+	default:
+		return false;
 	}
 }
 

--- a/src/Entities/Registry.cpp
+++ b/src/Entities/Registry.cpp
@@ -349,7 +349,10 @@ void Registry::PrepareDraw(bool drawBoundingBox, bool drawBoundingStreams)
 		{
 			uint32_t streamEdgeCount = 0;
 			_registry.view<const Stream>().each([&streamEdgeCount](const Stream& com) {
-				for (const auto& from : com.streamNodes) { streamEdgeCount += from.edges.size(); }
+				for (const auto& from : com.streamNodes)
+				{
+					streamEdgeCount += from.edges.size();
+				}
 			});
 			std::vector<graphics::DebugLines::Vertex> streamEdges;
 			streamEdges.reserve(streamEdgeCount * 2);

--- a/src/Entities/RegistryContext.h
+++ b/src/Entities/RegistryContext.h
@@ -23,7 +23,8 @@ namespace openblack::entities
 {
 struct RenderContext
 {
-	RenderContext(): instanceUniformBuffer(BGFX_INVALID_HANDLE) {};
+	RenderContext()
+	    : instanceUniformBuffer(BGFX_INVALID_HANDLE) {};
 	~RenderContext()
 	{
 		if (bgfx::isValid(instanceUniformBuffer))
@@ -36,7 +37,11 @@ struct RenderContext
 
 	struct InstancedDrawDesc
 	{
-		InstancedDrawDesc(uint32_t offset, uint32_t count): offset(offset), count(count) {}
+		InstancedDrawDesc(uint32_t offset, uint32_t count)
+		    : offset(offset)
+		    , count(count)
+		{
+		}
 		uint32_t offset;
 		uint32_t count;
 	};

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -47,8 +47,11 @@ const std::string kWindowTitle = "openblack";
 Game* Game::sInstance = nullptr;
 
 Game::Game(Arguments&& args)
-    : _fileSystem(std::make_unique<FileSystem>()), _entityRegistry(std::make_unique<entities::Registry>()), _config(),
-      _frameCount(0), _intersection()
+    : _fileSystem(std::make_unique<FileSystem>())
+    , _entityRegistry(std::make_unique<entities::Registry>())
+    , _config()
+    , _frameCount(0)
+    , _intersection()
 {
 	spdlog::set_level(spdlog::level::debug);
 	sInstance = this;

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -102,7 +102,8 @@ bool Game::ProcessEvents()
 	{
 		switch (e.type)
 		{
-		case SDL_QUIT: return true;
+		case SDL_QUIT:
+			return true;
 		case SDL_WINDOWEVENT:
 			if (e.window.event == SDL_WINDOWEVENT_CLOSE && e.window.windowID == _window->GetID())
 			{
@@ -112,12 +113,19 @@ bool Game::ProcessEvents()
 		case SDL_KEYDOWN:
 			switch (e.key.keysym.sym)
 			{
-			case SDLK_ESCAPE: return true;
-			case SDLK_f: _window->SetFullscreen(true); break;
-			case SDLK_F1: _config.bgfxDebug = !_config.bgfxDebug; break;
+			case SDLK_ESCAPE:
+				return true;
+			case SDLK_f:
+				_window->SetFullscreen(true);
+				break;
+			case SDLK_F1:
+				_config.bgfxDebug = !_config.bgfxDebug;
+				break;
 			}
 			break;
-		case SDL_MOUSEMOTION: SDL_GetMouseState(&_mousePosition.x, &_mousePosition.y); break;
+		case SDL_MOUSEMOTION:
+			SDL_GetMouseState(&_mousePosition.x, &_mousePosition.y);
+			break;
 		case SDL_MOUSEBUTTONDOWN:
 		case SDL_MOUSEBUTTONUP:
 			switch (e.button.button)

--- a/src/Graphics/DebugLines.cpp
+++ b/src/Graphics/DebugLines.cpp
@@ -125,7 +125,11 @@ void DebugLines::Draw(RenderPass viewId, const bgfx::DynamicVertexBufferHandle& 
 	_mesh->Draw(desc);
 }
 
-DebugLines::DebugLines(std::unique_ptr<Mesh>&& mesh): _mesh(std::move(mesh)), _model(1.0f) {}
+DebugLines::DebugLines(std::unique_ptr<Mesh>&& mesh)
+    : _mesh(std::move(mesh))
+    , _model(1.0f)
+{
+}
 
 DebugLines::~DebugLines() = default;
 

--- a/src/Graphics/FrameBuffer.cpp
+++ b/src/Graphics/FrameBuffer.cpp
@@ -16,9 +16,14 @@ using namespace openblack::graphics;
 
 FrameBuffer::FrameBuffer(const std::string& name, uint16_t width, uint16_t height, Format colorFormat,
                          std::optional<Format> depthStencilFormat)
-    : _name(std::move(name)), _handle(BGFX_INVALID_HANDLE), _width(width), _height(height), _colorFormat(colorFormat),
-      _depthStencilFormat(depthStencilFormat), _colorAttachment(_name + "_color"),
-      _depthStencilAttachment(_name + "_depthStencil")
+    : _name(std::move(name))
+    , _handle(BGFX_INVALID_HANDLE)
+    , _width(width)
+    , _height(height)
+    , _colorFormat(colorFormat)
+    , _depthStencilFormat(depthStencilFormat)
+    , _colorAttachment(_name + "_color")
+    , _depthStencilAttachment(_name + "_depthStencil")
 {
 	_colorAttachment._handle = BGFX_INVALID_HANDLE;
 	_colorAttachment._info.width = width;

--- a/src/Graphics/IndexBuffer.cpp
+++ b/src/Graphics/IndexBuffer.cpp
@@ -16,7 +16,10 @@
 using namespace openblack::graphics;
 
 IndexBuffer::IndexBuffer(std::string name, const void* indices, size_t indicesCount, Type type)
-    : _name(std::move(name)), _count(indicesCount), _type(type), _handle(BGFX_INVALID_HANDLE)
+    : _name(std::move(name))
+    , _count(indicesCount)
+    , _type(type)
+    , _handle(BGFX_INVALID_HANDLE)
 {
 	assert(indices != nullptr);
 	assert(indicesCount > 0);
@@ -27,7 +30,9 @@ IndexBuffer::IndexBuffer(std::string name, const void* indices, size_t indicesCo
 }
 
 IndexBuffer::IndexBuffer(std::string name, const bgfx::Memory* mem, Type type)
-    : _name(std::move(name)), _type(type), _handle(BGFX_INVALID_HANDLE)
+    : _name(std::move(name))
+    , _type(type)
+    , _handle(BGFX_INVALID_HANDLE)
 {
 	_count = mem->size / sizeof(uint16_t);
 

--- a/src/Graphics/Mesh.cpp
+++ b/src/Graphics/Mesh.cpp
@@ -16,7 +16,9 @@
 using namespace openblack::graphics;
 
 Mesh::Mesh(VertexBuffer* vertexBuffer, IndexBuffer* indexBuffer, Topology topology)
-    : _vertexBuffer(vertexBuffer), _indexBuffer(indexBuffer), _topology(topology)
+    : _vertexBuffer(vertexBuffer)
+    , _indexBuffer(indexBuffer)
+    , _topology(topology)
 {
 }
 

--- a/src/Graphics/Texture2D.cpp
+++ b/src/Graphics/Texture2D.cpp
@@ -77,7 +77,11 @@ bgfx::TextureFormat::Enum getBgfxTextureFormat(Format format)
 	return textureFormatsBgfx[static_cast<size_t>(format)];
 }
 
-Texture2D::Texture2D(std::string name): _name(std::move(name)), _handle(BGFX_INVALID_HANDLE) {}
+Texture2D::Texture2D(std::string name)
+    : _name(std::move(name))
+    , _handle(BGFX_INVALID_HANDLE)
+{
+}
 
 Texture2D::~Texture2D()
 {

--- a/src/Graphics/VertexBuffer.cpp
+++ b/src/Graphics/VertexBuffer.cpp
@@ -33,8 +33,12 @@ constexpr std::array<bgfx::Attrib::Enum, 18> attributes {
 } // namespace
 
 VertexBuffer::VertexBuffer(std::string name, const void* vertices, uint32_t vertexCount, VertexDecl decl)
-    : _name(std::move(name)), _vertexCount(vertexCount), _vertexDecl(std::move(decl)), _strideBytes(0),
-      _handle(BGFX_INVALID_HANDLE), _layoutHandle(BGFX_INVALID_HANDLE)
+    : _name(std::move(name))
+    , _vertexCount(vertexCount)
+    , _vertexDecl(std::move(decl))
+    , _strideBytes(0)
+    , _handle(BGFX_INVALID_HANDLE)
+    , _layoutHandle(BGFX_INVALID_HANDLE)
 {
 	// assert(vertices != nullptr);
 	assert(vertexCount > 0);
@@ -67,8 +71,12 @@ VertexBuffer::VertexBuffer(std::string name, const void* vertices, uint32_t vert
 }
 
 VertexBuffer::VertexBuffer(std::string name, const bgfx::Memory* mem, VertexDecl decl)
-    : _name(std::move(name)), _vertexCount(0), _vertexDecl(std::move(decl)), _strideBytes(0), _handle(BGFX_INVALID_HANDLE),
-      _layoutHandle(BGFX_INVALID_HANDLE)
+    : _name(std::move(name))
+    , _vertexCount(0)
+    , _vertexDecl(std::move(decl))
+    , _strideBytes(0)
+    , _handle(BGFX_INVALID_HANDLE)
+    , _layoutHandle(BGFX_INVALID_HANDLE)
 {
 	// assert(vertices != nullptr);
 	assert(!_vertexDecl.empty());

--- a/src/Graphics/VertexBuffer.h
+++ b/src/Graphics/VertexBuffer.h
@@ -60,7 +60,11 @@ struct VertexAttrib
 
 	VertexAttrib() {}
 	VertexAttrib(Attribute attribute, uint8_t num, Type type, bool normalized = false, bool asInt = false)
-	    : _attribute(attribute), _num(num), _type(type), _normalized(normalized), _asInt(asInt)
+	    : _attribute(attribute)
+	    , _num(num)
+	    , _type(type)
+	    , _normalized(normalized)
+	    , _asInt(asInt)
 	{
 	}
 };

--- a/src/Gui.cpp
+++ b/src/Gui.cpp
@@ -483,10 +483,16 @@ bool Gui::Loop(Game& game)
 			};
 
 			ImGui::MenuItem("Story Islands", NULL, false, false);
-			for (auto& [label, path] : RegularIslands) { menu_item(label, path); }
+			for (auto& [label, path] : RegularIslands)
+			{
+				menu_item(label, path);
+			}
 			ImGui::Separator();
 			ImGui::MenuItem("Playground Islands", NULL, false, false);
-			for (auto& [label, path] : PlaygroundIslands) { menu_item(label, path); }
+			for (auto& [label, path] : PlaygroundIslands)
+			{
+				menu_item(label, path);
+			}
 
 			ImGui::EndMenu();
 		}

--- a/src/Gui.cpp
+++ b/src/Gui.cpp
@@ -79,12 +79,22 @@ std::unique_ptr<Gui> Gui::create(const GameWindow* window, graphics::RenderPass 
 }
 
 Gui::Gui(ImGuiContext* imgui, bgfx::ViewId viewId, std::unique_ptr<MeshViewer>&& meshViewer)
-    : _imgui(imgui), _time(0), _vertexBuffer(BGFX_INVALID_HANDLE), _indexBuffer(BGFX_INVALID_HANDLE),
-      _program(BGFX_INVALID_HANDLE), _imageProgram(BGFX_INVALID_HANDLE), _texture(BGFX_INVALID_HANDLE),
-      _s_tex(BGFX_INVALID_HANDLE),
-      _u_imageLodEnabled(BGFX_INVALID_HANDLE), _mousePressed {false, false, false}, _mouseCursors {0},
-      _clipboardTextData(nullptr), _last(bx::getHPCounter()), _lastScroll(0), _viewId(viewId),
-      _meshViewer(std::move(meshViewer))
+    : _imgui(imgui)
+    , _time(0)
+    , _vertexBuffer(BGFX_INVALID_HANDLE)
+    , _indexBuffer(BGFX_INVALID_HANDLE)
+    , _program(BGFX_INVALID_HANDLE)
+    , _imageProgram(BGFX_INVALID_HANDLE)
+    , _texture(BGFX_INVALID_HANDLE)
+    , _s_tex(BGFX_INVALID_HANDLE)
+    , _u_imageLodEnabled(BGFX_INVALID_HANDLE)
+    , _mousePressed {false, false, false}
+    , _mouseCursors {0}
+    , _clipboardTextData(nullptr)
+    , _last(bx::getHPCounter())
+    , _lastScroll(0)
+    , _viewId(viewId)
+    , _meshViewer(std::move(meshViewer))
 {
 	CreateDeviceObjectsBgfx();
 }

--- a/src/LHScriptX/CommandSignature.h
+++ b/src/LHScriptX/CommandSignature.h
@@ -31,15 +31,27 @@ enum class ParameterType
 class ScriptCommandParameter
 {
 public:
-	ScriptCommandParameter(ParameterType type = ParameterType::None): _type(type) {}
-	ScriptCommandParameter(const std::string value): _type(ParameterType::String)
+	ScriptCommandParameter(ParameterType type = ParameterType::None)
+	    : _type(type)
+	{
+	}
+	ScriptCommandParameter(const std::string value)
+	    : _type(ParameterType::String)
 	{
 		// TODO: Hacky, avoid new
 		_value._string = new std::string();
 		*_value._string = value;
 	}
-	ScriptCommandParameter(float value): _type(ParameterType::Float) { SetFloat(value); }
-	ScriptCommandParameter(int32_t value): _type(ParameterType::Number) { SetNumber(value); }
+	ScriptCommandParameter(float value)
+	    : _type(ParameterType::Float)
+	{
+		SetFloat(value);
+	}
+	ScriptCommandParameter(int32_t value)
+	    : _type(ParameterType::Number)
+	{
+		SetNumber(value);
+	}
 	ScriptCommandParameter(float x, float y, float z) { SetVector(x, y, z); }
 
 	[[nodiscard]] ParameterType GetType() const { return _type; };
@@ -76,7 +88,11 @@ typedef std::vector<ScriptCommandParameter> ScriptCommandParameters;
 class ScriptCommandContext
 {
 public:
-	ScriptCommandContext(Game* game, const ScriptCommandParameters* parameters): _game(game), _parameters(parameters) {}
+	ScriptCommandContext(Game* game, const ScriptCommandParameters* parameters)
+	    : _game(game)
+	    , _parameters(parameters)
+	{
+	}
 
 	[[nodiscard]] Game& GetGame() const { return *_game; }
 

--- a/src/LHScriptX/Lexer.cpp
+++ b/src/LHScriptX/Lexer.cpp
@@ -12,10 +12,11 @@
 #include <cctype>
 #include <utility>
 
-
 using namespace openblack::lhscriptx;
 
-Lexer::Lexer(std::string  source): source_(std::move(source)), currentLine_(1)
+Lexer::Lexer(std::string source)
+    : source_(std::move(source))
+    , currentLine_(1)
 {
 	current_ = source_.begin();
 	end_ = source_.end();

--- a/src/LHScriptX/Lexer.cpp
+++ b/src/LHScriptX/Lexer.cpp
@@ -112,7 +112,8 @@ Token Lexer::GetToken()
 		case 'x':
 		case 'y':
 		case 'z':
-		case '_': return gatherIdentifer();
+		case '_':
+			return gatherIdentifer();
 
 		/* gather numbers */
 		case '0':
@@ -125,15 +126,25 @@ Token Lexer::GetToken()
 		case '7':
 		case '8':
 		case '9':
-		case '-': return gatherNumber();
+		case '-':
+			return gatherNumber();
 
 		/* gather strings */
-		case '"': return gatherString();
+		case '"':
+			return gatherString();
 
-		case '=': current_++; return Token::MakeOperatorToken(Operator::Equal);
-		case ',': current_++; return Token::MakeOperatorToken(Operator::Comma);
-		case '(': current_++; return Token::MakeOperatorToken(Operator::LeftParentheses);
-		case ')': current_++; return Token::MakeOperatorToken(Operator::RightParentheses);
+		case '=':
+			current_++;
+			return Token::MakeOperatorToken(Operator::Equal);
+		case ',':
+			current_++;
+			return Token::MakeOperatorToken(Operator::Comma);
+		case '(':
+			current_++;
+			return Token::MakeOperatorToken(Operator::LeftParentheses);
+		case ')':
+			current_++;
+			return Token::MakeOperatorToken(Operator::RightParentheses);
 		default:
 			// todo: ignore BOM
 
@@ -226,25 +237,51 @@ void Token::Print(FILE* file) const
 {
 	switch (this->type_)
 	{
-	case Type::Invalid: fprintf(file, "invalid"); break;
-	case Type::EndOfFile: fprintf(file, "EOF"); break;
-	case Type::EndOfLine: fprintf(file, "\n"); break;
-	case Type::Identifier: fprintf(file, "identifier \"%s\"", this->u_.identifierValue->c_str()); break;
-	case Type::String: fprintf(file, "quoted string \"%s\"", this->u_.stringValue->c_str()); break;
-	case Type::Integer: fprintf(file, "integer %d", this->u_.integerValue); break;
-	case Type::Float: fprintf(file, "float %f", this->u_.floatValue); break;
+	case Type::Invalid:
+		fprintf(file, "invalid");
+		break;
+	case Type::EndOfFile:
+		fprintf(file, "EOF");
+		break;
+	case Type::EndOfLine:
+		fprintf(file, "\n");
+		break;
+	case Type::Identifier:
+		fprintf(file, "identifier \"%s\"", this->u_.identifierValue->c_str());
+		break;
+	case Type::String:
+		fprintf(file, "quoted string \"%s\"", this->u_.stringValue->c_str());
+		break;
+	case Type::Integer:
+		fprintf(file, "integer %d", this->u_.integerValue);
+		break;
+	case Type::Float:
+		fprintf(file, "float %f", this->u_.floatValue);
+		break;
 	case Type::Operator:
 		fprintf(file, "operator ");
 		switch (this->u_.op)
 		{
-		case Operator::Invalid: fprintf(file, "invalid"); break;
-		case Operator::Equal: fprintf(file, "="); break;
-		case Operator::Comma: fprintf(file, ","); break;
-		case Operator::LeftParentheses: fprintf(file, "("); break;
-		case Operator::RightParentheses: fprintf(file, ")"); break;
-		default: __builtin_unreachable();
+		case Operator::Invalid:
+			fprintf(file, "invalid");
+			break;
+		case Operator::Equal:
+			fprintf(file, "=");
+			break;
+		case Operator::Comma:
+			fprintf(file, ",");
+			break;
+		case Operator::LeftParentheses:
+			fprintf(file, "(");
+			break;
+		case Operator::RightParentheses:
+			fprintf(file, ")");
+			break;
+		default:
+			__builtin_unreachable();
 		}
 		break;
-	default: __builtin_unreachable();
+	default:
+		__builtin_unreachable();
 	}
 }

--- a/src/LHScriptX/Lexer.h
+++ b/src/LHScriptX/Lexer.h
@@ -22,7 +22,10 @@ namespace openblack::lhscriptx
 class LexerException: public std::runtime_error
 {
 public:
-	LexerException(const std::string& msg): std::runtime_error(msg.c_str()) {}
+	LexerException(const std::string& msg)
+	    : std::runtime_error(msg.c_str())
+	{
+	}
 };
 
 enum class Operator
@@ -110,7 +113,10 @@ public:
 	void Print(FILE* file) const;
 
 private:
-	Token(Type type): type_(type) {}
+	Token(Type type)
+	    : type_(type)
+	{
+	}
 
 	Type type_;
 	union

--- a/src/LHScriptX/Script.cpp
+++ b/src/LHScriptX/Script.cpp
@@ -88,15 +88,24 @@ ScriptCommandParameter GetParameter(Token& argument)
 
 	switch (type)
 	{
-	case Token::Type::Invalid: throw std::runtime_error("Invalid token. Unable to proceed");
-	case Token::Type::EndOfFile: throw std::runtime_error("Unexpected EOF in script");
-	case Token::Type::EndOfLine: throw std::runtime_error("Unexpected EOL in script");
-	case Token::Type::Identifier: return ScriptCommandParameter(argument.Identifier());
-	case Token::Type::String: return ScriptCommandParameter(argument.StringValue());
-	case Token::Type::Integer: return ScriptCommandParameter(*argument.IntegerValue());
-	case Token::Type::Float: return ScriptCommandParameter(*argument.FloatValue());
-	case Token::Type::Operator: throw std::runtime_error("Operator token as an argument is currently not supported");
-	default: throw std::runtime_error("Missing switch case for script token argument");
+	case Token::Type::Invalid:
+		throw std::runtime_error("Invalid token. Unable to proceed");
+	case Token::Type::EndOfFile:
+		throw std::runtime_error("Unexpected EOF in script");
+	case Token::Type::EndOfLine:
+		throw std::runtime_error("Unexpected EOL in script");
+	case Token::Type::Identifier:
+		return ScriptCommandParameter(argument.Identifier());
+	case Token::Type::String:
+		return ScriptCommandParameter(argument.StringValue());
+	case Token::Type::Integer:
+		return ScriptCommandParameter(*argument.IntegerValue());
+	case Token::Type::Float:
+		return ScriptCommandParameter(*argument.FloatValue());
+	case Token::Type::Operator:
+		throw std::runtime_error("Operator token as an argument is currently not supported");
+	default:
+		throw std::runtime_error("Missing switch case for script token argument");
 	}
 }
 

--- a/src/LHScriptX/Script.h
+++ b/src/LHScriptX/Script.h
@@ -20,13 +20,18 @@ namespace openblack::lhscriptx
 class NotImplemented: public std::logic_error
 {
 public:
-	NotImplemented(): std::logic_error("Function not yet implemented") {};
+	NotImplemented()
+	    : std::logic_error("Function not yet implemented") {};
 };
 
 class Script
 {
 public:
-	Script(Game* game): _game(game), token_(Token::MakeInvalidToken()) {}
+	Script(Game* game)
+	    : _game(game)
+	    , token_(Token::MakeInvalidToken())
+	{
+	}
 
 	void Load(const std::string&);
 

--- a/src/LHVMViewer.cpp
+++ b/src/LHVMViewer.cpp
@@ -735,7 +735,9 @@ void LHVMViewer::DrawScriptDisassembly(const openblack::LHVM::LHVM* lhvm, openbl
 			ImGui::SameLine();
 			ImGui::TextColored(Disassembly_ColorConstant, "0x%04x", instruction.GetData());
 			break;
-		default: ImGui::TextColored(Disassembly_ColorKeyword, "%s", instruction.Disassemble().c_str()); break;
+		default:
+			ImGui::TextColored(Disassembly_ColorKeyword, "%s", instruction.Disassemble().c_str());
+			break;
 		}
 
 		if (instruction.GetOpcode() == LHVM::VMInstruction::Opcode::END)
@@ -766,11 +768,15 @@ std::string openblack::LHVMViewer::DataToString(uint32_t data, openblack::LHVM::
 {
 	switch (type)
 	{
-	case LHVM::VMInstruction::DataType::INT: return std::to_string(data);
+	case LHVM::VMInstruction::DataType::INT:
+		return std::to_string(data);
 	case LHVM::VMInstruction::DataType::FLOAT:
-	case LHVM::VMInstruction::DataType::VECTOR: return std::to_string(*reinterpret_cast<float*>(&data)) + "f";
-	case LHVM::VMInstruction::DataType::BOOLEAN: return data ? "true" : "false";
-	default: return std::to_string(data) + " (unk type)";
+	case LHVM::VMInstruction::DataType::VECTOR:
+		return std::to_string(*reinterpret_cast<float*>(&data)) + "f";
+	case LHVM::VMInstruction::DataType::BOOLEAN:
+		return data ? "true" : "false";
+	default:
+		return std::to_string(data) + " (unk type)";
 	}
 }
 

--- a/src/MeshViewer.cpp
+++ b/src/MeshViewer.cpp
@@ -26,8 +26,9 @@
 using namespace openblack;
 
 MeshViewer::MeshViewer()
-    : _cameraPosition(5.0f, 3.0f, 5.0f), _boundingBox(graphics::DebugLines::CreateBox(glm::vec4(1.0f, 0.0f, 0.0f, 0.5f))),
-      _frameBuffer(std::make_unique<graphics::FrameBuffer>("MeshViewer", 512, 512, graphics::Format::RGBA8,
+    : _cameraPosition(5.0f, 3.0f, 5.0f)
+    , _boundingBox(graphics::DebugLines::CreateBox(glm::vec4(1.0f, 0.0f, 0.0f, 0.5f)))
+    , _frameBuffer(std::make_unique<graphics::FrameBuffer>("MeshViewer", 512, 512, graphics::Format::RGBA8,
                                                            graphics::Format::Depth24Stencil8))
 {
 }

--- a/src/Profiler.h
+++ b/src/Profiler.h
@@ -49,7 +49,9 @@ public:
 private:
 	struct ScopedSection
 	{
-		inline explicit ScopedSection(Profiler* profiler, Stage stage): _profiler(profiler), _stage(stage)
+		inline explicit ScopedSection(Profiler* profiler, Stage stage)
+		    : _profiler(profiler)
+		    , _stage(stage)
 		{
 			_profiler->Begin(_stage);
 		}

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -123,7 +123,9 @@ Renderer::Renderer(const GameWindow* window, bgfx::RendererType::Enum rendererTy
 
 	// give debug names to views
 	for (bgfx::ViewId i = 0; i < static_cast<bgfx::ViewId>(graphics::RenderPass::_count); ++i)
-	{ bgfx::setViewName(i, RenderPassNames[i].data()); }
+	{
+		bgfx::setViewName(i, RenderPassNames[i].data());
+	}
 }
 
 Renderer::~Renderer()
@@ -136,7 +138,9 @@ Renderer::~Renderer()
 void Renderer::LoadShaders()
 {
 	for (const auto& shader : Shaders)
-	{ _shaderManager->LoadShader(shader.name.data(), shader.vertexShaderName.data(), shader.fragmentShaderName.data()); }
+	{
+		_shaderManager->LoadShader(shader.name.data(), shader.vertexShaderName.data(), shader.fragmentShaderName.data());
+	}
 }
 
 void Renderer::ConfigureView(graphics::RenderPass viewId, uint16_t width, uint16_t height) const

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -86,7 +86,8 @@ struct BgfxCallback: public bgfx::CallbackI
 } // namespace openblack
 
 Renderer::Renderer(const GameWindow* window, bgfx::RendererType::Enum rendererType, bool vsync)
-    : _shaderManager(std::make_unique<ShaderManager>()), _bgfxCallback(std::make_unique<BgfxCallback>())
+    : _shaderManager(std::make_unique<ShaderManager>())
+    , _bgfxCallback(std::make_unique<BgfxCallback>())
 {
 	bgfx::Init init {};
 	init.type = rendererType;


### PR DESCRIPTION
While working on #203 which would enforce a style I noticed some settings in clang format which I wish to change.

These are my thoughts. Style is always a touchy subject but I will try to make my case. Take a look at the diff and I hope you will see what I see which is an improvement in readability in all cases.

I propose the following changes to clang format which all make code less horizontal and more readable:

* In constructors, put each initializer on a new line
This make initializers be vertical instead of all one one line.
It also makes diffs easier to read as a new initializer is one line on the diff which affects only that variable.

* Don't force short case statements on one line
Forcing short statements to have the form `case: code; break;` on the same line makes many switch statements harder to read and to modify. They don't even align properly and result in many cases to having to scroll horizontally.

* Don't force short blocks on one line
Similar to case statements, this makes many statements horizontal.
It makes some statements oddly aligned with a `{ ` at the beginning of a statement at the start of a new line.
If I use an `if` statement is one line and using braces it is because I would like it to be in a block,
not on one line.