### PR TITLE
Implement font rendering from custom game fonts.

### DIFF
--- a/assets/shaders/fs_text.sc
+++ b/assets/shaders/fs_text.sc
@@ -1,0 +1,14 @@
+$input v_color0, v_texcoord0
+
+#include <bgfx_shader.sh>
+
+SAMPLER2D(s_tex, 0);
+
+void main()
+{
+	vec4 texel = texture2D(s_tex, v_texcoord0.xy);
+
+	// if (texel.r < 0.1) discard;
+
+	gl_FragColor = vec4(v_color0.rgb, texel.r * v_color0.a); 
+}

--- a/assets/shaders/vs_text.sc
+++ b/assets/shaders/vs_text.sc
@@ -1,0 +1,15 @@
+$input a_position, a_color0
+$output v_color0, v_texcoord0
+
+#include <bgfx_shader.sh>
+
+void main()
+{
+	vec2 pos = 2.0*a_position.xy*u_viewTexel.xy;
+	gl_Position = vec4(pos.x - 1.0, 1.0 - pos.y, 0.0, 1.0);
+	// gl_Position = mul(u_proj, vec4(a_position.xy, 0.0, 1.0) );
+	v_texcoord0 = vec4(a_position.zw, 0.0, 0.0);
+
+	// v_texcoord0 = a_texcoord0;
+	v_color0    = a_color0;
+}

--- a/src/Debug/FontViewer.cpp
+++ b/src/Debug/FontViewer.cpp
@@ -1,0 +1,132 @@
+/******************************************************************************
+ * Copyright (c) 2018-2023 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *******************************************************************************/
+
+#include "FontViewer.h"
+
+#include <imgui.h>
+
+#include "Game.h"
+#include "Graphics/Font/Font.h"
+#include "Graphics/Texture2D.h"
+#include "Gui.h"
+
+using namespace openblack;
+using namespace openblack::debug::gui;
+
+FontViewer::FontViewer()
+    : Window("Font Viewer", ImVec2(600.0f, 600.0f))
+{
+}
+
+void FontViewer::Draw(Game& game)
+{
+	ImGuiStyle& style = ImGui::GetStyle();
+
+	auto const& fonts = game.GetFonts();
+
+	for (const auto& font : fonts)
+	{
+		auto const& glyphs = font->GetGlyphs();
+		const bool font_details_opened = ImGui::TreeNode(font.get(), "Font \"%s\" %d px, %zu glyphs", font->GetName().c_str(),
+		                                                 font->GetSize(), glyphs.size());
+		if (font_details_opened)
+		{
+			if (ImGui::TreeNode("Atlas Texture"))
+			{
+				auto const& texture = font->GetAtlasTexture();
+				ImGui::Image(texture.GetNativeHandle(), ImVec2(texture.GetWidth(), texture.GetHeight()));
+				ImGui::TreePop();
+			}
+
+			if (ImGui::TreeNode("Glyphs", "Glyphs (%zu)", glyphs.size()))
+			{
+				for (unsigned int base = 0; base <= IM_UNICODE_CODEPOINT_MAX; base += 256)
+				{
+					int count = 0;
+					for (unsigned int n = 0; n < 256; n++)
+					{
+						count += font->FindGlyphNoFallback(base + n) != nullptr ? 1 : 0;
+					}
+
+					if (count > 0 &&
+					    ImGui::TreeNode(reinterpret_cast<void*>(static_cast<intptr_t>(base)), "U+%04X..U+%04X (%d %s)", base,
+					                    base + 255, count, count > 1 ? "glyphs" : "glyph"))
+					{
+						float cellSize = font->GetSize() * 1.0f;
+						float cellSpacing = style.ItemSpacing.y;
+						ImVec2 basePos = ImGui::GetCursorScreenPos();
+						ImDrawList* drawList = ImGui::GetWindowDrawList();
+
+						for (unsigned int n = 0; n < 256; n++)
+						{
+							ImVec2 cellPos1(basePos.x + (n % 8) * (cellSize + cellSpacing),
+							                basePos.y + (n / 8) * (cellSize + cellSpacing));
+							ImVec2 cellPos2(cellPos1.x + cellSize, cellPos1.y + cellSize);
+							const Font::Glyph* glyph = font->FindGlyphNoFallback(base + n);
+
+							drawList->AddRect(cellPos1, cellPos2,
+							                  glyph ? IM_COL32(255, 255, 255, 100) : IM_COL32(255, 255, 255, 50));
+							if (glyph)
+							{
+								union
+								{
+									struct
+									{
+										bgfx::TextureHandle handle;
+										uint8_t flags;
+										uint8_t mip;
+									} s;
+									ImTextureID ptr;
+								} texture;
+								texture.s.handle = font->GetAtlasTexture().GetNativeHandle();
+								texture.s.flags = IMGUI_FLAGS_ALPHA_BLEND;
+								texture.s.mip = 0;
+
+								ImVec2 glyphPos1(basePos.x + (n % 8) * (cellSize + cellSpacing),
+								                 basePos.y + (n / 8) * (cellSize + cellSpacing));
+								ImVec2 glyphPos2(cellPos1.x + glyph->width, cellPos1.y + font->GetSize());
+
+								drawList->AddImage(texture.ptr, glyphPos1, glyphPos2, ImVec2(glyph->u0, glyph->v0),
+								                   ImVec2(glyph->u1, glyph->v1));
+							}
+							if (glyph && ImGui::IsMouseHoveringRect(cellPos1, cellPos2))
+							{
+								ImGui::BeginTooltip();
+								ImGui::Text("Codepoint: U+%04X", base + n);
+								ImGui::Separator();
+								ImGui::Text("UV: (%.3f,%.3f)->(%.3f,%.3f)", glyph->u0, glyph->v0, glyph->u1, glyph->v1);
+								ImGui::Text("x_offset: %d width: %d", glyph->xOffset, glyph->width);
+								ImGui::Text("fXoffset: %.3f fWidth: %.3f unk2: %.3f", glyph->fXoffset, glyph->fWidth,
+								            glyph->unk2);
+								/*ImGui::Text("Visible: %d", glyph->Visible);
+								ImGui::Text("AdvanceX: %.1f", glyph->AdvanceX);
+								ImGui::Text("Pos: (%.2f,%.2f)->(%.2f,%.2f)", glyph->X0, glyph->Y0, glyph->X1, glyph->Y1);
+								ImGui::Text("UV: (%.3f,%.3f)->(%.3f,%.3f)", glyph->U0, glyph->V0, glyph->U1, glyph->V1);*/
+								ImGui::EndTooltip();
+							}
+						}
+
+						ImGui::Dummy(ImVec2((cellSize + cellSpacing) * 8, (cellSize + cellSpacing) * 32));
+						ImGui::TreePop();
+					}
+				}
+
+				ImGui::TreePop();
+			}
+
+			ImGui::TreePop();
+		}
+	}
+}
+
+void FontViewer::Update(Game& game, const Renderer& renderer) {}
+
+void FontViewer::ProcessEventOpen(const SDL_Event& event) {}
+
+void FontViewer::ProcessEventAlways(const SDL_Event& event) {}

