### PR TITLE
Render boned meshes

### DIFF
--- a/apps/l3dtool/l3dtool.cpp
+++ b/apps/l3dtool/l3dtool.cpp
@@ -324,8 +324,8 @@ int PrintPrimitiveHeaders(openblack::l3d::L3DFile& l3d)
 		std::printf("vertex start offset: 0x%08X\n", header.verticesOffset);
 		std::printf("triangle count: %u\n", header.numTriangles);
 		std::printf("triangle start offset: 0x%08X\n", header.trianglesOffset);
-		std::printf("bone vertex look-up table size: %u\n", header.boneVertLUTSize);
-		std::printf("bone vertex look-up table start offset: 0x%08X\n", header.boneVertLUTOffset);
+		std::printf("vertex group count: %u\n", header.numGroups);
+		std::printf("vertex group start offset: 0x%08X\n", header.groupsOffset);
 		std::printf("vertex blend count: %u\n", header.numVertexBlends);
 		std::printf("vertex blend start offset: 0x%08X\n", header.vertexBlendsOffset);
 		std::printf("\n");
@@ -658,11 +658,11 @@ int WriteFile(const Arguments::Write& args)
 			primitive.numVertices = 0;
 			primitive.verticesOffset = static_cast<uint32_t>(l3d.GetVertices().size()); // FIXME: This is wrong
 			primitive.numTriangles = 0;
