### PR TITLE
logging: Add log to file and level options

### DIFF
--- a/azure-pipelines/templates/test-null-renderer.yml
+++ b/azure-pipelines/templates/test-null-renderer.yml
@@ -4,6 +4,6 @@ steps:
   displayName: 'Generate mock game data'
 - bash: |
     cp $PWD/bin/${{ parameters.BuildConfiguration }}/fmtd.dll .
-    bin/${{ parameters.BuildConfiguration }}/openblack --game-path ci/mock --num-frames-to-simulate 1000 --backend-type Noop
+    bin/${{ parameters.BuildConfiguration }}/openblack --game-path ci/mock --num-frames-to-simulate 1000 --backend-type Noop --log-file stdout
   workingDirectory: build
   displayName: 'Test Null Renderer'

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -150,6 +150,8 @@ else()
   endif()
 endif()
 
+target_compile_definitions(openblack PRIVATE "$<$<CONFIG:DEBUG>:OPENBLACK_DEBUG>")
+
 if(MSVC)
   # Debug builds create a debug console
   set_target_properties(openblack PROPERTIES LINK_FLAGS_DEBUG

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -29,6 +29,7 @@
 #include <glm/glm.hpp>
 #include <glm/gtc/type_ptr.hpp>
 #include <glm/gtx/intersect.hpp>
+#include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/spdlog.h>
 
 #include <cstdint>
@@ -53,7 +54,12 @@ Game::Game(Arguments&& args)
     , _frameCount(0)
     , _intersection()
 {
-	spdlog::set_level(spdlog::level::debug);
+	if (!args.logFile.empty() && args.logFile != "stdout")
+	{
+		auto logger = spdlog::basic_logger_mt("default_logger", args.logFile);
+		spdlog::set_default_logger(logger);
+	}
+	spdlog::set_level(static_cast<spdlog::level::level_enum>(spdlog::level::debug + args.logLevel));
 	sInstance = this;
 
 	std::string binaryPath = fs::path {args.executablePath}.parent_path().generic_string();

--- a/src/Game.h
+++ b/src/Game.h
@@ -54,6 +54,8 @@ struct Arguments
 	std::string gamePath;
 	float scale;
 	uint32_t numFramesToSimulate;
+	std::string logFile;
+	uint32_t logLevel;
 };
 
 class Game

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,8 @@ bool parseOptions(int argc, char** argv, openblack::Arguments& args, int& return
 		("m,window-mode", "Which mode to run window.", cxxopts::value<std::string>()->default_value("windowed"))
 		("b,backend-type", "Which backend to use for rendering.", cxxopts::value<std::string>()->default_value("OpenGL"))
 		("n,num-frames-to-simulate", "Number of frames to simulate before quitting.", cxxopts::value<uint32_t>()->default_value("0"))
+		("l,log-file", "Output file for logs, 'stdout' for terminal output.", cxxopts::value<std::string>()->default_value("openblack.log"))
+		("L,log-level", "Level of logging.", cxxopts::value<uint32_t>()->default_value("0"))
 	;
 	// clang-format on
 
@@ -118,6 +120,8 @@ bool parseOptions(int argc, char** argv, openblack::Arguments& args, int& return
 		args.displayMode = displayMode;
 		args.rendererType = rendererType;
 		args.numFramesToSimulate = result["num-frames-to-simulate"].as<uint32_t>();
+		args.logFile = result["log-file"].as<std::string>();
+		args.logLevel = result["log-level"].as<uint32_t>();
 	}
 	catch (cxxopts::OptionParseException& err)
 	{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,13 @@ bool parseOptions(int argc, char** argv, openblack::Arguments& args, int& return
 {
 	cxxopts::Options options("openblack", "Open source reimplementation of the game Black & White (2001).");
 
+	const std::string defaultLogFile =
+#ifdef OPENBLACK_DEBUG
+	    "stdout";
+#else
+	    "openblack.log";
+#endif
+
 	// clang-format off
 	options.add_options()
 		("h,help", "Display this help message.")
@@ -33,7 +40,7 @@ bool parseOptions(int argc, char** argv, openblack::Arguments& args, int& return
 		("m,window-mode", "Which mode to run window.", cxxopts::value<std::string>()->default_value("windowed"))
 		("b,backend-type", "Which backend to use for rendering.", cxxopts::value<std::string>()->default_value("OpenGL"))
 		("n,num-frames-to-simulate", "Number of frames to simulate before quitting.", cxxopts::value<uint32_t>()->default_value("0"))
-		("l,log-file", "Output file for logs, 'stdout' for terminal output.", cxxopts::value<std::string>()->default_value("openblack.log"))
+		("l,log-file", "Output file for logs, 'stdout' for terminal output.", cxxopts::value<std::string>()->default_value(defaultLogFile))
 		("L,log-level", "Level of logging.", cxxopts::value<uint32_t>()->default_value("0"))
 	;
 	// clang-format on


### PR DESCRIPTION
By default openblack will log to a file.
Specifying `--logfile stdout` will log to terminal.
Default level is now debug and any number higher than 0 will be a higher
level such as info, warning and error.