--- a/src/Debug/FontViewer.h
+++ b/src/Debug/FontViewer.h
@@ -1,0 +1,29 @@
+/******************************************************************************
+ * Copyright (c) 2018-2023 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *******************************************************************************/
+
+#pragma once
+
+#include "Window.h"
+
+namespace openblack::debug::gui
+{
+
+class FontViewer: public Window
+{
+public:
+	FontViewer();
+
+protected:
+	void Draw(Game& game) override;
+	void Update(Game& game, const Renderer& renderer) override;
+	void ProcessEventOpen(const SDL_Event& event) override;
+	void ProcessEventAlways(const SDL_Event& event) override;
+};
+
+} // namespace openblack::debug::gui

--- a/src/Debug/Gui.cpp
+++ b/src/Debug/Gui.cpp
@@ -56,6 +56,7 @@
 #include "Audio.h"
 #include "Console.h"
 #include "ECS/Systems/LivingActionSystemInterface.h"
+#include "FontViewer.h"
 #include "LHVMViewer.h"
 #include "LandIsland.h"
 #include "MeshViewer.h"
@@ -119,6 +120,7 @@ std::unique_ptr<Gui> Gui::Create(graphics::RenderPass viewId, float scale)
 	debugWindows.emplace_back(new PathFinding);
 	debugWindows.emplace_back(new Audio);
 	debugWindows.emplace_back(new TempleInterior);
+	debugWindows.emplace_back(new FontViewer);
 
 	auto gui = std::unique_ptr<Gui>(
 	    new Gui(imgui, static_cast<bgfx::ViewId>(viewId), std::move(debugWindows), !Locator::windowing::has_value()));

