### PR TITLE
Formatting and clean-up with clang tidy tests

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
 ---
 Checks: >-
   -*,
+  clang-analyzer-*,
   modernize-*,
   -modernize-use-equals-default,
   -modernize-use-trailing-return-type,

--- a/.github/workflows/ci-vcpkg.yml
+++ b/.github/workflows/ci-vcpkg.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Linux dependencies
         run: |
           sudo apt update -y
-          sudo apt install -y libgl1-mesa-dev libglu1-mesa-dev
+          sudo apt install -y libgl1-mesa-dev libglu1-mesa-dev clang-tidy
         if: matrix.os == 'ubuntu-latest'
 
       - name: Set GCC 10
@@ -80,6 +80,17 @@ jobs:
         env:
           CC: ${{matrix.cc}}
           CXX: ${{matrix.cxx}}
+
+      - name: Create compile_commands.json
+        run: cmake . -B cmake-build-tidy --preset=ninja-multi-vcpkg -DCMAKE_EXPORT_COMPILE_COMMANDS=On
+        if: matrix.os == 'ubuntu-latest'
+
+      - name: Run clang-tidy
+        uses: ZedThree/clang-tidy-review@v0.8.3
+        id: review
+        with:
+          build_dir: cmake-build-tidy
+        if: matrix.cc == 'ubuntu-latest'
 
       - name: Upload compiled openblack and tools
         uses: actions/upload-artifact@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 
 option(OPENBLACK_WARNINGS_AS_ERRORS "Treat warnings as errors (disable easier prototyping, enable for CI)" OFF)
 
+find_program(CLANG_TIDY NAMES clang-tidy-7 clang-tidy-6.0 clang-tidy-5.0 clang-tidy-4.0 clang-tidy)
+
 # Special case for SDL2 dependency, goal is to find a config that exports SDL2::SDL2 target
 # libsdl2-dev has a `sdl2-config.cmake` that doesn't export this, but vcpkg does..
 find_package(SDL2 CONFIG QUIET)