-			primitive.trianglesOffset = static_cast<uint32_t>(l3d.GetIndices().size() / 3);       // FIXME: This is wrong
-			primitive.boneVertLUTSize = 0;                                                        // TODO: Figure this out
-			primitive.boneVertLUTOffset = static_cast<uint32_t>(l3d.GetLookUpTableData().size()); // FIXME: This is wrong
-			primitive.numVertexBlends = 0;                                                        // TODO: Figure this out
-			primitive.vertexBlendsOffset = static_cast<uint32_t>(l3d.GetBlends().size());         // FIXME: This is wrong
+			primitive.trianglesOffset = static_cast<uint32_t>(l3d.GetIndices().size() / 3);  // FIXME: This is wrong
+			primitive.numGroups = 0;                                                         // TODO: Figure this out
+			primitive.groupsOffset = static_cast<uint32_t>(l3d.GetLookUpTableData().size()); // FIXME: This is wrong
+			primitive.numVertexBlends = 0;                                                   // TODO: Figure this out
+			primitive.vertexBlendsOffset = static_cast<uint32_t>(l3d.GetBlends().size());    // FIXME: This is wrong
 
 			struct attribute_t
 			{

--- a/assets/shaders/varying.def.sc
+++ b/assets/shaders/varying.def.sc
@@ -1,5 +1,6 @@
 vec4 a_position          : POSITION;
 vec3 a_normal            : NORMAL;
+vec4 a_indices           : BLENDINDICES;
 vec4 a_color0            : COLOR0;     // time of day
 vec3 a_color1            : COLOR1;     // firstMaterialID
 vec3 a_color2            : COLOR2;     // secondMaterialID

--- a/assets/shaders/vs_object.sc
+++ b/assets/shaders/vs_object.sc
@@ -1,14 +1,24 @@
 $input a_position, a_texcoord0, a_normal, a_indices
 $output v_position, v_texcoord0, v_normal
 
+#if BGFX_SHADER_LANGUAGE_HLSL == 3
+#define BGFX_CONFIG_MAX_BONES 48
+#else
 #define BGFX_CONFIG_MAX_BONES 64
+#endif
 
 #include <bgfx_shader.sh>
 
 void main()
 {
-	v_position = mul(u_model[uint(max(0, a_indices.x))], vec4(a_position.xyz, 1.0f));
-	v_texcoord0 = vec4(a_texcoord0, 0.0f, 0.0f);
+
+#if BGFX_SHADER_LANGUAGE_HLSL > 3 || BGFX_SHADER_LANGUAGE_PSSL || BGFX_SHADER_LANGUAGE_SPIRV || BGFX_SHADER_LANGUAGE_METAL
+	uint modelIndex = uint(max(0, floatBitsToInt(a_indices.x)));
+#else
+	uint modelIndex = uint(max(0, a_indices.x));
+#endif
+	v_position = mul(u_model[modelIndex], vec4(a_position.xyz, 1.0f));
+	v_texcoord0 = vec4(a_texcoord0, 0, 0);
 	v_normal = a_normal;
 	gl_Position = mul(u_viewProj, v_position);
 }

--- a/assets/shaders/vs_object.sc
+++ b/assets/shaders/vs_object.sc
@@ -1,13 +1,14 @@
-$input a_position, a_texcoord0, a_normal
+$input a_position, a_texcoord0, a_normal, a_indices
 $output v_position, v_texcoord0, v_normal
+
+#define BGFX_CONFIG_MAX_BONES 64
 
 #include <bgfx_shader.sh>
 
 void main()
 {
-	v_position = mul(u_model[0], vec4(a_position.xyz, 1.0f));
+	v_position = mul(u_model[uint(max(0, a_indices.x))], vec4(a_position.xyz, 1.0f));
 	v_texcoord0 = vec4(a_texcoord0, 0.0f, 0.0f);
 	v_normal = a_normal;
 	gl_Position = mul(u_viewProj, v_position);
-
 }

--- a/assets/shaders/vs_object_instanced.sc
+++ b/assets/shaders/vs_object_instanced.sc
@@ -1,4 +1,4 @@
-$input a_position, a_texcoord0, a_normal, i_data0, i_data1, i_data2, i_data3, i_data4
+$input a_position, a_texcoord0, a_normal, a_indices, i_data0, i_data1, i_data2, i_data3, i_data4
 $output v_position, v_texcoord0, v_normal
 
 #include <bgfx_shader.sh>

--- a/assets/shaders/vs_object_instanced.sc
+++ b/assets/shaders/vs_object_instanced.sc
@@ -1,17 +1,30 @@
 $input a_position, a_texcoord0, a_normal, a_indices, i_data0, i_data1, i_data2, i_data3, i_data4
 $output v_position, v_texcoord0, v_normal
 
+#if BGFX_SHADER_LANGUAGE_HLSL == 3
+#define BGFX_CONFIG_MAX_BONES 48
+#else
+#define BGFX_CONFIG_MAX_BONES 64
+#endif
+
 #include <bgfx_shader.sh>
 
 void main()
 {
+
+#if BGFX_SHADER_LANGUAGE_HLSL > 3 || BGFX_SHADER_LANGUAGE_PSSL || BGFX_SHADER_LANGUAGE_SPIRV || BGFX_SHADER_LANGUAGE_METAL
+	uint modelIndex = uint(max(0, floatBitsToInt(a_indices.x)));
+#else
+	uint modelIndex = uint(max(0, a_indices.x));
+#endif
+
 	mat4 model;
 	model[0] = i_data0;
 	model[1] = i_data1;
 	model[2] = i_data2;
 	model[3] = i_data3;
 
-	v_position = instMul(model, vec4(a_position.xyz, 1.0f));
+	v_position = instMul(model, mul(u_model[modelIndex], vec4(a_position.xyz, 1.0f)));
 	v_texcoord0 = vec4(a_texcoord0, 0.0f, 0.0f);
 	v_normal = a_normal;
 	gl_Position = mul(u_viewProj, v_position);

--- a/components/l3d/include/l3d_file.h
+++ b/components/l3d/include/l3d_file.h
@@ -229,6 +229,7 @@ protected:
 	std::vector<Span<L3DPrimitiveHeader>> _primitiveSpans;
 	std::vector<Span<L3DVertex>> _vertexSpans;
 	std::vector<Span<uint16_t>> _indexSpans;
+	std::vector<Span<L3DVertexGroup>> _vertexGroupSpans;
 	std::vector<Span<L3DBone>> _boneSpans;
 
 	/// Error handling
@@ -272,6 +273,10 @@ public:
 	[[nodiscard]] const Span<L3DBone>& GetBoneSpan(uint32_t submeshIndex) const { return _boneSpans[submeshIndex]; }
 	[[nodiscard]] const Span<L3DVertex>& GetVertexSpan(uint32_t submeshIndex) const { return _vertexSpans[submeshIndex]; }
 	[[nodiscard]] const Span<uint16_t>& GetIndexSpan(uint32_t submeshIndex) const { return _indexSpans[submeshIndex]; }
+	[[nodiscard]] const Span<L3DVertexGroup>& GetVertexGroupSpan(uint32_t submeshIndex) const
+	{
+		return _vertexGroupSpans[submeshIndex];
+	}
 
 	void AddSubmesh(const L3DSubmeshHeader& header);
 	void AddPrimitives(const std::vector<L3DPrimitiveHeader>& headers);

--- a/components/l3d/include/l3d_file.h
+++ b/components/l3d/include/l3d_file.h
@@ -189,6 +189,13 @@ struct L3DVertex
 };
 static_assert(sizeof(L3DVertex) == 32);
 
+struct L3DBlend
+{
+	uint16_t indices[2];
+	float weight;
+};
+static_assert(sizeof(L3DBlend) == 8);
+
 /**
   This class is used to read L3Ds.
  */
@@ -210,7 +217,7 @@ protected:
 	std::vector<L3DVertex> _vertices;
 	std::vector<uint16_t> _indices;
 	std::vector<uint8_t> _lookUpTable;
-	std::vector<uint8_t> _blends;
+	std::vector<L3DBlend> _blends;
 	std::vector<L3DBone> _bones;
 	std::vector<Span<L3DPrimitiveHeader>> _primitiveSpans;
 	std::vector<Span<L3DVertex>> _vertexSpans;
@@ -249,7 +256,7 @@ public:
 	[[nodiscard]] const std::vector<L3DVertex>& GetVertices() const { return _vertices; }
 	[[nodiscard]] const std::vector<uint16_t>& GetIndices() const { return _indices; }
 	[[nodiscard]] const std::vector<uint8_t>& GetLookUpTableData() const { return _lookUpTable; }
-	[[nodiscard]] const std::vector<uint8_t>& GetBlends() const { return _blends; }
+	[[nodiscard]] const std::vector<L3DBlend>& GetBlends() const { return _blends; }
 	[[nodiscard]] const std::vector<L3DBone>& GetBones() const { return _bones; }
 	[[nodiscard]] const Span<L3DPrimitiveHeader>& GetPrimitiveSpan(uint32_t submeshIndex) const
 	{

--- a/components/l3d/include/l3d_file.h
+++ b/components/l3d/include/l3d_file.h
@@ -174,8 +174,8 @@ struct L3DPrimitiveHeader
 	uint32_t verticesOffset;
 	uint32_t numTriangles;
 	uint32_t trianglesOffset;
-	uint32_t boneVertLUTSize;
-	uint32_t boneVertLUTOffset;
+	uint32_t numGroups;
+	uint32_t groupsOffset;
 	uint32_t numVertexBlends;
 	uint32_t vertexBlendsOffset;
 };
@@ -188,6 +188,13 @@ struct L3DVertex
 	L3DPoint normal;
 };
 static_assert(sizeof(L3DVertex) == 32);