--- a/src/Game.h
+++ b/src/Game.h
@@ -36,12 +36,14 @@ union SDL_Event;
 namespace openblack
 {
 class Camera;
+class Font;
 class EventManager;
 class Profiler;
 class Renderer;
 class L3DAnim;
 class L3DMesh;
 class Sky;
+class TextRenderer;
 class Water;
 
 namespace debug::gui
@@ -176,6 +178,7 @@ public:
 	LHVM::LHVM& GetLhvm() { return *_lhvm; }
 	const InfoConstants& GetInfoConstants() { return _infoConstants; } ///< Access should be only read-only
 	Config& GetConfig() { return _config; }
+	const std::vector<std::unique_ptr<Font>>& GetFonts() const { return _fonts; }
 	[[nodiscard]] const Config& GetConfig() const { return _config; }
 	[[nodiscard]] uint16_t GetTurn() const { return _turnCount; }
 	[[nodiscard]] bool IsPaused() const { return _paused; }
@@ -197,6 +200,7 @@ private:
 	std::unique_ptr<Camera> _camera;
 	std::unique_ptr<Profiler> _profiler;
 	std::unique_ptr<EventManager> _eventManager;
+	std::unique_ptr<TextRenderer> _textRenderer;
 
 	// std::unique_ptr<L3DMesh> _testModel;
 	std::unique_ptr<L3DMesh> _testModel;
@@ -208,6 +212,8 @@ private:
 	std::unique_ptr<LHVM::LHVM> _lhvm;
 
 	InfoConstants _infoConstants;
+	std::vector<std::unique_ptr<Font>> _fonts;
+
 	Config _config;
 	std::filesystem::path _startMap;
 

--- a/src/Graphics/Font/Font.cpp
+++ b/src/Graphics/Font/Font.cpp
@@ -1,0 +1,263 @@
+/******************************************************************************
+ * Copyright (c) 2018-2023 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *******************************************************************************/
+
+#include "Font.h"
+
+#include <algorithm>
+#include <codecvt>
+#include <locale>
+
+#include <imgui.h>
+#include <spdlog/spdlog.h>
+
+#define STB_RECT_PACK_IMPLEMENTATION
+#include <stb_rect_pack.h>
+
+#include "FileSystem/FileSystemInterface.h"
+#include "Graphics/Texture2D.h"
+#include "Locator.h"
+
+namespace openblack
+{
+
+void Font::LoadFromFile(const std::string& filename)
+{
+	auto& fileSystem = Locator::filesystem::value();
+
+	auto fnt_filename = filename + ".fnt";
+	auto met_filename = filename + ".met";
+
+	auto meta = fileSystem.Open(met_filename, filesystem::Stream::Mode::Read);
+
+	_size = meta->ReadValue<uint32_t>();
+
+	// read utf16 string
+	std::u16string u16_name(0x80, '\0');
+	meta->Read(reinterpret_cast<uint8_t*>(u16_name.data()), 0x100);
+
+	// convert to utf-8
+	std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
+	_name = convert.to_bytes(u16_name);
+
+	uint32_t numGlyphs = meta->ReadValue<uint32_t>();
+
+	_glyphs = std::vector<Glyph>(numGlyphs);
+	for (uint32_t i = 0; i < numGlyphs; i++)
+	{
+		meta->Read(reinterpret_cast<uint8_t*>(&_glyphs[i]), sizeof(Glyph) - 16);
+	}
+
+	// build lookup table
+	codepoint_t max_codepoint = 0;
+	for (uint32_t i = 0; i != _glyphs.size(); i++)
+		max_codepoint = std::max(max_codepoint, _glyphs[i].codepoint);
+
+	_glyphLookup.resize(max_codepoint + 1, -1);
+
+	for (uint32_t i = 0; i < _glyphs.size(); i++)
+	{
+		_glyphLookup[_glyphs[i].codepoint] = i;
+	}
+
+	meta.release();
+
+	auto fntFile = fileSystem.Open(fnt_filename, filesystem::Stream::Mode::Read);
+	size_t size = fntFile->Size();
+
+	uint8_t* data = new uint8_t[size];
+	fntFile->Read(data, size);
+	BuildFontAtlas(data);
+	delete[] data;
+
+	fntFile.release();
+}
+
+const Font::Glyph* Font::FindGlyphNoFallback(codepoint_t codepoint) const
+{
+	if (codepoint >= _glyphLookup.size())
+		return nullptr;
+
+	const auto i = _glyphLookup[codepoint];
+	if (i == (char16_t)-1)
+		return nullptr;
+
+	return &_glyphs[i];
+}
+
+/**
+ * render our glyphs into rects, pack them and upload them to opengl
+ */
+// buildFontAtlas
+void Font::BuildFontAtlas(uint8_t* fontData)
+{
+	std::vector<stbrp_rect> rects(_glyphs.size());
+	memset(rects.data(), 0, rects.size() * sizeof(stbrp_rect));
+
+	int total_surface = 0;
+	for (size_t i = 0; i < _glyphs.size(); i++)
+	{
+		const auto& glyph = _glyphs[i];
+		rects[i].id = i;
+		rects[i].w = glyph.width + 2;
+		rects[i].h = _size + 2;
+		total_surface += rects[i].w * rects[i].h;
+	}
+
+	const int surface_sqrt = (int)sqrt((float)total_surface) + 1;
+	const std::size_t tex_width = (surface_sqrt >= 4096 * 0.7f)   ? 4096
+	                              : (surface_sqrt >= 2048 * 0.7f) ? 2048
+	                              : (surface_sqrt >= 1024 * 0.7f) ? 1024
+	                                                              : 512;
+	const std::size_t TEX_HEIGHT_MAX = 1024 * 32;
+
+	constexpr int nodeCount = 4096 * 2;
+	struct stbrp_node* nodes = new stbrp_node[nodeCount];
+
+	stbrp_context context;
+	stbrp_init_target(&context, tex_width, TEX_HEIGHT_MAX, nodes, nodeCount);
+	stbrp_pack_rects(&context, rects.data(), rects.size());
+
+	std::size_t tex_height = 0;
+
+	for (size_t i = 0; i < rects.size(); i++)
+	{
+		if (rects[i].was_packed)
+			tex_height = std::max(tex_height, static_cast<std::size_t>(rects[i].y + rects[i].h));
+	}
+
+	printf("atlas tex: %zux%zu\n", tex_width, tex_height);
+
+	// todo: do we need to round tex_height to pow2
+
+	// allocate texture
+	uint8_t* texPixels = new uint8_t[tex_width * tex_height];
+	memset(texPixels, 0x00, tex_width * tex_height);
+
+	float u_scale = 1.0f / tex_width;
+	float v_scale = 1.0f / tex_height;
+
+	// render / rasterize font glyphs into the texture
+	for (size_t i = 0; i < _glyphs.size(); i++)
+	{
+		if (!rects[i].was_packed)
+			continue;
+
+		size_t offset = tex_width * rects[i].y + rects[i].x;
+		size_t stride = tex_width;
+
+		// for (int ry = 0; ry < rects[i].h; ry++)
+		// {
+		// 	int start_offset = tex_width * (rects[i].y + ry) + rects[i].x;
+		// 	memset(&texPixels[start_offset], i, rects[i].w);
+		// }
+
+		RenderGlyph(&fontData[_glyphs[i].dataOffset], _glyphs[i].dataSize, _glyphs[i].width, &texPixels[offset], stride);
+
+		// work out uv
+		_glyphs[i].u0 = rects[i].x * u_scale;
+		_glyphs[i].u1 = (rects[i].x + rects[i].w) * u_scale;
+		_glyphs[i].v0 = rects[i].y * v_scale;
+		_glyphs[i].v1 = (rects[i].y + rects[i].h) * v_scale;
+	}
+
+	// upload to gpu
+	_atlasTexture = std::make_unique<graphics::Texture2D>("Font");
+	_atlasTexture->Create(tex_width, tex_height, 1, graphics::Format::R8, graphics::Wrapping::ClampEdge,
+	                      graphics::Filter::Linear, texPixels, tex_width * tex_height);
+
+	delete[] texPixels;
+	delete[] nodes;
+}
+
+void Font::RenderGlyph(uint8_t* glyphData, [[maybe_unused]] size_t size, uint16_t width, uint8_t* dest, size_t stride)
+{
+	int pixels = _size * width;
+	uint8_t* bitmap = new uint8_t[pixels];
+
+	int pos = 0;
+	bool fill = false;
+	while (pos < pixels)
+	{
+		// get the number of pixels to fill, if byte is 0xFF then get the next short.
+		int count = *glyphData++;
+		if (count == 0xFF)
+		{
+			count = *((uint16_t*)glyphData);
+			glyphData += 2;
+		}
+
+		// if count exceeds our remaining pixels, just fill the remaining
+		if (count + pos > pixels)
+			count = pixels - pos;
+
+		// fill the number of pixels
+		memset(&bitmap[pos], fill ? 0xFF : 0x00, count);
+
+		// add count and alternate fill
+		pos += count;
+		fill = !fill;
+	}
+
+	// copy to dest
+	for (uint32_t y = 0; y < _size; y++)
+	{
+		for (int x = 0; x < width; x++)
+		{
+			dest[y * stride + x] = bitmap[y * width + x];
+		}
+	}
+
+	delete[] bitmap;
+}
+
+/*
+// wip
+Font::Font(const std::string& filename)
+{
+    auto fnt_filename = filename + ".fnt";
+    auto met_filename = filename + ".met";
+
+    auto meta = Game::instance()->GetFileSystem().Open(met_filename, FileMode::Read);
+
+    meta->Read(&_size, 4);
+
+    // read utf16 string
+    std::u16string u16_name(0x80, '\0');
+    meta->Read(u16_name.data(), 0x100);
+
+    // convert to utf-8
+    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
+    _name = convert.to_bytes(u16_name);
+
+    uint32_t numGlyphs;
+    meta->Read(&numGlyphs, 4);
+
+    printf("font %s has %d glyphs\n", _name.c_str(), numGlyphs);
+
+    //_glyphs = std::vector<FontGlyph>(numGlyphs);
+}
+
+std::string Font::GetName() const
+{
+    return _name;
+}
+
+unsigned int Font::GetSize() const
+{
+    return _size;
+}
+
+std::unique_ptr<uint8_t[]> Font::LoadGlyph(codepoint_t codepoint, Glyph& glyph) const
+{
+    auto glyph_data = std::make_unique<uint8_t[]>(1);
+    return glyph_data;
+}
+*/
+
+} // namespace openblack

--- a/src/Graphics/Font/Font.h
+++ b/src/Graphics/Font/Font.h
@@ -1,0 +1,129 @@
+/******************************************************************************
+ * Copyright (c) 2018-2023 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *******************************************************************************/
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <typeindex>
+#include <vector>
+
+#include "Util/Hash.h"
+
+namespace openblack
+{
+
+namespace graphics
+{
+class Texture2D;
+}
+
+class FileStream;
+
+using codepoint_t = char16_t;
+
+/**
+ * A font in Black & White consists of two files, a .fnt and a .met.
+ * .met contains all the meta data about the font and it's glyphs.
+ * Where a .fnt contains run length encoded 1 bit bitmap data.
+ */
+class Font
+{
+public:
+	struct Glyph
+	{
+		codepoint_t codepoint;
+		uint16_t width;
+		int16_t xOffset;
+		uint16_t padding;
+		float fXoffset;
+		float fWidth;
+		float unk2;
+		uint32_t dataOffset;
+		uint32_t dataSize;
+
+		float u0;
+		float u1;
+		float v0;
+		float v1;
+	};
+
+	void LoadFromFile(const std::string& name);
+
+	[[nodiscard]] std::string GetName() const { return _name; }
+	[[nodiscard]] uint32_t GetSize() const { return _size; }
+	[[nodiscard]] const std::vector<Glyph>& GetGlyphs() const { return _glyphs; }
+	[[nodiscard]] const graphics::Texture2D& GetAtlasTexture() const { return *_atlasTexture; }
+	[[nodiscard]] const Glyph* FindGlyphNoFallback(codepoint_t glyph) const;
+
+private:
+	uint32_t _size;
+	std::string _name;
+	std::vector<Glyph> _glyphs;
+	std::vector<codepoint_t> _glyphLookup;
+
+	std::unique_ptr<graphics::Texture2D> _atlasTexture;
+
+	void BuildFontAtlas(uint8_t* fontData);
+	void RenderGlyph(uint8_t* glyphData, size_t size, uint16_t width, uint8_t* dest, size_t stride);
+};
+
+// WIP stuff:
+
+/*struct Glyph {
+    codepoint_t codepoint;
+    unsigned int width;
+    unsigned int height;
+    unsigned int height_offset; // idk
+    float unk0;
+    float unk1;
+    float unk2;
+};
+
+class Font
+{
+    friend class FontAtlas;
+
+public:
+    Font(const std::string& filename);
+    ~Font() = default;
+
+    std::string GetName() const;
+    unsigned int GetSize() const;
+
+protected:
+
+    // Load a particular glyph's info and retrieves the glyph's bitmap data. (Decompresses)
+    std::unique_ptr<uint8_t[]> LoadGlyph(codepoint_t codepoint, Glyph& glyph) const;
+
+
+private:
+    std::string _name;
+    unsigned int _size;
+    std::unique_ptr<FileStream> _fntFile;
+
+    std::vector<Glyph> _glyphs;
+    std::vector<codepoint_t> _glyphLookup;
+};*/
+} // namespace openblack
+
+namespace std
+{
+template <>
+struct hash<openblack::Font>
+{
+	size_t operator()(const openblack::Font& font) const
+	{
+		size_t hash = std::hash<std::type_index>()(std::type_index(typeid(openblack::Font)));
+		openblack::hash_combine(hash, font.GetName());
+		openblack::hash_combine(hash, font.GetSize());
+		return hash;
+	}
+};
+} // namespace std

--- a/src/Graphics/Font/FontAtlas.cpp
+++ b/src/Graphics/Font/FontAtlas.cpp
@@ -1,0 +1,181 @@
+/******************************************************************************
+ * Copyright (c) 2018-2023 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *******************************************************************************/
+
+#if FALSE
+
+#include "FontAtlas.h"
+
+#include <algorithm>
+
+#include "Graphics/Texture2D.h"
+#include "Util/Hash.h"
+
+namespace openblack
+{
+
+FontAtlas::FontAtlas()
+    : _texWidth(0)
+    , _texHeight(0)
+{
+	_texture = std::make_unique<graphics::Texture2D>("Font Atlas");
+}
+
+FontAtlas::~FontAtlas()
+{
+	// free all our bitmaps
+	// free our stb_rect stuff
+}
+
+void FontAtlas::AddFont(const Font& font) {}
+
+void FontAtlas::addGlyph(const Font& font, codepoint_t codepoint)
+{
+	std::size_t key = getKey(font, codepoint);
+	// auto it = _entries.find(key);
+	// if (it != _entries.end()) {
+	//	return false; // entry already exists
+	// }
+
+	Glyph glyph;
+	std::unique_ptr<uint8_t[]> image = font.LoadGlyph(codepoint, glyph);
+
+	stbrp_rect rect;
+	rect.id = key;
+	rect.w = glyph.width + 2; // give each glyph a border
+	rect.h = font.GetSize() + 2;
+	rect.x = 0;
+	rect.y = 0;
+	rect.was_packed = 0;
+	_rects.push_back(rect);
+
+	Entry entry;
+	entry.glyph = glyph;
+	entry.u0 = 0.0f;
+	entry.v0 = 0.0f;
+	entry.u1 = 0.0f;
+	entry.v1 = 0.0f;
+	entry.bitmap = std::move(image);
+	_entries.emplace(key, entry);
+}
+
+std::size_t FontAtlas::getKey(const Font& font, codepoint_t codepoint)
+{
+	std::size_t hash = std::hash<std::type_index>()(std::type_index(typeid(FontAtlas)));
+	hash_combine(hash, font);
+	hash_combine(hash, codepoint);
+	return hash;
+}
+
+const graphics::Texture2D& FontAtlas::GetTexture() const
+{
+	// if texture isn't built...................
+	// build();
+
+	return *_texture;
+}
+
+void FontAtlas::build()
+{
+	// Calculate our surface area to get a texture width.
+	std::size_t totalSurface = 0;
+	for (int i = 0; i < _rects.size(); i++)
+		totalSurface += (_rects[i].w * _rects[i].h);
+
+	const int surfaceSqrt = (int)sqrt((float)totalSurface) + 1;
+	_texWidth = (surfaceSqrt >= 4096 * 0.7f)   ? 4096
+	            : (surfaceSqrt >= 2048 * 0.7f) ? 2048
+	            : (surfaceSqrt >= 1024 * 0.7f) ? 1024
+	                                           : 512;
+
+	// Pack our rects
+	const int maxTexHeight = 32768;
+	const int nodeCount = 4096 * 2;
+	struct stbrp_node nodes[nodeCount];
+
+	stbrp_context spc = {};
+	stbrp_init_target(&spc, _texWidth, maxTexHeight, nodes, nodeCount);
+	stbrp_pack_rects(&spc, _rects.data(), _rects.size());
+
+	// Allocate our texture
+	_texPixelsAlpha8.release();
+	_texPixelsAlpha8 = std::unique_ptr<uint8_t[]>(new uint8_t[_texWidth * _texHeight]);
+	std::memset(_texPixelsAlpha8.get(), 0x00, _texWidth * _texHeight);
+
+	// Render/rasterize font characters into the texture
+
+	// Finally upload our texture to the GPU
+	_texture->Create(_texWidth, _texHeight, 1, graphics::Format::R8, graphics::Wrapping::ClampEdge, _texPixelsAlpha8.get(),
+	                 _texWidth * _texHeight);
+}
+
+FontCache::Entry FontCache::Set(std::size_t key, const Glyph& glyph, const uint8_t* bitmap)
+{
+	int required_width = glyph.width;
+	int required_height = glyph.height;
+
+	if (_shelves.empty())
+	{
+		_shelves.emplace_back(0, _width, required_height);
+	}
+
+	for (auto& shelf : _shelves)
+	{
+		if (shelf.Fits(required_width, required_height))
+		{
+			unsigned int x_pos = shelf.Reserve(required_width, required_height);
+			unsigned int y_pos = shelf.yPosition;
+
+			// Create a new entry and insert it
+			FontCache::Entry entry;
+			entry.glyph = glyph;
+			entry.u0 = static_cast<float>(x_pos) / _width;
+			entry.v0 = static_cast<float>(y_pos) / _height;
+			entry.u1 = static_cast<float>(x_pos + glyph.width) / _width;
+			entry.v1 = static_cast<float>(y_pos + glyph.height) / _height;
+
+			for (unsigned int y = 0; y < glyph.height; y++)
+			{
+				memcpy(_buffer.get() + ((y_pos + y) * _width + x_pos), bitmap + (y * glyph.width),
+				       glyph.width * sizeof(unsigned char));
+			}
+
+			_dirtyRect = {
+			    std::min(_dirtyRect.x1, x_pos),
+			    std::min(_dirtyRect.y1, y_pos),
+			    std::max(_dirtyRect.x2, x_pos + glyph.width),
+			    std::max(_dirtyRect.y2, y_pos + glyph.height),
+			};
+			_isDirty = true;
+
+			_glyphs.emplace(key, entry);
+			return entry;
+		}
+	}
+
+	FontCache::Shelf last_shelf = _shelves.back();
+	if (_height > (last_shelf.yPosition + last_shelf.height + required_height))
+	{
+		_shelves.emplace_back(last_shelf.yPosition + last_shelf.height, _width, required_height);
+		return Set(key, glyph, bitmap);
+	}
+
+	// todo: never get here
+}
+
+std::size_t FontCache::getKey(Font* font, codepoint_t codepoint) const
+{
+	std::size_t hash = std::hash<std::type_index>()(std::type_index(typeid(FontCache)));
+	hash_combine(hash, *font);
+	hash_combine(hash, codepoint);
+	return hash;
+}
+
+} // namespace openblack
+
+#endif

--- a/src/Graphics/Font/FontAtlas.h
+++ b/src/Graphics/Font/FontAtlas.h
@@ -1,0 +1,226 @@
+/******************************************************************************
+ * Copyright (c) 2018-2023 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *******************************************************************************/
+
+#if FALSE
+
+#pragma once
+
+#include "Font.h"
+
+#define STB_RECT_PACK_IMPLEMENTATION
+#include <memory>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+#include <stb_rect_pack.h>
+
+namespace openblack
+{
+
+// forward declares
+namespace graphics
+{
+class Texture2D;
+}
+
+/**
+ * FontAtlas packs glyphs from several fonts into a single atlas texture.
+ *
+ * Each glyph is get/set from a [Font, codepoint_t] pair.
+ * If the glyph doesn't exist the bitmap is loaded from the Font and packed
+ * into the texture atlas.
+ *
+ * The returned struct returns the Glyph and UV0, UV1 of the position in the
+ * texture atlas.
+ *
+ * For Black & White 1:
+ * We have 3 fonts at size 80 when combined have a total of 684 glyphs.
+ * All glyphs should be able to fit in a 2048x2048 texture.
+ */
+class FontAtlas
+{
+public:
+	class Entry
+	{
+		friend class FontAtlas;
+
+	public:
+		Glyph glyph; // so we don't have to search the Font and FontAtlas
+		float u0;
+		float v0;
+		float u1;
+		float v1;
+
+	protected:
+		std::unique_ptr<uint8_t[]> bitmap; // todo: maybe this isn't needed
+	};
+
+public:
+	FontAtlas();
+	~FontAtlas();
+
+	/**
+	 * AddFont packs all the glyphs from the given font into the atlas.
+	 */
+	void AddFont(const Font& font);
+
+	bool Build();
+
+	// add a glyph ready to be packed on Build() lets you batch them before packing begins
+	// bool AddGlyph(const Font& font, codepoint_t codepoint);
+	// AddGlyphs(Font, vector<codepoint_t>);
+
+	/**
+	 * Gets the UV coordinates of the given codepoint from a font.
+	 * If the glyph doesn't exist, UV coordinates for an invalid glyph will be returned. (Maybe just return first glyph.)
+	 */
+	Entry Get(const Font& font, codepoint_t codepoint);
+
+	const graphics::Texture2D& GetTexture() const;
+
+private:
+	void addGlyph(const Font& font, codepoint_t codepoint);
+
+	void build();
+	static std::size_t getKey(const Font& font, codepoint_t codepoint);
+
+private:
+	std::size_t _texWidth;
+	std::size_t _texHeight;
+	std::unique_ptr<uint8_t[]> _texPixelsAlpha8;
+	std::unique_ptr<graphics::Texture2D> _texture;
+
+	std::unordered_map<std::size_t, Entry> _entries;
+	std::vector<stbrp_rect> _rects;
+};
+
+/*class FontAtlas
+{
+public:
+    struct Entry {
+        Glyph glyph;
+        glm::vec2 uv0;
+        glm::vec2 uv1;
+    };
+
+public:
+    FontAtlas(unsigned int width = 2048, unsigned int height = 2048);
+
+    Entry Get(const Font& font, codepoint_t codepoint);
+
+    const graphics::Texture2D& GetTexture();
+
+private:
+    Entry set(std::size_t key, const Glyph& glyph, const uint8_t* bitmap);
+    std::size_t getKey(const Font& font, codepoint_t codepoint) const;
+
+    void updateDirty();
+
+private:
+    struct Shelf {
+        int y;
+        int height;
+        int width_remaining;
+    };
+
+    /*struct Shelf {
+        Shelf(int pos, int width, int height);
+        bool Fits(int width, int height);
+        int Reserve(int width, int height);
+
+        int yPosition;
+        int width;
+        int height;
+        int remainingWidth;
+    };*/
+/*
+    struct Rect {
+        unsigned int x1;
+        unsigned int y1;
+        unsigned int x2;
+        unsigned int y2;
+    };
+
+private:
+    unsigned int _width;
+    unsigned int _height;
+    bool _isDirty;
+    Rect _dirtyRect;
+
+    std::vector<uint8_t> _buffer;
+
+    std::unique_ptr<graphics::Texture2D> _texture;
+    std::unordered_map<std::size_t, FontCache::Entry> _glyphs;
+    std::vector<Shelf> _shelves;
+};*/
+
+/**
+ * A glyph atlas is used to pack and manage several font glyphs in to a single atlas texture.
+ * A single glyph atlas can be used to store glyphs from multiple fonts.
+ */
+class FontCache
+{
+public:
+	struct Entry
+	{
+		Glyph glyph;
+		float u0;
+		float v0;
+		float u1;
+		float v1;
+	};
+
+public:
+	FontCache(unsigned int width = 1024, unsigned int height = 1024);
+
+	FontCache::Entry Get(Font* font, codepoint_t codepoint);
+	FontCache::Entry Set(std::size_t key, const Glyph& glyph, const uint8_t* bitmap);
+
+	const graphics::Texture2D& GetTexture();
+
+private:
+	std::size_t getKey(Font* font, codepoint_t codepoint) const;
+
+private:
+	struct Shelf
+	{
+		Shelf(int pos, int width, int height);
+		bool Fits(int width, int height);
+		int Reserve(int width, int height);
+
+		int yPosition;
+		int width;
+		int height;
+		int remainingWidth;
+	};
+
+	struct Rect
+	{
+		unsigned int x1;
+		unsigned int y1;
+		unsigned int x2;
+		unsigned int y2;
+	};
+
+private:
+	unsigned int _width;
+	unsigned int _height;
+	bool _isDirty;
+	Rect _dirtyRect;
+
+	std::unique_ptr<uint8_t> _buffer;
+	std::unique_ptr<graphics::Texture2D> _texture;
+	std::unordered_map<std::size_t, FontCache::Entry> _glyphs;
+	std::vector<Shelf> _shelves;
+};
+
+} // namespace openblack
+
+#endif

--- a/src/Graphics/Font/FontManager.h
+++ b/src/Graphics/Font/FontManager.h
@@ -1,0 +1,224 @@
+/******************************************************************************
+ * Copyright (c) 2018-2023 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *******************************************************************************/
+
+#pragma once
+
+#include "Font.h"
+
+#define STB_RECT_PACK_IMPLEMENTATION
+#include <memory>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+#include <stb/stb_rect_pack.h>
+
+namespace openblack
+{
+
+// forward declares
+namespace graphics
+{
+class Texture2D;
+}
+
+/**
+ * FontAtlas packs glyphs from several fonts into a single atlas texture.
+ *
+ * Each glyph is get/set from a [Font, codepoint_t] pair.
+ * If the glyph doesn't exist the bitmap is loaded from the Font and packed
+ * into the texture atlas.
+ *
+ * The returned struct returns the Glyph and UV0, UV1 of the position in the
+ * texture atlas.
+ *
+ * For Black & White 1:
+ * We have 3 fonts at size 80 when combined have a total of 684 glyphs.
+ * All glyphs should be able to fit in a 2048x2048 texture.
+ */
+class FontAtlas
+{
+public:
+	class Entry
+	{
+		friend class FontAtlas;
+
+	public:
+		Glyph glyph; // so we don't have to search the Font and FontAtlas
+		float u0;
+		float v0;
+		float u1;
+		float v1;
+
+	protected:
+		std::unique_ptr<uint8_t[]> bitmap; // todo: maybe this isn't needed
+	};
+
+public:
+	FontAtlas();
+	~FontAtlas();
+
+	/**
+	 * AddFont packs all the glyphs from the given font into the atlas.
+	 */
+	void AddFont(const Font& font);
+
+	bool Build();
+
+	// add a glyph ready to be packed on Build() lets you batch them before packing begins
+	// bool AddGlyph(const Font& font, codepoint_t codepoint);
+	// AddGlyphs(Font, vector<codepoint_t>);
+
+	/**
+	 * Gets the UV coordinates of the given codepoint from a font.
+	 * If the glyph doesn't exist, UV coordinates for an invalid glyph will be returned. (Maybe just return first glyph.)
+	 */
+	Entry Get(const Font& font, codepoint_t codepoint);
+
+	const graphics::Texture2D& GetTexture() const;
+
+private:
+	void addGlyph(const Font& font, codepoint_t codepoint);
+
+	void build();
+	static std::size_t getKey(const Font& font, codepoint_t codepoint);
+
+private:
+	std::size_t _texWidth;
+	std::size_t _texHeight;
+	std::unique_ptr<uint8_t[]> _texPixelsAlpha8;
+	std::unique_ptr<graphics::Texture2D> _texture;
+
+	std::unordered_map<std::size_t, Entry> _entries;
+	std::vector<stbrp_rect> _rects;
+};
+
+/*class FontAtlas
+{
+public:
+    struct Entry {
+        Glyph glyph;
+        glm::vec2 uv0;
+        glm::vec2 uv1;
+    };
+
+public:
+    FontAtlas(unsigned int width = 2048, unsigned int height = 2048);
+
+    Entry Get(const Font& font, codepoint_t codepoint);
+
+    const graphics::Texture2D& GetTexture();
+
+private:
+    Entry set(std::size_t key, const Glyph& glyph, const uint8_t* bitmap);
+    std::size_t getKey(const Font& font, codepoint_t codepoint) const;
+
+    void updateDirty();
+
+private:
+    struct Shelf {
+        int y;
+        int height;
+        int width_remaining;
+    };
+
+    /*struct Shelf {
+        Shelf(int pos, int width, int height);
+        bool Fits(int width, int height);
+        int Reserve(int width, int height);
+
+        int yPosition;
+        int width;
+        int height;
+        int remainingWidth;
+    };*/
+/*
+    struct Rect {
+        unsigned int x1;
+        unsigned int y1;
+        unsigned int x2;
+        unsigned int y2;
+    };
+
+private:
+    unsigned int _width;
+    unsigned int _height;
+    bool _isDirty;
+    Rect _dirtyRect;
+
+    std::vector<uint8_t> _buffer;
+
+    std::unique_ptr<graphics::Texture2D> _texture;
+    std::unordered_map<std::size_t, FontCache::Entry> _glyphs;
+    std::vector<Shelf> _shelves;
+};*/
+
+/**
+ * A glyph atlas is used to pack and manage several font glyphs in to a single atlas texture.
+ * A single glyph atlas can be used to store glyphs from multiple fonts.
+ */
+class FontCache
+{
+public:
+	struct Entry
+	{
+		Glyph glyph;
+		float u0;
+		float v0;
+		float u1;
+		float v1;
+	};
+
+public:
+	FontCache(unsigned int width = 1024, unsigned int height = 1024);
+
+	FontCache::Entry Get(Font* font, codepoint_t codepoint);
+	FontCache::Entry Set(std::size_t key, const Glyph& glyph, const uint8_t* bitmap);
+
+	const graphics::Texture2D& GetTexture();
+
+private:
+	std::size_t getKey(Font* font, codepoint_t codepoint) const;
+
+private:
+	struct Shelf
+	{
+		Shelf(int pos, int width, int height);
+		bool Fits(int width, int height);
+		int Reserve(int width, int height);
+
+		int yPosition;
+		int width;
+		int height;
+		int remainingWidth;
+	};
+
+	struct Rect
+	{
+		unsigned int x1;
+		unsigned int y1;
+		unsigned int x2;
+		unsigned int y2;
+	};
+
+private:
+	unsigned int _width;
+	unsigned int _height;
+	bool _isDirty;
+	Rect _dirtyRect;
+
+	std::unique_ptr<uint8_t> _buffer;
+	std::unique_ptr<graphics::Texture2D> _texture;
+	std::unordered_map<std::size_t, FontCache::Entry> _glyphs;
+	std::vector<Shelf> _shelves;
+};
+
+} // namespace openblack
+
+#endif

--- a/src/Graphics/RenderPass.h
+++ b/src/Graphics/RenderPass.h
@@ -24,6 +24,7 @@ enum class RenderPass : uint8_t
 	Main,
 	ImGui,
 	MeshViewer,
+	Gui,
 
 	_count
 };