--- a/apps/anmtool/CMakeLists.txt
+++ b/apps/anmtool/CMakeLists.txt
@@ -6,7 +6,6 @@ set(ANMTOOL
 
 source_group(apps\\anmtool FILES ${ANMTOOL})
 
-# set(CMAKE_CXX_CLANG_TIDY clang-tidy -checks=-*,readability-*)
 add_executable(anmtool ${ANMTOOL})
 
 target_link_libraries(anmtool
@@ -14,6 +13,11 @@ target_link_libraries(anmtool
 		cxxopts::cxxopts
 		anm
 )
+
+# FIXME(bwrsandman) MSVC is throwing false errors about exceptions being disabled
+if (NOT MSVC AND CLANG_TIDY)
+	set_target_properties(anmtool PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
+endif()
 
 if(MSVC)
 	target_compile_options(anmtool PRIVATE /W4 /WX)

--- a/apps/anmtool/anmtool.cpp
+++ b/apps/anmtool/anmtool.cpp
@@ -119,8 +119,8 @@ int WriteFile(const Arguments::Write& args)
 	std::string warn;
 
 	// TODO (bwrsandman): Extract animation from gltf
-	char name[] = "TODO";
-	memcpy(anm.GetHeader().name, name, sizeof(name));
+	const std::string name = "TODO";
+	memcpy(anm.GetHeader().name, name.c_str(), std::min(sizeof(anm.GetHeader().name), name.length()));
 	anm.GetHeader().frame_count = 0;
 	anm.GetHeader().animation_duration = 0;
 	anm.Write(args.outFilename);

--- a/apps/l3dtool/CMakeLists.txt
+++ b/apps/l3dtool/CMakeLists.txt
@@ -6,7 +6,6 @@ set(L3DTOOL
 
 source_group(apps\\l3dtool FILES ${L3DTOOL})
 
-# set(CMAKE_CXX_CLANG_TIDY clang-tidy -checks=-*,readability-*)
 add_executable(l3dtool ${L3DTOOL})
 
 target_link_libraries(l3dtool
@@ -14,6 +13,11 @@ target_link_libraries(l3dtool
 		cxxopts::cxxopts
 		l3d
 )
+
+# FIXME(bwrsandman) MSVC is throwing false errors about exceptions being disabled
+if (NOT MSVC AND CLANG_TIDY)
+	set_target_properties(l3dtool PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
+endif()
 
 if(MSVC)
 	target_compile_options(l3dtool PRIVATE /W4 /WX)

--- a/apps/l3dtool/l3dtool.cpp
+++ b/apps/l3dtool/l3dtool.cpp
@@ -636,9 +636,9 @@ int WriteFile(const Arguments::Write& args)
 				std::function<void(const std::vector<int>&, uint32_t parent)> buildJoints;
 				buildJoints = [&gltf, &bones, &buildJoints](const std::vector<int>& children, uint32_t parentId) {
 					openblack::l3d::L3DBone* leftSibbling = nullptr;
-					for (uint32_t i = 0; i < children.size(); ++i)
+					for (const auto& child : children)
 					{
-						auto& gltfJoint = gltf.nodes[children[i]];
+						auto& gltfJoint = gltf.nodes[child];
 
 						auto id = static_cast<uint32_t>(bones.size());
 						bones.emplace_back();
@@ -710,11 +710,11 @@ int WriteFile(const Arguments::Write& args)
 				std::vector<float> values;
 				uint8_t type;
 			};
-			attribute_t attributes[3] = {
+			std::array<attribute_t, 3> attributes = {{
 			    {"POSITION", {}, 0},
 			    {"TEXCOORD_0", {}, 0},
 			    {"NORMAL", {}, 0},
-			};
+			}};
 			uint32_t count = 0;
 			for (auto& attribute : attributes)
 			{

--- a/apps/lndtool/CMakeLists.txt
+++ b/apps/lndtool/CMakeLists.txt
@@ -4,7 +4,6 @@ set(LNDTOOL
 
 source_group(apps\\lndtool FILES ${LNDTOOL})
 
-# set(CMAKE_CXX_CLANG_TIDY clang-tidy -checks=-*,readability-*)
 add_executable(lndtool ${LNDTOOL})
 
 target_link_libraries(lndtool
@@ -12,6 +11,11 @@ target_link_libraries(lndtool
 		cxxopts::cxxopts
 		lnd
 )
+
+# FIXME(bwrsandman) MSVC is throwing false errors about exceptions being disabled
+if (NOT MSVC AND CLANG_TIDY)
+	set_target_properties(lndtool PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
+endif()
 
 if(MSVC)
 	target_compile_options(lndtool PRIVATE /W4 /WX)

--- a/apps/morphtool/CMakeLists.txt
+++ b/apps/morphtool/CMakeLists.txt
@@ -4,7 +4,6 @@ set(MORPHTOOL
 
 source_group(apps\\morphtool FILES ${MORPHTOOL})
 
-# set(CMAKE_CXX_CLANG_TIDY clang-tidy -checks=-*,readability-*)
 add_executable(morphtool ${MORPHTOOL})
 
 target_link_libraries(morphtool
@@ -12,6 +11,11 @@ target_link_libraries(morphtool
 		cxxopts::cxxopts
 		morph
 )
+
+# FIXME(bwrsandman) MSVC is throwing false errors about exceptions being disabled
+if (NOT MSVC AND CLANG_TIDY)
+	set_target_properties(morphtool PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
+endif()
 
 if(MSVC)
 	target_compile_options(morphtool PRIVATE /W4 /WX)

--- a/apps/packtool/CMakeLists.txt
+++ b/apps/packtool/CMakeLists.txt
@@ -4,7 +4,6 @@ set(PACKTOOL
 
 source_group(apps\\packtool FILES ${PACKTOOL})
 
-# set(CMAKE_CXX_CLANG_TIDY clang-tidy -checks=-*,readability-*)
 add_executable(packtool ${PACKTOOL})
 
 target_link_libraries(packtool
@@ -12,6 +11,11 @@ target_link_libraries(packtool
 		cxxopts::cxxopts
 		pack
 )
+
+# FIXME(bwrsandman) MSVC is throwing false errors about exceptions being disabled
+if (NOT MSVC AND CLANG_TIDY)
+	set_target_properties(packtool PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
+endif()
 
 if(MSVC)
 	target_compile_options(packtool PRIVATE /W4 /WX)

--- a/components/anm/CMakeLists.txt
+++ b/components/anm/CMakeLists.txt
@@ -1,13 +1,19 @@
 file(GLOB SOURCES "${CMAKE_CURRENT_LIST_DIR}/src/*.cpp")
 file(GLOB HEADERS "${CMAKE_CURRENT_LIST_DIR}/include/*.h")
 
-# set(CMAKE_CXX_CLANG_TIDY clang-tidy -checks=-*,readability-*)
 add_library(anm STATIC ${SOURCES} ${HEADERS})
+
 target_include_directories(anm
 	PUBLIC
 		$<INSTALL_INTERFACE:include>
 		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
+
+# FIXME(bwrsandman) MSVC is throwing false errors about exceptions being disabled
+if (NOT MSVC AND CLANG_TIDY)
+	set_target_properties(anm PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
+endif()
+
 if(MSVC)
 	target_compile_options(anm PRIVATE /W4 /WX)
 else()

--- a/components/l3d/CMakeLists.txt
+++ b/components/l3d/CMakeLists.txt
@@ -1,13 +1,19 @@
 file(GLOB SOURCES "${CMAKE_CURRENT_LIST_DIR}/src/*.cpp")
 file(GLOB HEADERS "${CMAKE_CURRENT_LIST_DIR}/include/*.h")
 
-# set(CMAKE_CXX_CLANG_TIDY clang-tidy -checks=-*,readability-*)
 add_library(l3d STATIC ${SOURCES} ${HEADERS})
+
 target_include_directories(l3d
 	PUBLIC
 		$<INSTALL_INTERFACE:include>
 		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
+
+# FIXME(bwrsandman) MSVC is throwing false errors about exceptions being disabled
+if (NOT MSVC AND CLANG_TIDY)
+	set_target_properties(l3d PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
+endif()
+
 if(MSVC)
 	target_compile_options(l3d PRIVATE /W4 /WX)
 else()

--- a/components/l3d/src/L3DFile.cpp
+++ b/components/l3d/src/L3DFile.cpp
@@ -680,7 +680,7 @@ void L3DFile::Write(const std::filesystem::path& filepath)
 	_header.skinOffsetsOffset = _header.skinCount > 0 ? static_cast<uint32_t>(offset) : std::numeric_limits<uint32_t>::max();
 	offset += _header.skinCount * sizeof(uint32_t);
 	_header.extraDataOffset = _header.extraDataCount > 0 ? static_cast<uint32_t>(offset) : std::numeric_limits<uint32_t>::max();
-	offset += _header.extraDataCount * sizeof(_extraPoints[0]);
+	// offset += _header.extraDataCount * sizeof(_extraPoints[0]);
 	_header.footprintDataOffset = std::numeric_limits<uint32_t>::max();
 
 	size_t submeshOffsetsBase = sizeof(L3DHeader);

--- a/components/lnd/CMakeLists.txt
+++ b/components/lnd/CMakeLists.txt
@@ -1,13 +1,19 @@
 file(GLOB SOURCES "${CMAKE_CURRENT_LIST_DIR}/src/*.cpp")
 file(GLOB HEADERS "${CMAKE_CURRENT_LIST_DIR}/include/*.h")
 
-# set(CMAKE_CXX_CLANG_TIDY clang-tidy -checks=-*,readability-*)
 add_library(lnd STATIC ${SOURCES} ${HEADERS})
+
 target_include_directories(lnd
 	PUBLIC
 		$<INSTALL_INTERFACE:include>
 		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
+
+# FIXME(bwrsandman) MSVC is throwing false errors about exceptions being disabled
+if (NOT MSVC AND CLANG_TIDY)
+	set_target_properties(lnd PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
+endif()
+
 if(MSVC)
 	target_compile_options(lnd PRIVATE /W4 /WX)
 else()

--- a/components/morph/CMakeLists.txt
+++ b/components/morph/CMakeLists.txt
@@ -1,13 +1,19 @@
 file(GLOB SOURCES "${CMAKE_CURRENT_LIST_DIR}/src/*.cpp")
 file(GLOB HEADERS "${CMAKE_CURRENT_LIST_DIR}/include/*.h")
 
-# set(CMAKE_CXX_CLANG_TIDY clang-tidy -checks=-*,readability-*)
 add_library(morph STATIC ${SOURCES} ${HEADERS})
+
 target_include_directories(morph
 	PUBLIC
 		$<INSTALL_INTERFACE:include>
 		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
+
+# FIXME(bwrsandman) MSVC is throwing false errors about exceptions being disabled
+if (NOT MSVC AND CLANG_TIDY)
+	set_target_properties(morph PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
+endif()
+
 if(MSVC)
 	target_compile_options(morph PRIVATE /W4 /WX)
 else()

--- a/components/pack/CMakeLists.txt
+++ b/components/pack/CMakeLists.txt
@@ -1,13 +1,19 @@
 file(GLOB SOURCES "${CMAKE_CURRENT_LIST_DIR}/src/*.cpp")
 file(GLOB HEADERS "${CMAKE_CURRENT_LIST_DIR}/include/*.h")
 
-# set(CMAKE_CXX_CLANG_TIDY clang-tidy -checks=-*,readability-*)
 add_library(pack STATIC ${SOURCES} ${HEADERS})
+
 target_include_directories(pack
 	PUBLIC
 		$<INSTALL_INTERFACE:include>
 		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
+
+# FIXME(bwrsandman) MSVC is throwing false errors about exceptions being disabled
+if (NOT MSVC AND CLANG_TIDY)
+	set_target_properties(pack PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
+endif()
+
 if(MSVC)
 	target_compile_options(pack PRIVATE /W4 /WX)
 else()

--- a/components/pack/include/PackFile.h
+++ b/components/pack/include/PackFile.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <array>
 #include <filesystem>
 #include <istream>
 #include <map>
@@ -91,7 +92,7 @@ struct G3DTexture
 class PackFile
 {
 protected:
-	static constexpr const char kMagic[8] = {'L', 'i', 'O', 'n', 'H', 'e', 'A', 'd'};
+	static constexpr const std::array<char, 8> kMagic = {'L', 'i', 'O', 'n', 'H', 'e', 'A', 'd'};
 
 	/// True when a file has been loaded
 	bool _isLoaded;

--- a/src/3D/Camera.cpp
+++ b/src/3D/Camera.cpp
@@ -532,7 +532,7 @@ void Camera::handleMouseInput(const SDL_Event& e)
 void Camera::Update(std::chrono::microseconds dt)
 {
 	auto airResistance = .92f; // reduced to make more floaty
-	float fdt = float(dt.count());
+	auto fdt = static_cast<float>(dt.count());
 	glm::mat3 rotation = glm::transpose(GetViewMatrix());
 
 	// deal with hand pulling camera around
@@ -560,7 +560,7 @@ void Camera::Update(std::chrono::microseconds dt)
 			glm::ivec2 mousePosition;
 
 			SDL_GetMouseState(&mousePosition.x, &mousePosition.y);
-			glm::ivec2 handScreenCoords = glm::ivec2(handToScreen);
+			auto handScreenCoords = glm::ivec2(handToScreen);
 			handScreenCoords.y = sHeight - handScreenCoords.y;
 			_handScreenVec = mousePosition - handScreenCoords;
 			_handDragMult = glm::length(glm::vec2(_handScreenVec));

--- a/src/3D/L3DMesh.cpp
+++ b/src/3D/L3DMesh.cpp
@@ -24,9 +24,9 @@
 using namespace openblack;
 using namespace openblack::graphics;
 
-L3DMesh::L3DMesh(const std::string& debugName)
+L3DMesh::L3DMesh(std::string debugName)
     : _flags(static_cast<l3d::L3DMeshFlags>(0))
-    , _debugName(debugName)
+    , _debugName(std::move(debugName))
     , _physicsMass(1.0f) // TODO(bwrsandman): Find somewhere in file a value
     , _boundingBox {glm::vec3(FLT_MAX, FLT_MAX, FLT_MAX), glm::vec3(-FLT_MAX, -FLT_MAX, -FLT_MAX)}
 {

--- a/src/3D/L3DMesh.h
+++ b/src/3D/L3DMesh.h
@@ -76,7 +76,7 @@ inline l3d::L3DMeshFlags operator&(l3d::L3DMeshFlags a, l3d::L3DMeshFlags b)
 class L3DMesh
 {
 public:
-	L3DMesh(const std::string& debugName = "");
+	L3DMesh(std::string debugName = "");
 	virtual ~L3DMesh();
 
 	void Load(const l3d::L3DFile& l3d);

--- a/src/3D/L3DSubMesh.cpp
+++ b/src/3D/L3DSubMesh.cpp
@@ -174,10 +174,10 @@ bool L3DSubMesh::Load(const l3d::L3DFile& l3d, uint32_t meshIndex)
 		        {false, true, L3DSubMesh::Primitive::BlendMode::Additive, true, true},    // AlphaTexturedAlphaAdditiveChromaNz
 		        {true, false, L3DSubMesh::Primitive::BlendMode::Additive, true, false},   // AlphaTexturedAlphaAdditive
 		        {false, false, L3DSubMesh::Primitive::BlendMode::Additive, true, false},  // AlphaTexturedAlphaAdditiveNz
-		        {0, 0, L3DSubMesh::Primitive::BlendMode::Disabled, 0, 0},                 // 0xe
+		        {false, false, L3DSubMesh::Primitive::BlendMode::Disabled, false, false}, // 0xe
 		        {true, true, L3DSubMesh::Primitive::BlendMode::Standard, true, true},     // TexturedChromaAlpha
 		        {false, true, L3DSubMesh::Primitive::BlendMode::Standard, true, true},    // TexturedChromaAlphaNz
-		        {0, 0, L3DSubMesh::Primitive::BlendMode::Disabled, 0, 0},                 // 0x11
+		        {false, false, L3DSubMesh::Primitive::BlendMode::Disabled, false, false}, // 0x11
 		        {true, true, L3DSubMesh::Primitive::BlendMode::Standard, false, true},    // ChromaJustZ
 		    }};
 

--- a/src/3D/LandBlock.h
+++ b/src/3D/LandBlock.h
@@ -11,6 +11,8 @@
 
 #include <cstdint>
 
+#include <array>
+
 #include <glm/fwd.hpp>
 
 #include "Graphics/Mesh.h"
@@ -39,8 +41,8 @@ struct LandVertex
 	uint8_t lightLevel[4];               // aligned to 4 bytes
 	float waterAlpha;
 
-	LandVertex(const glm::vec3& _position, const glm::vec3& _weight, uint32_t mat[6], uint32_t blend[3], uint8_t _lightLevel,
-	           float _alpha);
+	LandVertex(const glm::vec3& _position, const glm::vec3& _weight, const std::array<uint32_t, 6>& mat,
+	           const std::array<uint32_t, 3>& blend, uint8_t _lightLevel, float _alpha);
 };
 
 class LandIsland;

--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -160,10 +160,8 @@ void LandIsland::DumpMaps() const
 
 	memset(data, 0x00, 32 * 32 * cellsize * cellsize);
 
-	for (unsigned int b = 0; b < _landBlocks.size(); b++)
+	for (const auto& block : _landBlocks)
 	{
-		const LandBlock& block = _landBlocks[b];
-
 		int mapx = block.GetBlockPosition().x;
 		int mapz = block.GetBlockPosition().y;
 		int lineStride = 32 * cellsize;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -119,6 +119,11 @@ target_link_libraries(
     spdlog::spdlog
 )
 
+# FIXME(bwrsandman) MSVC is throwing false errors about exceptions being disabled
+if (NOT MSVC AND CLANG_TIDY)
+	set_target_properties(openblack_lib PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
+endif()
+
 if(ANDROID)
   target_link_libraries(openblack_lib PRIVATE EGL)
 elseif (UNIX)

--- a/src/Common/FileStream.cpp
+++ b/src/Common/FileStream.cpp
@@ -34,6 +34,7 @@ FileStream::FileStream(const std::filesystem::path& path, FileMode mode)
 		break;
 	case FileMode::Append:
 		recognisedMode = L"ab";
+		break;
 	}
 
 #ifdef _WIN32

--- a/src/Common/FileStream.h
+++ b/src/Common/FileStream.h
@@ -23,7 +23,7 @@ enum class FileMode
 	Append
 };
 
-class FileStream: public IStream
+class FileStream final: public IStream
 {
 public:
 	FileStream(const std::filesystem::path& filename, FileMode mode);

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -195,8 +195,8 @@ bool Game::ProcessEvents(const SDL_Event& event)
 		}
 		else if (event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED)
 		{
-			uint16_t width = static_cast<uint16_t>(event.window.data1);
-			uint16_t height = static_cast<uint16_t>(event.window.data2);
+			const auto width = static_cast<uint16_t>(event.window.data1);
+			const auto height = static_cast<uint16_t>(event.window.data2);
 			_renderer->Reset(width, height);
 			_renderer->ConfigureView(graphics::RenderPass::Main, width, height);
 

--- a/src/Graphics/ShaderManager.cpp
+++ b/src/Graphics/ShaderManager.cpp
@@ -79,16 +79,16 @@ struct ShaderDefinition
 	const std::string_view fragmentShaderName;
 };
 
-const bgfx::EmbeddedShader s_embeddedShaders[] = {
-    BGFX_EMBEDDED_SHADER(vs_line),    BGFX_EMBEDDED_SHADER(vs_line_instanced),   //
-    BGFX_EMBEDDED_SHADER(fs_line),                                               //
-    BGFX_EMBEDDED_SHADER(vs_object),  BGFX_EMBEDDED_SHADER(vs_object_instanced), //
-    BGFX_EMBEDDED_SHADER(fs_object),  BGFX_EMBEDDED_SHADER(fs_sky),              //
-    BGFX_EMBEDDED_SHADER(vs_terrain), BGFX_EMBEDDED_SHADER(fs_terrain),          //
-    BGFX_EMBEDDED_SHADER(vs_water),   BGFX_EMBEDDED_SHADER(fs_water),            //
-    BGFX_EMBEDDED_SHADER(vs_sprite),  BGFX_EMBEDDED_SHADER(fs_sprite),           //
-    BGFX_EMBEDDED_SHADER_END()                                                   //
-};
+const std::array<bgfx::EmbeddedShader, 14> s_embeddedShaders = {{
+    BGFX_EMBEDDED_SHADER(vs_line), BGFX_EMBEDDED_SHADER(vs_line_instanced),     //
+    BGFX_EMBEDDED_SHADER(fs_line),                                              //
+    BGFX_EMBEDDED_SHADER(vs_object), BGFX_EMBEDDED_SHADER(vs_object_instanced), //
+    BGFX_EMBEDDED_SHADER(fs_object), BGFX_EMBEDDED_SHADER(fs_sky),              //
+    BGFX_EMBEDDED_SHADER(vs_terrain), BGFX_EMBEDDED_SHADER(fs_terrain),         //
+    BGFX_EMBEDDED_SHADER(vs_water), BGFX_EMBEDDED_SHADER(fs_water),             //
+    BGFX_EMBEDDED_SHADER(vs_sprite), BGFX_EMBEDDED_SHADER(fs_sprite),           //
+    BGFX_EMBEDDED_SHADER_END()                                                  //
+}};
 
 constexpr std::array Shaders {
     ShaderDefinition {"DebugLine", "vs_line", "fs_line"},
@@ -115,9 +115,9 @@ void ShaderManager::LoadShaders()
 	for (const auto& shader : Shaders)
 	{
 		bgfx::RendererType::Enum type = bgfx::getRendererType();
-		auto vs = bgfx::createEmbeddedShader(s_embeddedShaders, type, shader.vertexShaderName.data());
+		auto vs = bgfx::createEmbeddedShader(s_embeddedShaders.data(), type, shader.vertexShaderName.data());
 		assert(bgfx::isValid(vs));
-		auto fs = bgfx::createEmbeddedShader(s_embeddedShaders, type, shader.fragmentShaderName.data());
+		auto fs = bgfx::createEmbeddedShader(s_embeddedShaders.data(), type, shader.fragmentShaderName.data());
 		assert(bgfx::isValid(fs));
 		_shaderPrograms[shader.name.data()] = new ShaderProgram(shader.name.data(), std::move(vs), std::move(fs));
 	}

--- a/src/Gui/Console.cpp
+++ b/src/Gui/Console.cpp
@@ -354,7 +354,7 @@ void Console::Draw(Game& game)
 		if (s[0])
 			ExecCommand(s, game);
 
-		strcpy(_input_buffer.data(), "");
+		_input_buffer[0] = '\0';
 
 		_reclaim_focus = true;
 	}

--- a/src/Gui/Gui.cpp
+++ b/src/Gui/Gui.cpp
@@ -78,14 +78,14 @@ using namespace openblack::gui;
 
 namespace
 {
-const bgfx::EmbeddedShader s_embeddedShaders[] = {
+const std::array<bgfx::EmbeddedShader, 5> s_embeddedShaders = {{
     BGFX_EMBEDDED_SHADER(vs_ocornut_imgui),
     BGFX_EMBEDDED_SHADER(fs_ocornut_imgui),
     BGFX_EMBEDDED_SHADER(vs_imgui_image),
     BGFX_EMBEDDED_SHADER(fs_imgui_image),
 
     BGFX_EMBEDDED_SHADER_END(),
-};
+}};
 } // namespace
 
 std::unique_ptr<Gui> Gui::create(const GameWindow* window, graphics::RenderPass viewId, float scale)
@@ -324,10 +324,10 @@ bool Gui::CreateDeviceObjectsBgfx()
 {
 	// Create shaders
 	bgfx::RendererType::Enum type = bgfx::getRendererType();
-	_program = bgfx::createProgram(bgfx::createEmbeddedShader(s_embeddedShaders, type, "vs_ocornut_imgui"),
-	                               bgfx::createEmbeddedShader(s_embeddedShaders, type, "fs_ocornut_imgui"), true);
-	_imageProgram = bgfx::createProgram(bgfx::createEmbeddedShader(s_embeddedShaders, type, "vs_imgui_image"),
-	                                    bgfx::createEmbeddedShader(s_embeddedShaders, type, "fs_imgui_image"), true);
+	_program = bgfx::createProgram(bgfx::createEmbeddedShader(s_embeddedShaders.data(), type, "vs_ocornut_imgui"),
+	                               bgfx::createEmbeddedShader(s_embeddedShaders.data(), type, "fs_ocornut_imgui"), true);
+	_imageProgram = bgfx::createProgram(bgfx::createEmbeddedShader(s_embeddedShaders.data(), type, "vs_imgui_image"),
+	                                    bgfx::createEmbeddedShader(s_embeddedShaders.data(), type, "fs_imgui_image"), true);
 
 	// Create buffers
 	_u_imageLodEnabled = bgfx::createUniform("u_imageLodEnabled", bgfx::UniformType::Vec4);

--- a/src/Gui/MeshViewer.cpp
+++ b/src/Gui/MeshViewer.cpp
@@ -93,7 +93,7 @@ void MeshViewer::Draw([[maybe_unused]] Game& game)
 
 	auto mesh = meshes.Handle(_selectedMesh);
 
-	static char bitfieldTitle[0x400];
+	static std::array<char, 0x400> bitfieldTitle;
 	{
 		int32_t offset = 0;
 		int32_t newLines = 1;
@@ -101,19 +101,19 @@ void MeshViewer::Draw([[maybe_unused]] Game& game)
 		{
 			if (mesh->GetFlags() & (1u << i))
 			{
-				auto writen = std::sprintf(bitfieldTitle + offset, "%s%s%s", offset ? "|" : "",
-				                           offset > newLines * 100 ? "\n" : "", L3DMeshFlagNames[i].data());
+				auto writen = std::snprintf(bitfieldTitle.data() + offset, bitfieldTitle.size() - offset, "%s%s%s",
+				                            offset ? "|" : "", offset > newLines * 100 ? "\n" : "", L3DMeshFlagNames[i].data());
 				while (offset > newLines * 100) newLines++;
 				offset += writen;
 			}
 		}
 	}
 
-	char meshFlagStr[0x20];
-	std::sprintf(meshFlagStr, "Mesh flag=0x%X", mesh->GetFlags());
-	if (ImGui::TreeNodeEx(meshFlagStr))
+	std::array<char, 0x20> meshFlagStr;
+	std::snprintf(meshFlagStr.data(), meshFlagStr.size(), "Mesh flag=0x%X", mesh->GetFlags());
+	if (ImGui::TreeNodeEx(meshFlagStr.data()))
 	{
-		ImGui::Text("%s", bitfieldTitle);
+		ImGui::Text("%s", bitfieldTitle.data());
 		ImGui::TreePop();
 	}
 

--- a/src/LHScriptX/Script.cpp
+++ b/src/LHScriptX/Script.cpp
@@ -95,13 +95,13 @@ ScriptCommandParameter GetParameter(Token& argument)
 	case Token::Type::EndOfLine:
 		throw std::runtime_error("Unexpected EOL in script");
 	case Token::Type::Identifier:
-		return ScriptCommandParameter(argument.Identifier());
+		return {argument.Identifier()};
 	case Token::Type::String:
-		return ScriptCommandParameter(argument.StringValue());
+		return {argument.StringValue()};
 	case Token::Type::Integer:
-		return ScriptCommandParameter(*argument.IntegerValue());
+		return {*argument.IntegerValue()};
 	case Token::Type::Float:
-		return ScriptCommandParameter(*argument.FloatValue());
+		return {*argument.FloatValue()};
 	case Token::Type::Operator:
 		throw std::runtime_error("Operator token as an argument is currently not supported");
 	default:

--- a/src/LHScriptX/ScriptingBindingUtils.cpp
+++ b/src/LHScriptX/ScriptingBindingUtils.cpp
@@ -20,7 +20,7 @@ glm::vec2 GetHorizontalPosition(const std::string& str)
 	const auto pos = str.find_first_of(',');
 	const auto y = std::stof(str.substr(pos + 1));
 	const auto x = std::stof(str.substr(0, pos));
-	return glm::vec2(x, y);
+	return {x, y};
 }
 
 template <>

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -61,10 +61,10 @@ struct BgfxCallback: public bgfx::CallbackI
 	void traceVargs([[maybe_unused]] const char* filePath, [[maybe_unused]] uint16_t line, const char* format,
 	                va_list argList) override
 	{
-		char temp[0x2000];
-		char* out = temp;
-		int32_t len = vsnprintf(out, sizeof(temp), format, argList);
-		if ((int32_t)sizeof(temp) < len)
+		std::array<char, 0x2000> temp;
+		char* out = temp.data();
+		int32_t len = vsnprintf(out, temp.size(), format, argList);
+		if (static_cast<int32_t>(temp.size()) < len)
 		{
 			out = (char*)alloca(len + 1);
 			len = vsnprintf(out, len, format, argList);


### PR DESCRIPTION
I discovered that we have a `.clang-tidy`. I made sure we enforce it in our tests and added `clang-analyzer-*` too.