+
+struct L3DVertexGroup
+{
+	uint16_t vertexCount;
+	uint16_t boneIndex;
+};
+static_assert(sizeof(L3DVertexGroup) == 4);
 
 struct L3DBlend
 {
@@ -216,7 +223,7 @@ protected:
 	std::vector<L3DPrimitiveHeader> _primitiveHeaders;
 	std::vector<L3DVertex> _vertices;
 	std::vector<uint16_t> _indices;
-	std::vector<uint8_t> _lookUpTable;
+	std::vector<L3DVertexGroup> _vertexGroups;
 	std::vector<L3DBlend> _blends;
 	std::vector<L3DBone> _bones;
 	std::vector<Span<L3DPrimitiveHeader>> _primitiveSpans;
@@ -255,7 +262,7 @@ public:
 	[[nodiscard]] const std::vector<L3DPrimitiveHeader>& GetPrimitiveHeaders() const { return _primitiveHeaders; }
 	[[nodiscard]] const std::vector<L3DVertex>& GetVertices() const { return _vertices; }
 	[[nodiscard]] const std::vector<uint16_t>& GetIndices() const { return _indices; }
-	[[nodiscard]] const std::vector<uint8_t>& GetLookUpTableData() const { return _lookUpTable; }
+	[[nodiscard]] const std::vector<L3DVertexGroup>& GetLookUpTableData() const { return _vertexGroups; }
 	[[nodiscard]] const std::vector<L3DBlend>& GetBlends() const { return _blends; }
 	[[nodiscard]] const std::vector<L3DBone>& GetBones() const { return _bones; }
 	[[nodiscard]] const Span<L3DPrimitiveHeader>& GetPrimitiveSpan(uint32_t submeshIndex) const

--- a/components/l3d/src/l3d_file.cpp
+++ b/components/l3d/src/l3d_file.cpp
@@ -486,24 +486,30 @@ void L3DFile::ReadFile(std::istream& stream)
 	// Create Primitive spans per submesh
 	_vertexSpans.reserve(_submeshHeaders.size());
 	_indexSpans.reserve(_submeshHeaders.size());
+	_vertexGroupSpans.reserve(_submeshHeaders.size());
 	{
 		uint32_t vertexStart = 0;
 		uint32_t indexStart = 0;
+		uint32_t vertexGroupStart = 0;
 		for (uint32_t i = 0; i < _submeshHeaders.size(); ++i)
 		{
 			uint32_t vertexLength = 0;
 			uint32_t indexLength = 0;
+			uint32_t vertexGroupLength = 0;
 			for (auto& primitive : GetPrimitiveSpan(i))
 			{
 				vertexLength += primitive.numVertices;
 				indexLength += primitive.numTriangles * 3;
+				vertexGroupLength += primitive.numGroups;
 			}
 
 			_vertexSpans.emplace_back(_vertices, vertexStart, vertexLength);
 			_indexSpans.emplace_back(_indices, indexStart, indexLength);
+			_vertexGroupSpans.emplace_back(_vertexGroups, vertexGroupStart, vertexGroupLength);
 
 			vertexStart += vertexLength;
 			indexStart += indexLength;
+			vertexGroupStart += vertexGroupLength;
 		}
 	}
 

--- a/components/l3d/src/l3d_file.cpp
+++ b/components/l3d/src/l3d_file.cpp
@@ -117,7 +117,9 @@
  *
  * ------------------------ start of blend block -------------------------------
  *
- * - ? bytes * total vertex blendcount, TODO: contents unknown
+ * - 8 bytes * total vertex blend count, each record containing:
+ *         indices: 2 16 bit ints representing an index TODO: unknown of what
+ *         weight: float representing a normalized weight between 0 and 1
  *
  */
 
@@ -415,6 +417,7 @@ void L3DFile::ReadFile(std::istream& stream)
 
 	// Reserve space for vertex blend data
 	_blends.resize(totalBlendValues);
+
 	if (!_blends.empty())
 	{
 		uint32_t counter = 0;

--- a/src/3D/L3DMesh.cpp
+++ b/src/3D/L3DMesh.cpp
@@ -131,12 +131,13 @@ void L3DMesh::Submit(graphics::RenderPass viewId, const glm::mat4* modelMatrices
 }
 
 void L3DMesh::Submit(graphics::RenderPass viewId, const bgfx::DynamicVertexBufferHandle& instanceBuffer, uint32_t instanceStart,
-                     uint32_t instanceCount, const ShaderProgram& program, uint64_t state, uint32_t rgba) const
+                     uint32_t instanceCount, const glm::mat4* modelMatrices, uint8_t matrixCount,
+                     const ShaderProgram& program, uint64_t state, uint32_t rgba) const
 {
 	for (auto it = _subMeshes.begin(); it != _subMeshes.end(); ++it)
 	{
 		const L3DSubMesh& submesh = *it->get();
-		submesh.Submit(viewId, instanceBuffer, instanceStart, instanceCount, program, state, rgba,
+		submesh.Submit(viewId, instanceBuffer, instanceStart, instanceCount, modelMatrices, matrixCount, program, state, rgba,
 		               std::next(it) != _subMeshes.end());
 	}
 }

--- a/src/3D/L3DMesh.cpp
+++ b/src/3D/L3DMesh.cpp
@@ -15,28 +15,14 @@
 #include "Game.h"
 
 #include <glm/gtc/type_ptr.hpp>
+#include <glm/matrix.hpp>
 #include <l3d_file.h>
 #include <spdlog/spdlog.h>
 
-#include <array>
 #include <stdexcept>
 
 using namespace openblack;
 using namespace openblack::graphics;
-
-struct LH3D_BoneVert
-{
-	uint16_t nVertices;
-	uint16_t boneIndex;
-};
-
-struct L3DModel_Vertex
-{
-	glm::vec3 pos;
-	glm::vec2 uv;
-	glm::vec3 norm;
-	uint32_t bone;
-};
 
 L3DMesh::L3DMesh(const std::string& debugName)
     : _flags(static_cast<l3d::L3DMeshFlags>(0))
@@ -52,6 +38,25 @@ void L3DMesh::Load(const l3d::L3DFile& l3d)
 		_skins[skin.id] = std::make_unique<Texture2D>(_debugName.c_str());
 		_skins[skin.id]->Create(skin.width, skin.height, 1, Format::RGBA4, Wrapping::ClampEdge, skin.texels.data(),
 		                        skin.texels.size() * sizeof(skin.texels[0]));
+	}
+
+	std::map<uint32_t, glm::mat4> matrices;
+	auto& bones = l3d.GetBones();
+	for (uint32_t i = 0; i < bones.size(); ++i)
+	{
+		auto& bone = bones[i];
+		// clang-format off
+		auto matrix = glm::mat4(bone.orientation[0], bone.orientation[1], bone.orientation[2], 0.0f,
+		                        bone.orientation[3], bone.orientation[4], bone.orientation[5], 0.0f,
+		                        bone.orientation[6], bone.orientation[7], bone.orientation[8], 0.0f,
+		                        bone.position.x, bone.position.y, bone.position.z, 1.0f);
+		// clang-format on
+		if (bone.parent != std::numeric_limits<uint32_t>::max())
+		{
+			matrix = matrices[bone.parent] * matrix;
+		}
+		_bonesDefaultMatrices.emplace_back(matrix);
+		matrices.emplace(i, matrix);
 	}
 
 	_subMeshes.resize(l3d.GetSubmeshHeaders().size());
@@ -99,8 +104,8 @@ void L3DMesh::LoadFromBuffer(const std::vector<uint8_t>& data)
 	Load(l3d);
 }
 