@@ -34,6 +35,7 @@ static constexpr std::array<std::string_view, static_cast<uint8_t>(RenderPass::_
     "Main Pass",        //
     "ImGui Pass",       //
     "Mesh Viewer Pass", //
+    "GUI Pass",
 };
 
 } // namespace openblack::graphics

--- a/src/Graphics/ShaderManager.cpp
+++ b/src/Graphics/ShaderManager.cpp
@@ -81,6 +81,11 @@
 #include "ShaderIncluder.h"
 #define SHADER_NAME fs_footprint
 #include "ShaderIncluder.h"
+
+#define SHADER_NAME vs_text
+#include "ShaderIncluder.h"
+#define SHADER_NAME fs_text
+#include "ShaderIncluder.h"
 // clang-format on
 
 namespace openblack::graphics
@@ -93,9 +98,10 @@ struct ShaderDefinition
 	const std::string_view fragmentShaderName;
 };
 
-const std::array<bgfx::EmbeddedShader, 17> k_EmbeddedShaders = {{
+const std::array<bgfx::EmbeddedShader, 19> k_EmbeddedShaders = {{
     BGFX_EMBEDDED_SHADER(vs_line), BGFX_EMBEDDED_SHADER(vs_line_instanced),                                                   //
     BGFX_EMBEDDED_SHADER(fs_line),                                                                                            //
+    BGFX_EMBEDDED_SHADER(vs_text), BGFX_EMBEDDED_SHADER(fs_text),                                                             //
     BGFX_EMBEDDED_SHADER(vs_object), BGFX_EMBEDDED_SHADER(vs_object_instanced), BGFX_EMBEDDED_SHADER(vs_object_hm_instanced), //
     BGFX_EMBEDDED_SHADER(fs_object), BGFX_EMBEDDED_SHADER(fs_sky),                                                            //
     BGFX_EMBEDDED_SHADER(vs_terrain), BGFX_EMBEDDED_SHADER(fs_terrain),                                                       //
@@ -113,6 +119,7 @@ constexpr std::array k_Shaders {
     ShaderDefinition {"ObjectInstanced", "vs_object_instanced", "fs_object"},
     ShaderDefinition {"ObjectHeightMapInstanced", "vs_object_hm_instanced", "fs_object"},
     ShaderDefinition {"Sky", "vs_object", "fs_sky"},
+    ShaderDefinition {"Text", "vs_text", "fs_text"},
     ShaderDefinition {"Water", "vs_water", "fs_water"},
     ShaderDefinition {"Sprite", "vs_sprite", "fs_sprite"},
     ShaderDefinition {"FootprintInstanced", "vs_footprint_instanced", "fs_footprint"},

--- a/src/Graphics/TextRenderer.cpp
+++ b/src/Graphics/TextRenderer.cpp
@@ -1,0 +1,182 @@
+/******************************************************************************
+ * Copyright (c) 2018-2023 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *******************************************************************************/
+
+#include "TextRenderer.h"
+
+#include <bgfx/embedded_shader.h>
+#include <bx/math.h>
+#include <imgui.h>
+
+#include "Graphics/ShaderManager.h"
+#include "Graphics/Texture2D.h"
+#include "Renderer.h"
+
+namespace openblack
+{
+
+TextRenderer::TextRenderer(bgfx::ViewId viewId, const Renderer& renderer)
+    : _vertexBuffer(BGFX_INVALID_HANDLE)
+    , _indexBuffer(BGFX_INVALID_HANDLE)
+    , _s_tex(BGFX_INVALID_HANDLE)
+    , _u_textColor(BGFX_INVALID_HANDLE)
+    , _u_textPosition(BGFX_INVALID_HANDLE)
+    , _viewId(viewId)
+{
+	auto& shaderManager = renderer.GetShaderManager();
+	_program = shaderManager.GetShader("Text")->GetRawHandle();
+	CreateDeviceObjectsBgfx();
+}
+
+TextRenderer::~TextRenderer()
+{
+	if (bgfx::isValid(_vertexBuffer))
+		bgfx::destroy(_vertexBuffer);
+	if (bgfx::isValid(_indexBuffer))
+		bgfx::destroy(_indexBuffer);
+	if (bgfx::isValid(_s_tex))
+		bgfx::destroy(_s_tex);
+	if (bgfx::isValid(_u_textColor))
+		bgfx::destroy(_u_textColor);
+	if (bgfx::isValid(_u_textPosition))
+		bgfx::destroy(_u_textPosition);
+	if (bgfx::isValid(_program))
+		bgfx::destroy(_program);
+}
+
+void TextRenderer::CreateDeviceObjectsBgfx()
+{
+	bgfx::RendererType::Enum type = bgfx::getRendererType();
+
+	// _u_textColor = bgfx::createUniform("u_textColor", bgfx::UniformType::Vec4);
+	// _u_textPosition = bgfx::createUniform("u_textPosition", bgfx::UniformType::Vec4);
+
+	_layout.begin()
+	    .add(bgfx::Attrib::Position, 4, bgfx::AttribType::Float)
+	    //.add(bgfx::Attrib::TexCoord0, 2, bgfx::AttribType::Float)
+	    .add(bgfx::Attrib::Color0, 4, bgfx::AttribType::Float)
+	    .end();
+
+	_s_tex = bgfx::createUniform("s_tex", bgfx::UniformType::Sampler);
+}
+
+void TextRenderer::DrawText(const Font& font, const std::string& text)
+{
+	_vertices.clear();
+	_indices.clear();
+
+	_vertices.resize(text.length() * 4);
+	_indices.resize(text.length() * 6);
+
+	float x = 50;
+	int y = 800;
+
+	int vert = 0;
+	int idx = 0;
+
+	// todo: this doesn't support utf-8
+	for (const char& c : text)
+	{
+		if (c == ' ')
+		{
+			x += 10;
+			continue;
+		}
+
+		const Font::Glyph* glyph = font.FindGlyphNoFallback(c);
+
+		// todo: handle missing characters
+		if (glyph == nullptr)
+			continue;
+
+		const int w = glyph->fWidth;
+		const int h = font.GetSize();
+
+		_indices[idx++] = vert;     // TL
+		_indices[idx++] = vert + 1; // TR
+		_indices[idx++] = vert + 2; // BL
+		_indices[idx++] = vert + 1; // TR
+		_indices[idx++] = vert + 3; // BR
+		_indices[idx++] = vert + 2; // BL
+
+		const float r = 1.0;
+		const float g = 0.7;
+		const float b = 0.7;
+
+		// x -= glyph->unk2;
+
+		_vertices[vert++] = TextVertex {static_cast<float>(x), static_cast<float>(y), glyph->u0, glyph->v0, r, g, b, 1.0}; // TL
+		_vertices[vert++] =
+		    TextVertex {static_cast<float>(x + w), static_cast<float>(y), glyph->u1, glyph->v0, r, g, b, 1.0}; // TR
+		_vertices[vert++] =
+		    TextVertex {static_cast<float>(x), static_cast<float>(y + h), glyph->u0, glyph->v1, r, g, b, 1.0}; // BL
+		_vertices[vert++] =
+		    TextVertex {static_cast<float>(x + w), static_cast<float>(y + h), glyph->u1, glyph->v1, r, g, b, 1.0}; // BR
+
+		x += glyph->fWidth + glyph->fXoffset; // +glyph->unk2;
+	}
+
+	// todo: hold this elsewhere
+	auto const& texture = font.GetAtlasTexture();
+	_tempFontTex = texture.GetNativeHandle();
+
+	// split utf8 text into codepoints
+	// with each codepoint get the glyph info
+	// with each glyph info make 4 verts, 6 indices - verts: lx, (ly=0???), uv (3 float)
+	// spam it all into a vbo and add to bgfx list or w/e
+}
+
+void TextRenderer::Draw()
+{
+	// cheat and use imgui to get this lmao
+	const ImGuiIO& io = ImGui::GetIO();
+	const float width = io.DisplaySize.x;
+	const float height = io.DisplaySize.y;
+
+	bgfx::setViewMode(_viewId, bgfx::ViewMode::Sequential);
+
+	const bgfx::Caps* caps = bgfx::getCaps();
+	{
+		float ortho[16];
+		bx::mtxOrtho(ortho, 0.0f, width, height, 0.0f, 0.0f, 1000.0f, 0.0f, caps->homogeneousDepth);
+		bgfx::setViewTransform(_viewId, NULL, ortho);
+		bgfx::setViewRect(_viewId, 0, 0, uint16_t(width), uint16_t(height));
+	}
+
+	if (!bgfx::isValid(_vertexBuffer))
+	{
+		if (bgfx::isValid(_vertexBuffer))
+		{
+			bgfx::destroy(_vertexBuffer);
+		}
+		_vertexBuffer = bgfx::createDynamicVertexBuffer(_vertices.size(), _layout);
+	}
+	if (!bgfx::isValid(_indexBuffer))
+	{
+		if (bgfx::isValid(_indexBuffer))
+		{
+			bgfx::destroy(_indexBuffer);
+		}
+		_indexBuffer = bgfx::createDynamicIndexBuffer(_indices.size());
+	}
+
+	bgfx::update(_vertexBuffer, 0, bgfx::makeRef(_vertices.data(), _vertices.size() * sizeof(TextVertex)));
+	bgfx::update(_indexBuffer, 0, bgfx::makeRef(_indices.data(), _indices.size() * sizeof(uint16_t)));
+
+	bgfx::ProgramHandle program = _program;
+	uint64_t state = 0u | BGFX_STATE_WRITE_RGB | BGFX_STATE_WRITE_A | BGFX_STATE_MSAA;
+	state |= BGFX_STATE_BLEND_FUNC(BGFX_STATE_BLEND_SRC_ALPHA, BGFX_STATE_BLEND_INV_SRC_ALPHA);
+
+	bgfx::setState(state);
+	bgfx::setTexture(0, _s_tex, _tempFontTex);
+	bgfx::setVertexBuffer(0, _vertexBuffer, 0, _vertices.size());
+	bgfx::setIndexBuffer(_indexBuffer, 0, _indices.size());
+	bgfx::submit(_viewId, program);
+}
+
+} // namespace openblack

--- a/src/Graphics/TextRenderer.h
+++ b/src/Graphics/TextRenderer.h
@@ -1,0 +1,75 @@
+/******************************************************************************
+ * Copyright (c) 2018-2023 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *******************************************************************************/
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <bgfx/bgfx.h>
+
+#include "Graphics/Font/Font.h"
+
+namespace openblack
+{
+class Renderer;
+
+// data\\j0
+// data\\f1
+// data\\fneutral
+// data\\f3
+enum class TextType
+{
+	Good,
+	Evil,
+	Neutral
+};
+
+class TextRenderer
+{
+public:
+	TextRenderer(bgfx::ViewId viewId, const Renderer& renderer);
+	~TextRenderer();
+
+	void CreateDeviceObjectsBgfx();
+
+	void DrawText(const Font& font, const std::string& text);
+	void Draw();
+
+private:
+	struct TextVertex
+	{
+		float x;
+		float y;
+		float u;
+		float v;
+		float r;
+		float g;
+		float b;
+		float a;
+	};
+
+	std::vector<TextVertex> _vertices;
+	std::vector<uint16_t> _indices;
+
+	bgfx::TextureHandle _tempFontTex;
+
+	bgfx::DynamicVertexBufferHandle _vertexBuffer;
+	bgfx::DynamicIndexBufferHandle _indexBuffer;
+	uint32_t _vertexCount;
+	uint32_t _indexCount;
+	bgfx::VertexLayout _layout;
+	bgfx::ProgramHandle _program;
+	bgfx::UniformHandle _s_tex;
+	bgfx::UniformHandle _u_textColor;
+	bgfx::UniformHandle _u_textPosition;
+	const bgfx::ViewId _viewId;
+};
+} // namespace openblack

--- a/src/Graphics/Texture2D.cpp
+++ b/src/Graphics/Texture2D.cpp
@@ -137,6 +137,13 @@ void Texture2D::Create(uint16_t width, uint16_t height, uint16_t layers, Format 
 	Texture2D::Create(width, height, layers, format, wrapping, filter, bgfx::makeRef(data, size));
 }
 
+void Texture2D::Update(uint16_t x, uint16_t y, uint16_t width, uint16_t height, uint16_t layer, const void* data, size_t size)
+{
+	auto memory = bgfx::makeRef(data, size);
+	bgfx::updateTexture2D(_handle, layer, 0, x, y, width, height, memory);
+	bgfx::frame();
+}
+
 void Texture2D::DumpTexture() const
 {
 	assert(!_name.empty());

--- a/src/Graphics/Texture2D.h
+++ b/src/Graphics/Texture2D.h
@@ -112,6 +112,8 @@ public:
 	            Wrapping wrapping = Wrapping::ClampEdge, Filter filter = Filter::Linear, const void* data = nullptr,
 	            uint32_t size = 0);
 
+	void Update(uint16_t x, uint16_t y, uint16_t width, uint16_t height, uint16_t layer, const void* data, size_t size);
+
 	[[nodiscard]] const std::string& GetName() const { return _name; }
 	[[nodiscard]] const bgfx::TextureHandle& GetNativeHandle() const { return _handle; }
 	[[nodiscard]] uint16_t GetWidth() const { return _info.width; }

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -481,6 +481,13 @@ void Renderer::DrawScene(const DrawSceneDesc& drawDesc) const
 		auto section = drawDesc.profiler.BeginScoped(Profiler::Stage::MainPass);
 		DrawPass(drawDesc);
 	}
+
+	// Draw some text
+	{
+
+		// auto textShader = _shaderManager->GetShader("Text");
+		// textShader->SetTextureSampler()
+	}
 }
 
 void Renderer::DrawPass(const DrawSceneDesc& desc) const

--- a/src/Util/Hash.h
+++ b/src/Util/Hash.h
@@ -1,0 +1,25 @@
+/******************************************************************************
+ * Copyright (c) 2018-2023 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *******************************************************************************/
+
+#pragma once
+
+#include <cstddef>
+
+#include <functional>
+
+namespace openblack
+{
+// https://www.boost.org/doc/libs/1_70_0/doc/html/hash/reference.html#boost.hash_combine
+template <class T>
+inline void hash_combine(std::size_t& seed, const T& v)
+{
+	const std::hash<T> hasher;
+	seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+} // namespace openblack


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1388267/81360856-c7562700-90d4-11ea-9282-a2a973163753.png)

The game implements it's own custom font format, we read this in as glyphs and convert it to a texture atlas which we can then render directly on the screen.

I believe the game does box filtering on this font for anti aliasing too, however this isn't something I've implemented yet.