### PR TITLE
Fix union braces

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -19,7 +19,18 @@ AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: true
 BinPackParameters: true
-BreakBeforeBraces: Allman
+BraceWrapping:
+    AfterCaseLabel: true
+    AfterClass: true
+    AfterControlStatement: true
+    AfterEnum: true
+    AfterFunction: true
+    AfterNamespace: true
+    AfterStruct: true
+    AfterUnion: true
+    BeforeCatch: true
+    BeforeElse: true
+BreakBeforeBraces: Custom
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: BeforeComma
 BreakInheritanceList: AfterColon

--- a/apps/lndtool/lndtool.cpp
+++ b/apps/lndtool/lndtool.cpp
@@ -135,10 +135,10 @@ int PrintBlocks(openblack::lnd::LNDFile& lnd)
 		};
 		for (auto& cell : block.cells)
 		{
-			std::printf(
-			    "    %u: r %u, g %u, b %u, luminosity %u, altitude %u, saveColor %u, country %u properties %s flags 0x%02X\n",
-			    j++, cell.r, cell.g, cell.b, cell.luminosity, cell.altitude, cell.saveColor, cell.properties.country,
-			    flagToStr(cell.properties).c_str(), cell.flags);
+			std::printf("    %u: r %u, g %u, b %u, luminosity %u, altitude %u, saveColor %u, country %u properties %s "
+			            "flags 0x%02X\n",
+			            j++, cell.r, cell.g, cell.b, cell.luminosity, cell.altitude, cell.saveColor, cell.properties.country,
+			            flagToStr(cell.properties).c_str(), cell.flags);
 		}
 		std::printf("index: %u\n", block.index);
 		std::printf("mapX: %f\n", block.mapX);


### PR DESCRIPTION
There is an inconsistency between the clang-format on my machine and the ci.

My clang format will try to fix the braces as such:
```diff
  // clang-format version 9.0.1
-       union
-       {
+       union {
```