-void L3DMesh::Draw(graphics::RenderPass viewId, const glm::mat4& modelMatrix, const ShaderProgram& program, uint32_t mesh,
-                   uint64_t state, uint32_t rgba) const
+void L3DMesh::Submit(graphics::RenderPass viewId, const glm::mat4* modelMatrices, uint8_t matrixCount,
+                     const ShaderProgram& program, uint32_t mesh, uint64_t state, uint32_t rgba) const
 {
 	if (_subMeshes.empty())
 	{
@@ -112,16 +117,16 @@ void L3DMesh::Draw(graphics::RenderPass viewId, const glm::mat4& modelMatrix, co
 		spdlog::warn("tried to draw submesh out of range ({}/{})", mesh, _subMeshes.size());
 	}
 
-	_subMeshes[mesh]->Submit(viewId, modelMatrix, program, state, rgba, false);
+	_subMeshes[mesh]->Submit(viewId, modelMatrices, matrixCount, program, state, rgba, false);
 }
 
-void L3DMesh::Submit(graphics::RenderPass viewId, const glm::mat4& modelMatrix, const ShaderProgram& program, uint64_t state,
-                     uint32_t rgba) const
+void L3DMesh::Submit(graphics::RenderPass viewId, const glm::mat4* modelMatrices, uint8_t matrixCount,
+                     const ShaderProgram& program, uint64_t state, uint32_t rgba) const
 {
 	for (auto it = _subMeshes.begin(); it != _subMeshes.end(); ++it)
 	{
 		const L3DSubMesh& submesh = *it->get();
-		submesh.Submit(viewId, modelMatrix, program, state, rgba, std::next(it) != _subMeshes.end());
+		submesh.Submit(viewId, modelMatrices, matrixCount, program, state, rgba, std::next(it) != _subMeshes.end());
 	}
 }
 

--- a/src/3D/L3DMesh.h
+++ b/src/3D/L3DMesh.h
@@ -77,16 +77,17 @@ public:
 	void Load(const l3d::L3DFile& l3d);
 	void LoadFromFile(const std::string& fileName);
 	void LoadFromBuffer(const std::vector<uint8_t>& data);
-	void Draw(graphics::RenderPass viewId, const glm::mat4& modelMatrix, const graphics::ShaderProgram& program, uint32_t mesh,
-	          uint64_t state, uint32_t rgba = 0) const;
-	void Submit(graphics::RenderPass viewId, const glm::mat4& modelMatrix, const graphics::ShaderProgram& program,
-	            uint64_t state, uint32_t rgba = 0) const;
+	void Submit(graphics::RenderPass viewId, const glm::mat4* modelMatrices, uint8_t matrixCount,
+	            const graphics::ShaderProgram& program, uint32_t mesh, uint64_t state, uint32_t rgba = 0) const;
+	void Submit(graphics::RenderPass viewId, const glm::mat4* modelMatrices, uint8_t matrixCount,
+	            const graphics::ShaderProgram& program, uint64_t state, uint32_t rgba = 0) const;
 	void Submit(graphics::RenderPass viewId, const bgfx::DynamicVertexBufferHandle& instanceBuffer, uint32_t instanceStart,
 	            uint32_t instanceCount, const graphics::ShaderProgram& program, uint64_t state, uint32_t rgba = 0) const;
 
 	[[nodiscard]] uint8_t GetNumSubMeshes() const { return _subMeshes.size(); }
 	[[nodiscard]] const std::vector<std::unique_ptr<L3DSubMesh>>& GetSubMeshes() const { return _subMeshes; }
 	[[nodiscard]] const std::unordered_map<SkinId, std::unique_ptr<graphics::Texture2D>>& GetSkins() const { return _skins; }
+	[[nodiscard]] const std::vector<glm::mat4>& GetBoneMatrices() const { return _bonesDefaultMatrices; }
 
 private:
 	l3d::L3DMeshFlags _flags;
@@ -94,6 +95,7 @@ private:
 
 	std::unordered_map<SkinId, std::unique_ptr<graphics::Texture2D>> _skins;
 	std::vector<std::unique_ptr<L3DSubMesh>> _subMeshes;
+	std::vector<glm::mat4> _bonesDefaultMatrices;
 
 public:
 	[[nodiscard]] const std::string& GetDebugName() const { return _debugName; }

--- a/src/3D/L3DMesh.h
+++ b/src/3D/L3DMesh.h
@@ -82,7 +82,7 @@ public:
 	void Submit(graphics::RenderPass viewId, const glm::mat4* modelMatrices, uint8_t matrixCount,
 	            const graphics::ShaderProgram& program, uint64_t state, uint32_t rgba = 0) const;
 	void Submit(graphics::RenderPass viewId, const bgfx::DynamicVertexBufferHandle& instanceBuffer, uint32_t instanceStart,
-	            uint32_t instanceCount, const graphics::ShaderProgram& program, uint64_t state, uint32_t rgba = 0) const;
+	            uint32_t instanceCount, const glm::mat4* modelMatrices, uint8_t matrixCount, const graphics::ShaderProgram& program, uint64_t state, uint32_t rgba = 0) const;
 
 	[[nodiscard]] uint8_t GetNumSubMeshes() const { return _subMeshes.size(); }
 	[[nodiscard]] const std::vector<std::unique_ptr<L3DSubMesh>>& GetSubMeshes() const { return _subMeshes; }

--- a/src/3D/L3DMesh.h
+++ b/src/3D/L3DMesh.h
@@ -68,6 +68,19 @@ inline l3d::L3DMeshFlags operator&(l3d::L3DMeshFlags a, l3d::L3DMeshFlags b)
 	                                      static_cast<std::underlying_type<l3d::L3DMeshFlags>::type>(b));
 }
 
+struct L3DMeshSubmitDesc
+{
+	graphics::RenderPass viewId;
+	const graphics::ShaderProgram* program;
+	uint64_t state;
+	uint32_t rgba;
+	const glm::mat4* modelMatrices;
+	uint8_t matrixCount;
+	const bgfx::DynamicVertexBufferHandle* instanceBuffer;
+	uint32_t instanceStart;
+	uint32_t instanceCount;
+};
+
 class L3DMesh
 {
 public:
@@ -77,12 +90,7 @@ public:
 	void Load(const l3d::L3DFile& l3d);
 	void LoadFromFile(const std::string& fileName);
 	void LoadFromBuffer(const std::vector<uint8_t>& data);
-	void Submit(graphics::RenderPass viewId, const glm::mat4* modelMatrices, uint8_t matrixCount,
-	            const graphics::ShaderProgram& program, uint32_t mesh, uint64_t state, uint32_t rgba = 0) const;
-	void Submit(graphics::RenderPass viewId, const glm::mat4* modelMatrices, uint8_t matrixCount,
-	            const graphics::ShaderProgram& program, uint64_t state, uint32_t rgba = 0) const;
-	void Submit(graphics::RenderPass viewId, const bgfx::DynamicVertexBufferHandle& instanceBuffer, uint32_t instanceStart,
-	            uint32_t instanceCount, const glm::mat4* modelMatrices, uint8_t matrixCount, const graphics::ShaderProgram& program, uint64_t state, uint32_t rgba = 0) const;
+	void Submit(const L3DMeshSubmitDesc& desc, uint8_t subMeshIndex = std::numeric_limits<uint8_t>::max()) const;
 
 	[[nodiscard]] uint8_t GetNumSubMeshes() const { return _subMeshes.size(); }
 	[[nodiscard]] const std::vector<std::unique_ptr<L3DSubMesh>>& GetSubMeshes() const { return _subMeshes; }

--- a/src/3D/L3DSubMesh.cpp
+++ b/src/3D/L3DSubMesh.cpp
@@ -140,10 +140,11 @@ void L3DSubMesh::Submit(graphics::RenderPass viewId, const glm::mat4* modelMatri
 }
 
 void L3DSubMesh::Submit(graphics::RenderPass viewId, const bgfx::DynamicVertexBufferHandle& instanceBuffer,
-                        uint32_t instanceStart, uint32_t instanceCount, const graphics::ShaderProgram& program, uint64_t state,
+                        uint32_t instanceStart, uint32_t instanceCount, const glm::mat4* modelMatrices, uint8_t matrixCount,
+                        const graphics::ShaderProgram& program, uint64_t state,
                         uint32_t rgba, bool preserveState) const
 {
-	Submit_(viewId, nullptr, 0, &instanceBuffer, instanceStart, instanceCount, program, state, rgba, preserveState);
+	Submit_(viewId, modelMatrices, matrixCount, &instanceBuffer, instanceStart, instanceCount, program, state, rgba, preserveState);
 }
 
 void L3DSubMesh::Submit_(graphics::RenderPass viewId, const glm::mat4* modelMatrices, uint8_t matrixCount,

--- a/src/3D/L3DSubMesh.h
+++ b/src/3D/L3DSubMesh.h
@@ -47,7 +47,8 @@ public:
 	void Submit(graphics::RenderPass viewId, const glm::mat4* modelMatrices, uint8_t matrixCount,
 	            const graphics::ShaderProgram& program, uint64_t state, uint32_t rgba = 0, bool preserveState = false) const;
 	void Submit(graphics::RenderPass viewId, const bgfx::DynamicVertexBufferHandle& instanceBuffer, uint32_t instanceStart,
-	            uint32_t instanceCount, const graphics::ShaderProgram& program, uint64_t state, uint32_t rgba = 0,
+	            uint32_t instanceCount, const glm::mat4* modelMatrices, uint8_t matrixCount,
+	            const graphics::ShaderProgram& program, uint64_t state, uint32_t rgba = 0,
 	            bool preserveState = false) const;
 
 	[[nodiscard]] openblack::l3d::L3DSubmeshHeader::Flags GetFlags() const { return _flags; }

--- a/src/3D/L3DSubMesh.h
+++ b/src/3D/L3DSubMesh.h
@@ -23,6 +23,7 @@
 namespace openblack
 {
 class L3DMesh;
+struct L3DMeshSubmitDesc;
 
 namespace graphics
 {
@@ -44,22 +45,14 @@ public:
 	~L3DSubMesh();
 
 	void Load(const l3d::L3DFile& l3d, uint32_t meshIndex);
-	void Submit(graphics::RenderPass viewId, const glm::mat4* modelMatrices, uint8_t matrixCount,
-	            const graphics::ShaderProgram& program, uint64_t state, uint32_t rgba = 0, bool preserveState = false) const;
-	void Submit(graphics::RenderPass viewId, const bgfx::DynamicVertexBufferHandle& instanceBuffer, uint32_t instanceStart,
-	            uint32_t instanceCount, const glm::mat4* modelMatrices, uint8_t matrixCount,
-	            const graphics::ShaderProgram& program, uint64_t state, uint32_t rgba = 0,
-	            bool preserveState = false) const;
+	void Submit(const L3DMeshSubmitDesc& desc, graphics::RenderPass viewId, const graphics::ShaderProgram& program,
+	            uint64_t state, uint32_t rgba = 0, bool preserveState = false) const;
 
 	[[nodiscard]] openblack::l3d::L3DSubmeshHeader::Flags GetFlags() const { return _flags; }
 	[[nodiscard]] graphics::Mesh& GetMesh() const;
 	[[nodiscard]] AxisAlignedBoundingBox GetBoundingBox() const { return _boundingBox; }
 
 private:
-	void Submit_(graphics::RenderPass viewId, const glm::mat4* modelMatrices, uint8_t matrixCount,
-	             const bgfx::DynamicVertexBufferHandle* instanceBuffer, uint32_t instanceStart, uint32_t instanceCount,
-	             const graphics::ShaderProgram& program, uint64_t state, uint32_t rgba = 0, bool preserveState = false) const;
-
 	L3DMesh& _l3dMesh;
 
 	openblack::l3d::L3DSubmeshHeader::Flags _flags;

--- a/src/3D/L3DSubMesh.h
+++ b/src/3D/L3DSubMesh.h
@@ -44,8 +44,8 @@ public:
 	~L3DSubMesh();
 
 	void Load(const l3d::L3DFile& l3d, uint32_t meshIndex);
-	void Submit(graphics::RenderPass viewId, const glm::mat4& modelMatrix, const graphics::ShaderProgram& program,
-	            uint64_t state, uint32_t rgba = 0, bool preserveState = false) const;
+	void Submit(graphics::RenderPass viewId, const glm::mat4* modelMatrices, uint8_t matrixCount,
+	            const graphics::ShaderProgram& program, uint64_t state, uint32_t rgba = 0, bool preserveState = false) const;
 	void Submit(graphics::RenderPass viewId, const bgfx::DynamicVertexBufferHandle& instanceBuffer, uint32_t instanceStart,
 	            uint32_t instanceCount, const graphics::ShaderProgram& program, uint64_t state, uint32_t rgba = 0,
 	            bool preserveState = false) const;
@@ -55,7 +55,7 @@ public:
 	[[nodiscard]] AxisAlignedBoundingBox GetBoundingBox() const { return _boundingBox; }
 
 private:
-	void Submit_(graphics::RenderPass viewId, const glm::mat4* modelMatrix,
+	void Submit_(graphics::RenderPass viewId, const glm::mat4* modelMatrices, uint8_t matrixCount,
 	             const bgfx::DynamicVertexBufferHandle* instanceBuffer, uint32_t instanceStart, uint32_t instanceCount,
 	             const graphics::ShaderProgram& program, uint64_t state, uint32_t rgba = 0, bool preserveState = false) const;
 

--- a/src/3D/Sky.cpp
+++ b/src/3D/Sky.cpp
@@ -120,7 +120,7 @@ void Sky::Draw(graphics::RenderPass viewId, const glm::mat4& modelMatrix, const 
 
 	uint64_t state = 0u | BGFX_STATE_WRITE_RGB | BGFX_STATE_WRITE_A | BGFX_STATE_WRITE_Z | BGFX_STATE_DEPTH_TEST_LESS |
 	                 (cullBack ? BGFX_STATE_CULL_CW : BGFX_STATE_CULL_CCW) | BGFX_STATE_MSAA;
-	_model->Draw(viewId, modelMatrix, program, 0, state);
+	_model->Submit(viewId, &modelMatrix, 1, program, 0, state);
 }
 
 } // namespace openblack

--- a/src/3D/Sky.cpp
+++ b/src/3D/Sky.cpp
@@ -118,9 +118,23 @@ void Sky::Draw(graphics::RenderPass viewId, const glm::mat4& modelMatrix, const 
 {
 	program.SetTextureSampler("s_diffuse", 0, *_texture);
 
-	uint64_t state = 0u | BGFX_STATE_WRITE_RGB | BGFX_STATE_WRITE_A | BGFX_STATE_WRITE_Z | BGFX_STATE_DEPTH_TEST_LESS |
-	                 (cullBack ? BGFX_STATE_CULL_CW : BGFX_STATE_CULL_CCW) | BGFX_STATE_MSAA;
-	_model->Submit(viewId, &modelMatrix, 1, program, 0, state);
+	L3DMeshSubmitDesc desc = {};
+	desc.viewId = viewId;
+	desc.program = &program;
+	// clang-format off
+	desc.state = 0u
+		| BGFX_STATE_WRITE_RGB
+		| BGFX_STATE_WRITE_A
+		| BGFX_STATE_WRITE_Z
+		| BGFX_STATE_DEPTH_TEST_LESS
+		| (cullBack ? BGFX_STATE_CULL_CW : BGFX_STATE_CULL_CCW)
+		| BGFX_STATE_MSAA
+	;
+	// clang-format on
+	desc.modelMatrices = &modelMatrix;
+	desc.matrixCount = 1;
+
+	_model->Submit(desc, 0);
 }
 
 } // namespace openblack

--- a/src/Entities/Registry.cpp
+++ b/src/Entities/Registry.cpp
@@ -391,7 +391,15 @@ void Registry::DrawModels(graphics::RenderPass viewId, const graphics::ShaderMan
 	for (const auto& [meshId, placers] : renderCtx.instancedDrawDescs)
 	{
 		const L3DMesh& mesh = Game::instance()->GetMeshPack().GetMesh(static_cast<uint32_t>(meshId));
-		mesh.Submit(viewId, renderCtx.instanceUniformBuffer, placers.offset, placers.count, *objectShaderInstanced, state);
+		if (mesh.IsBoned())
+		{
+			mesh.Submit(viewId, renderCtx.instanceUniformBuffer, placers.offset, placers.count, mesh.GetBoneMatrices().data(), mesh.GetBoneMatrices().size(), *objectShaderInstanced, state);
+		}
+		else
+		{
+			const auto identity = glm::mat4(1.0f);
+			mesh.Submit(viewId, renderCtx.instanceUniformBuffer, placers.offset, placers.count, &identity, 1, *objectShaderInstanced, state);
+		}
 	}
 
 	if (viewId == graphics::RenderPass::Main)

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -76,7 +76,7 @@ Game::~Game()
 {
 	_water.reset();
 	_sky.reset();
-	// _testModel.reset();
+	_testModel.reset();
 	_meshPack.reset();
 	_landIsland.reset();
 	_entityRegistry.reset();
@@ -248,8 +248,8 @@ void Game::Run()
 	_meshPack = std::make_unique<MeshPack>();
 	_meshPack->LoadFromFile("Data/AllMeshes.g3d");
 
-	// _testModel = std::make_unique<L3DMesh>();
-	// _testModel->LoadFromFile("Data/CreatureMesh/C_Tortoise_Base.l3d");
+	_testModel = std::make_unique<L3DMesh>();
+	_testModel->LoadFromFile("Data/CreatureMesh/C_Tortoise_Base.l3d");
 
 	_sky = std::make_unique<Sky>();
 	_water = std::make_unique<Water>();
@@ -291,6 +291,8 @@ void Game::Run()
 			    /*island =*/*_landIsland,
 			    /*drawEntities =*/_config.drawEntities,
 			    /*entities =*/*_entityRegistry,
+			    /*drawTestModel =*/_config.drawEntities,
+			    /*testModel =*/*_testModel,
 			    /*drawDebugCross =*/_config.drawDebugCross,
 			    /*drawBoundingBoxes =*/_config.drawBoundingBoxes,
 			    /*cullBack =*/false,

--- a/src/Game.h
+++ b/src/Game.h
@@ -72,6 +72,7 @@ public:
 		bool drawWater {true};
 		bool drawIsland {true};
 		bool drawEntities {true};
+		bool drawTestModel {true};
 		bool drawDebugCross {true};
 		bool drawBoundingBoxes {false};
 		bool drawStreams {false};
@@ -110,7 +111,7 @@ public:
 	[[nodiscard]] Water& GetWater() const { return *_water; }
 	LandIsland& GetLandIsland() { return *_landIsland; }
 	[[nodiscard]] LandIsland& GetLandIsland() const { return *_landIsland; }
-	// [[nodiscard]] L3DMesh& GetTestModel() const { return *_testModel; }
+	[[nodiscard]] L3DMesh& GetTestModel() const { return *_testModel; }
 	MeshPack& GetMeshPack() { return *_meshPack; }
 	[[nodiscard]] const LHVM::LHVM* GetLhvm() { return _lhvm.get(); }
 	FileSystem& GetFileSystem() { return *_fileSystem; }
@@ -138,7 +139,7 @@ private:
 	std::unique_ptr<LandIsland> _landIsland;
 	std::unique_ptr<MeshPack> _meshPack;
 
-	// std::unique_ptr<L3DMesh> _testModel;
+	std::unique_ptr<L3DMesh> _testModel;
 	std::unique_ptr<Sky> _sky;
 	std::unique_ptr<Water> _water;
 	std::unique_ptr<lhscriptx::Script> _scriptx;

--- a/src/Gui.cpp
+++ b/src/Gui.cpp
@@ -767,6 +767,8 @@ void Gui::ShowProfilerWindow(Game& game)
 		ImGui::NextColumn();
 		ImGui::Checkbox("Entities", &game.GetConfig().drawEntities);
 		ImGui::NextColumn();
+		ImGui::Checkbox("TestModel", &game.GetConfig().drawTestModel);
+		ImGui::NextColumn();
 		ImGui::Checkbox("Debug Cross", &game.GetConfig().drawDebugCross);
 		ImGui::Columns(1);
 

--- a/src/MeshViewer.cpp
+++ b/src/MeshViewer.cpp
@@ -182,7 +182,16 @@ void MeshViewer::DrawScene()
 	const auto& mesh = meshes[static_cast<int>(_selectedMesh)];
 	if (_selectedSubMesh >= 0 && static_cast<uint32_t>(_selectedSubMesh) < mesh->GetSubMeshes().size())
 	{
-		mesh->Draw(_viewId, glm::mat4(1.0f), *objectShader, _selectedSubMesh, state);
+		if (mesh->IsBoned())
+		{
+			mesh->Submit(_viewId, mesh->GetBoneMatrices().data(), mesh->GetBoneMatrices().size(), *objectShader,
+			             _selectedSubMesh, state);
+		}
+		else
+		{
+			const auto identity = glm::mat4(1.0f);
+			mesh->Submit(_viewId, &identity, 1, *objectShader, _selectedSubMesh, state);
+		}
 		if (_viewBoundingBox)
 		{
 			auto box = mesh->GetSubMeshes()[_selectedSubMesh]->GetBoundingBox();

--- a/src/MeshViewer.cpp
+++ b/src/MeshViewer.cpp
@@ -182,16 +182,19 @@ void MeshViewer::DrawScene()
 	const auto& mesh = meshes[static_cast<int>(_selectedMesh)];
 	if (_selectedSubMesh >= 0 && static_cast<uint32_t>(_selectedSubMesh) < mesh->GetSubMeshes().size())
 	{
+		const auto identity = glm::mat4(1.0f);
+		L3DMeshSubmitDesc desc = {};
+		desc.viewId = _viewId;
+		desc.program = objectShader;
+		desc.state = state;
+		desc.modelMatrices = &identity;
+		desc.matrixCount = 1;
 		if (mesh->IsBoned())
 		{
-			mesh->Submit(_viewId, mesh->GetBoneMatrices().data(), mesh->GetBoneMatrices().size(), *objectShader,
-			             _selectedSubMesh, state);
+			desc.modelMatrices = mesh->GetBoneMatrices().data();
+			desc.matrixCount = mesh->GetBoneMatrices().size();
 		}
-		else
-		{
-			const auto identity = glm::mat4(1.0f);
-			mesh->Submit(_viewId, &identity, 1, *objectShader, _selectedSubMesh, state);
-		}
+		mesh->Submit(desc, _selectedSubMesh);
 		if (_viewBoundingBox)
 		{
 			auto box = mesh->GetSubMeshes()[_selectedSubMesh]->GetBoundingBox();

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -243,17 +243,20 @@ void Renderer::DrawPass(const DrawSceneDesc& desc) const
 
 		if (desc.drawTestModel)
 		{
-			auto shader = _shaderManager->GetShader("Object");
+			L3DMeshSubmitDesc submitDesc = {};
+			submitDesc.viewId = desc.viewId;
+			submitDesc.program = _shaderManager->GetShader("Object");
 			// clang-format off
-			uint64_t state = 0u
-			    | BGFX_STATE_WRITE_MASK
-			    | BGFX_STATE_DEPTH_TEST_LESS
-			    | BGFX_STATE_CULL_CCW
-			    | BGFX_STATE_MSAA
+			submitDesc.state = 0u
+				| BGFX_STATE_WRITE_MASK
+				| BGFX_STATE_DEPTH_TEST_LESS
+				| BGFX_STATE_CULL_CCW
+				| BGFX_STATE_MSAA
 			;
 			// clang-format on
-			desc.testModel.Submit(desc.viewId, desc.testModel.GetBoneMatrices().data(), desc.testModel.GetBoneMatrices().size(),
-			                      *shader, 0, state);
+			submitDesc.modelMatrices = desc.testModel.GetBoneMatrices().data();
+			submitDesc.matrixCount = static_cast<uint8_t>(desc.testModel.GetBoneMatrices().size());
+			desc.testModel.Submit(submitDesc, 0);
 		}
 	}
 

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -240,6 +240,21 @@ void Renderer::DrawPass(const DrawSceneDesc& desc) const
 		{
 			desc.entities.DrawModels(desc.viewId, *_shaderManager);
 		}
+
+		if (desc.drawTestModel)
+		{
+			auto shader = _shaderManager->GetShader("Object");
+			// clang-format off
+			uint64_t state = 0u
+			    | BGFX_STATE_WRITE_MASK
+			    | BGFX_STATE_DEPTH_TEST_LESS
+			    | BGFX_STATE_CULL_CCW
+			    | BGFX_STATE_MSAA
+			;
+			// clang-format on
+			desc.testModel.Submit(desc.viewId, desc.testModel.GetBoneMatrices().data(), desc.testModel.GetBoneMatrices().size(),
+			                      *shader, 0, state);
+		}
 	}
 
 	{

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -28,6 +28,7 @@ struct BgfxCallback;
 class Camera;
 class GameWindow;
 class Game;
+class L3DMesh;
 class LandIsland;
 class Profiler;
 class Sky;
@@ -91,6 +92,8 @@ public:
 		const LandIsland& island;
 		bool drawEntities;
 		const entities::Registry& entities;
+		bool drawTestModel;
+		const L3DMesh& testModel;
 		bool drawDebugCross;
 		bool drawBoundingBoxes;
 		bool cullBack;


### PR DESCRIPTION
Improved the representation of boned meshes by using the vertex groups in L3D file.
Updated the object shader (not the instanced one) to use default pose as model matrices.

The vertex blending is still not implemented.
~~The instanced drawing does not use the bones matrices yet.~~
The concept of states of animation is not yet done. I would like to avoid putting that in the mesh as
as mesh is not a game object. There should only be one instance of a type of mesh regardless of the number of instances drawn. The same mesh should be drawn several times with different matrix values.
Updates to root position is not implemented in single mesh drawin. This means no animation and the test creature will be centered at 0 coordinate. This can be fixed by offsetting all bone indices by one.

I added back the test model with options to disable it.
![Screenshot from 2020-02-07 22-08-23](https://user-images.githubusercontent.com/1013356/74067383-6ea1c000-49f9-11ea-8720-68a7021f7566.png)

The boned models are all viewable from the mesh viewer.
![Screenshot from 2020-02-07 21-45-55](https://user-images.githubusercontent.com/1013356/74067412-80836300-49f9-11ea-8085-bbea955d8d5f.png)
![Screenshot from 2020-02-07 21-46-57](https://user-images.githubusercontent.com/1013356/74067413-811bf980-49f9-11ea-81f3-637d4d9a922b.png)
![Screenshot from 2020-02-07 21-48-08](https://user-images.githubusercontent.com/1013356/74067415-81b49000-49f9-11ea-96fb-43a6065f0595.png)
![Screenshot from 2020-02-10 10-54-21](https://user-images.githubusercontent.com/1013356/74144083-62d21b80-4bfc-11ea-8670-b3eed764b9e4.png)
