### PR TITLE
Filesystem and cleanup

### DIFF
--- a/src/3D/AnimationPack.cpp
+++ b/src/3D/AnimationPack.cpp
@@ -22,18 +22,18 @@ AnimationPack::AnimationPack() = default;
 
 AnimationPack::~AnimationPack() = default;
 
-void AnimationPack::LoadFromFile(const std::string& filename)
+void AnimationPack::LoadFromFile(const fs::path& path)
 {
-	spdlog::debug("Loading Mesh Pack from file: {}", filename);
+	spdlog::debug("Loading Mesh Pack from file: {}", path.generic_string());
 	pack::PackFile pack;
 
 	try
 	{
-		pack.Open(Game::instance()->GetFileSystem().FindPath(filename).u8string());
+		pack.Open(Game::instance()->GetFileSystem().FindPath(path).u8string());
 	}
 	catch (std::runtime_error& err)
 	{
-		spdlog::error("Failed to open {}: {}", filename, err.what());
+		spdlog::error("Failed to open {}: {}", path.generic_string(), err.what());
 		return;
 	}
 

--- a/src/3D/AnimationPack.h
+++ b/src/3D/AnimationPack.h
@@ -11,7 +11,13 @@
 
 #include <cstdint>
 
+#ifdef HAS_FILESYSTEM
 #include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif // HAS_FILESYSTEM
 #include <memory>
 #include <vector>
 
@@ -26,7 +32,7 @@ public:
 	AnimationPack();
 	virtual ~AnimationPack();
 
-	void LoadFromFile(const std::string& filename);
+	void LoadFromFile(const fs::path& path);
 
 	using AnimationVec = std::vector<std::unique_ptr<L3DAnim>>;
 	[[nodiscard]] const AnimationVec& GetAnimations() const { return _animations; }

--- a/src/3D/L3DAnim.cpp
+++ b/src/3D/L3DAnim.cpp
@@ -53,18 +53,18 @@ void L3DAnim::Load(const anm::ANMFile& anm)
 	}
 }
 
-void L3DAnim::LoadFromFile(const std::string& fileName)
+void L3DAnim::LoadFromFile(const fs::path& path)
 {
-	spdlog::debug("Loading L3DAnim from file: {}", fileName);
+	spdlog::debug("Loading L3DAnim from file: {}", path.generic_string());
 	anm::ANMFile anm;
 
 	try
 	{
-		anm.Open(Game::instance()->GetFileSystem().FindPath(fileName).u8string());
+		anm.Open(Game::instance()->GetFileSystem().FindPath(path).u8string());
 	}
 	catch (std::runtime_error& err)
 	{
-		spdlog::error("Failed to open l3d mesh from filesystem {}: {}", fileName, err.what());
+		spdlog::error("Failed to open l3d mesh from filesystem {}: {}", path.generic_string(), err.what());
 		return;
 	}
 

--- a/src/3D/L3DAnim.h
+++ b/src/3D/L3DAnim.h
@@ -11,10 +11,16 @@
 
 #include <cstdint>
 
-#include <glm/fwd.hpp>
-
-#include <string>
+#ifdef HAS_FILESYSTEM
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif // HAS_FILESYSTEM
 #include <vector>
+
+#include <glm/fwd.hpp>
 
 namespace openblack
 {
@@ -36,7 +42,7 @@ public:
 	virtual ~L3DAnim() = default;
 
 	void Load(const anm::ANMFile& anm);
-	void LoadFromFile(const std::string& fileName);
+	void LoadFromFile(const fs::path& path);
 	void LoadFromBuffer(const std::vector<uint8_t>& data);
 
 	[[nodiscard]] const std::string& GetName() const { return _name; }

--- a/src/3D/L3DMesh.cpp
+++ b/src/3D/L3DMesh.cpp
@@ -71,18 +71,18 @@ void L3DMesh::Load(const l3d::L3DFile& l3d)
 	bgfx::frame();
 }
 
-void L3DMesh::LoadFromFile(const std::string& fileName)
+void L3DMesh::LoadFromFile(const fs::path& path)
 {
-	spdlog::debug("Loading L3DMesh from file: {}", fileName);
+	spdlog::debug("Loading L3DMesh from file: {}", path.generic_string());
 	l3d::L3DFile l3d;
 
 	try
 	{
-		l3d.Open(Game::instance()->GetFileSystem().FindPath(fileName).u8string());
+		l3d.Open(Game::instance()->GetFileSystem().FindPath(path).u8string());
 	}
 	catch (std::runtime_error& err)
 	{
-		spdlog::error("Failed to open l3d mesh from filesystem {}: {}", fileName, err.what());
+		spdlog::error("Failed to open l3d mesh from filesystem {}: {}", path.generic_string(), err.what());
 		return;
 	}
 

--- a/src/3D/L3DMesh.h
+++ b/src/3D/L3DMesh.h
@@ -9,13 +9,21 @@
 
 #pragma once
 
+#ifdef HAS_FILESYSTEM
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif // HAS_FILESYSTEM
+#include <unordered_map>
+
+#include <glm/gtc/quaternion.hpp>
+
 #include "Graphics/Mesh.h"
 #include "Graphics/ShaderProgram.h"
 #include "Graphics/Texture2D.h"
 #include "L3DSubMesh.h"
-
-#include <glm/gtc/quaternion.hpp>
-#include <unordered_map>
 
 namespace openblack
 {
@@ -75,7 +83,7 @@ public:
 	~L3DMesh() = default;
 
 	void Load(const l3d::L3DFile& l3d);
-	void LoadFromFile(const std::string& fileName);
+	void LoadFromFile(const fs::path& path);
 	void LoadFromBuffer(const std::vector<uint8_t>& data);
 
 	[[nodiscard]] uint8_t GetNumSubMeshes() const { return _subMeshes.size(); }

--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -29,7 +29,8 @@ const float LandIsland::CellSize = 10.0f;
 LandIsland::LandIsland()
     : _blockIndexLookup {0}
 {
-	auto file = Game::instance()->GetFileSystem().Open("Data/Textures/smallbumpa.raw", FileMode::Read);
+	auto& filesystem = Game::instance()->GetFileSystem();
+	auto file = filesystem.Open(filesystem.TexturePath() / "smallbumpa.raw", FileMode::Read);
 	auto* smallbumpa = new uint8_t[file->Size()];
 	file->Read(smallbumpa, file->Size());
 

--- a/src/3D/MeshPack.cpp
+++ b/src/3D/MeshPack.cpp
@@ -25,18 +25,18 @@
 namespace openblack
 {
 
-void MeshPack::LoadFromFile(const std::string& filename)
+void MeshPack::LoadFromFile(const fs::path& path)
 {
-	spdlog::debug("Loading Mesh Pack from file: {}", filename);
+	spdlog::debug("Loading Mesh Pack from file: {}", path.generic_string());
 	pack::PackFile pack;
 
 	try
 	{
-		pack.Open(Game::instance()->GetFileSystem().FindPath(filename).u8string());
+		pack.Open(Game::instance()->GetFileSystem().FindPath(path).u8string());
 	}
 	catch (std::runtime_error& err)
 	{
-		spdlog::error("Failed to open {}: {}", filename, err.what());
+		spdlog::error("Failed to open {}: {}", path.generic_string(), err.what());
 		return;
 	}
 

--- a/src/3D/MeshPack.h
+++ b/src/3D/MeshPack.h
@@ -9,9 +9,15 @@
 
 #pragma once
 
+#ifdef HAS_FILESYSTEM
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif // HAS_FILESYSTEM
 #include <map>
 #include <memory>
-#include <string>
 #include <vector>
 
 namespace openblack
@@ -41,7 +47,7 @@ class MeshPack
 public:
 	MeshPack() = default;
 
-	void LoadFromFile(const std::string& filename);
+	void LoadFromFile(const fs::path& path);
 
 	using MeshesVec = std::vector<std::unique_ptr<L3DMesh>>;
 	using TexturesVec = std::vector<std::unique_ptr<graphics::Texture2D>>;

--- a/src/3D/Sky.cpp
+++ b/src/3D/Sky.cpp
@@ -9,15 +9,14 @@
 
 #include "Sky.h"
 
-#include "3D/L3DMesh.h"
-#include "Common/Bitmap16B.h"
-#include "Graphics/ShaderProgram.h"
-#include "Graphics/Texture2D.h"
-
-#include <glm/glm.hpp>
-#include <glm/gtc/type_ptr.hpp>
 #include <spdlog/fmt/fmt.h>
 #include <spdlog/spdlog.h>
+
+#include "3D/L3DMesh.h"
+#include "Common/Bitmap16B.h"
+#include "Common/FileSystem.h"
+#include "Game.h"
+#include "Graphics/Texture2D.h"
 
 constexpr std::array<std::string_view, 3> alignments = {"Ntrl", "good", "evil"};
 constexpr std::array<std::string_view, 3> times = {"day", "dusk", "night"};
@@ -32,8 +31,9 @@ Sky::Sky()
 	SetDayNightTimes(4.5, 7.0, 7.5, 8.25);
 
 	// load in the mesh
+	auto& filesystem = Game::instance()->GetFileSystem();
 	_model = std::make_unique<L3DMesh>("Sky");
-	_model->LoadFromFile("./Data/WeatherSystem/sky.l3d");
+	_model->LoadFromFile(filesystem.WeatherSystemPath() / "sky.l3d");
 
 	for (uint32_t i = 0; i < alignments.size(); i++)
 	{
@@ -49,8 +49,8 @@ Sky::Sky()
 			{
 				filename[0] = std::toupper(filename[0]);
 			}
-			std::string path = fmt::format("./Data/WeatherSystem/{}", filename);
-			spdlog::debug("Loading sky texture: {}", path);
+			auto path = filesystem.WeatherSystemPath() / filename;
+			spdlog::debug("Loading sky texture: {}", path.generic_string());
 
 			Bitmap16B* bitmap = Bitmap16B::LoadFromFile(path);
 			memcpy(_bitmaps[i * 3 + j].data(), bitmap->Data(), bitmap->Size());

--- a/src/3D/Water.cpp
+++ b/src/3D/Water.cpp
@@ -31,7 +31,8 @@ Water::Water()
 	    std::make_unique<FrameBuffer>("Reflection", 1024, 1024, graphics::Format::RGBA8, graphics::Format::Depth24Stencil8);
 
 	// water texture (256x256 RAW RGB 24bpp)
-	auto const& waterTextureData = Game::instance()->GetFileSystem().ReadAll("Data/Textures/Sky.raw");
+	auto& filesystem = Game::instance()->GetFileSystem();
+	auto const& waterTextureData = filesystem.ReadAll(filesystem.TexturePath() / "Sky.raw");
 	const uint16_t textureWidth = 256, textureHeight = 256;
 
 	_texture = std::make_unique<Texture2D>("Water");

--- a/src/Common/Bitmap16B.cpp
+++ b/src/Common/Bitmap16B.cpp
@@ -9,13 +9,10 @@
 
 #include "Bitmap16B.h"
 
+#include <cstring> // memcpy
+
 #include "FileSystem.h"
 #include "Game.h"
-
-#include <cassert>
-#include <cstring> // memset, memcpy
-#include <sstream>
-#include <stdexcept>
 
 using namespace openblack;
 
@@ -34,9 +31,9 @@ Bitmap16B::~Bitmap16B()
 	delete[] _data;
 }
 
-Bitmap16B* Bitmap16B::LoadFromFile(const std::string& strFile)
+Bitmap16B* Bitmap16B::LoadFromFile(const fs::path& path)
 {
-	auto const& data = Game::instance()->GetFileSystem().ReadAll(strFile);
+	auto const& data = Game::instance()->GetFileSystem().ReadAll(path);
 	auto* bitmap = new Bitmap16B(data.data());
 
 	return bitmap;

--- a/src/Common/Bitmap16B.h
+++ b/src/Common/Bitmap16B.h
@@ -12,6 +12,14 @@
 #include <cstdint>
 #include <string>
 
+#ifdef HAS_FILESYSTEM
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif // HAS_FILESYSTEM
+
 namespace openblack
 {
 class Bitmap16B
@@ -34,7 +42,7 @@ private:
 	size_t _size;
 
 public:
-	static Bitmap16B* LoadFromFile(const std::string& file);
+	static Bitmap16B* LoadFromFile(const fs::path& path);
 };
 
 } // namespace openblack

--- a/src/Common/FileSystem.cpp
+++ b/src/Common/FileSystem.cpp
@@ -11,14 +11,15 @@
 
 #include <algorithm>
 #include <array>
+#include <cctype>
 #include <cstddef>
 
 namespace openblack
 {
 
-std::string FileSystem::FixPath(const std::string& path)
+fs::path FileSystem::FixPath(const fs::path& path)
 {
-	std::string result = path;
+	std::string result = path.generic_string();
 
 	constexpr std::array<std::string_view, 3> caseFixTable = {
 	    "\\Data\\",

--- a/src/Common/FileSystem.h
+++ b/src/Common/FileSystem.h
@@ -25,6 +25,22 @@ FileSystem
 class FileSystem
 {
 public:
+	static inline fs::path ScriptsPath() { return "Scripts"; }
+
+	static inline fs::path PlaygroundPath() { return ScriptsPath() / "Playgrounds"; }
+
+	static inline fs::path QuestsPath() { return ScriptsPath() / "Quests"; }
+
+	static inline fs::path DataPath() { return "Data"; }
+
+	static inline fs::path MiscPath() { return DataPath() / "Misc"; }
+
+	static inline fs::path TexturePath() { return DataPath() / "Textures"; }
+
+	static inline fs::path WeatherSystemPath() { return DataPath() / "WeatherSystem"; }
+
+	static inline fs::path CreatureMeshPath() { return DataPath() / "CreatureMesh"; }
+
 	static fs::path FixPath(const fs::path& path);
 
 	[[nodiscard]] fs::path FindPath(const fs::path& path) const;

--- a/src/Common/FileSystem.h
+++ b/src/Common/FileSystem.h
@@ -14,7 +14,6 @@
 #include <cstddef>
 #include <list>
 #include <memory>
-#include <string>
 #include <vector>
 
 namespace openblack
@@ -26,7 +25,7 @@ FileSystem
 class FileSystem
 {
 public:
-	static std::string FixPath(const std::string& path);
+	static fs::path FixPath(const fs::path& path);
 
 	[[nodiscard]] fs::path FindPath(const fs::path& path) const;
 

--- a/src/Console.cpp
+++ b/src/Console.cpp
@@ -108,7 +108,6 @@ int Console::InputTextCallback(ImGuiInputTextCallbackData* data)
 		{
 			if (word_end == word_start || strncmp(Command.first.c_str(), word_start, (int)(word_end - word_start)) == 0)
 			{
-				printf("%s", Command.first.c_str());
 				candidates.push_back(Command.first);
 			}
 		}

--- a/src/Entities/Components/Abode.h
+++ b/src/Entities/Components/Abode.h
@@ -11,6 +11,9 @@
 
 #include "Enums.h"
 
+namespace openblack
+{
+
 struct Abode
 {
 	openblack::AbodeInfo abodeInfo;
@@ -20,3 +23,5 @@ struct Abode
 	uint32_t foodAmount;
 	uint32_t woodAmount;
 };
+
+} // namespace openblack

--- a/src/Entities/Components/Tree.h
+++ b/src/Entities/Components/Tree.h
@@ -11,7 +11,12 @@
 
 #include "Enums.h"
 
+namespace openblack
+{
+
 struct Tree
 {
 	openblack::TreeInfo treeInfo;
 };
+
+} // namespace openblack

--- a/src/Entities/Components/Velocity.h
+++ b/src/Entities/Components/Velocity.h
@@ -9,9 +9,14 @@
 
 #pragma once
 
+namespace openblack
+{
+
 struct Velocity
 {
 	float dX;
 	float dY;
 	float dZ;
 };
+
+} // namespace openblack

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -81,7 +81,7 @@ Game::Game(Arguments&& args)
 	_renderer = std::make_unique<Renderer>(_window.get(), args.rendererType, args.vsync);
 	_fileSystem->SetGamePath(GetGamePath());
 	_handModel = std::make_unique<L3DMesh>();
-	_handModel->LoadFromFile("Data/CreatureMesh/Hand_Boned_Base2.l3d");
+	_handModel->LoadFromFile(_fileSystem->CreatureMeshPath() / "Hand_Boned_Base2.l3d");
 	spdlog::debug("The GamePath is \"{}\".", _fileSystem->GetGamePath().generic_string());
 
 	_gui = Gui::create(_window.get(), graphics::RenderPass::ImGui, args.scale);
@@ -284,28 +284,28 @@ void Game::Run()
 	_camera->SetRotation(glm::vec3(0.0f, -45.0f, 0.0f));
 
 	_meshPack = std::make_unique<MeshPack>();
-	_meshPack->LoadFromFile("Data/AllMeshes.g3d");
+	_meshPack->LoadFromFile(_fileSystem->DataPath() / "AllMeshes.g3d");
 
 	_animationPack = std::make_unique<AnimationPack>();
-	_animationPack->LoadFromFile("Data/AllAnims.anm");
+	_animationPack->LoadFromFile(_fileSystem->DataPath() / "AllAnims.anm");
 
 	_testModel = std::make_unique<L3DMesh>();
-	_testModel->LoadFromFile("Data/Misc/coffre.l3d");
+	_testModel->LoadFromFile(_fileSystem->MiscPath() / "coffre.l3d");
 
 	_testAnimation = std::make_unique<L3DAnim>();
-	_testAnimation->LoadFromFile("Data/Misc/coffre.anm");
+	_testAnimation->LoadFromFile(_fileSystem->MiscPath() / "coffre.anm");
 
 	_handModel = std::make_unique<L3DMesh>();
-	_handModel->LoadFromFile("Data/CreatureMesh/Hand_Boned_Base2.l3d");
+	_handModel->LoadFromFile(_fileSystem->CreatureMeshPath() / "Hand_Boned_Base2.l3d");
 
 	_sky = std::make_unique<Sky>();
 	_water = std::make_unique<Water>();
 
 	LoadVariables();
-	LoadMap("./Scripts/Land1.txt");
+	LoadMap(_fileSystem->ScriptsPath() / "Land1.txt");
 
 	// _lhvm = std::make_unique<LHVM::LHVM>();
-	// _lhvm->LoadBinary(GetGamePath() + "/Scripts/Quests/challenge.chl");
+	// _lhvm->LoadBinary(GetGamePath() + fileSystem->QuestsPath() / "challenge.chl");
 
 	if (_window)
 	{
@@ -411,7 +411,7 @@ void Game::LoadVariables()
 {
 	return;
 
-	auto file = _fileSystem->Open("Scripts/info.dat", FileMode::Read);
+	auto file = _fileSystem->Open(_fileSystem->ScriptsPath() / "info.dat", FileMode::Read);
 
 	// check magic header
 	constexpr char kLionheadMagic[] = "LiOnHeAd";

--- a/src/Game.h
+++ b/src/Game.h
@@ -9,17 +9,25 @@
 
 #pragma once
 
-#include "GameWindow.h"
-
-#include <LHVM/LHVM.h>
-#include <SDL.h>
-#include <bgfx/bgfx.h>
-#include <glm/glm.hpp>
-
-#include <entt/entity/fwd.hpp>
+#ifdef HAS_FILESYSTEM
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif // HAS_FILESYSTEM
 #include <memory>
 #include <string>
 #include <vector>
+
+#include <SDL.h>
+#include <bgfx/bgfx.h>
+#include <entt/entity/fwd.hpp>
+#include <glm/glm.hpp>
+
+#include <LHVM/LHVM.h>
+
+#include "GameWindow.h"
 
 namespace openblack
 {
@@ -102,13 +110,13 @@ public:
 	bool Update();
 	void Run();
 
-	void LoadMap(const std::string& name);
-	void LoadLandscape(const std::string& name);
+	void LoadMap(const fs::path& path);
+	void LoadLandscape(const fs::path& path);
 
 	void LoadVariables();
 
-	void SetGamePath(const std::string& gamePath);
-	const std::string& GetGamePath();
+	void SetGamePath(const fs::path& path);
+	const fs::path& GetGamePath();
 
 	GameWindow* GetWindow() { return _window.get(); }
 	[[nodiscard]] const GameWindow& GetWindow() const { return *_window; }
@@ -139,7 +147,8 @@ public:
 private:
 	static Game* sInstance;
 
-	std::string sGamePath; // path to Lionhead Studios Ltd/Black & White folder
+	/// path to Lionhead Studios Ltd/Black & White folder
+	fs::path _gamePath;
 
 	std::unique_ptr<GameWindow> _window;
 	std::unique_ptr<Renderer> _renderer;

--- a/src/Gui.cpp
+++ b/src/Gui.cpp
@@ -9,11 +9,24 @@
 
 #include "Gui.h"
 
+#include <bgfx/bgfx.h>
+#include <bgfx/embedded_shader.h>
+#include <bx/math.h>
+#include <bx/timer.h>
+#include <imgui.h>
+#include <imgui_widget_flamegraph.h>
+#ifdef _WIN32
+#include <SDL2/SDL_syswm.h>
+#endif
+
+#include <LNDFile.h>
+
 #include "3D/Camera.h"
 #include "3D/LandIsland.h"
 #include "3D/MeshPack.h"
 #include "3D/Sky.h"
 #include "3D/Water.h"
+#include "Common/FileSystem.h"
 #include "Console.h"
 #include "Entities/Components/Transform.h"
 #include "Entities/Components/Tree.h"
@@ -27,17 +40,6 @@
 #include "LHVMViewer.h"
 #include "MeshViewer.h"
 #include "Profiler.h"
-
-#include <LNDFile.h>
-#include <bgfx/bgfx.h>
-#include <bgfx/embedded_shader.h>
-#include <bx/math.h>
-#include <bx/timer.h>
-#include <imgui.h>
-#include <imgui_widget_flamegraph.h>
-#ifdef _WIN32
-#include <SDL2/SDL_syswm.h>
-#endif
 
 using namespace openblack;
 
@@ -488,33 +490,35 @@ bool Gui::Loop(Game& game, const Renderer& renderer)
 		if (ImGui::BeginMenu("Load Island"))
 		{
 			constexpr std::array<std::pair<std::string_view, std::string_view>, 6> RegularIslands = {
-			    std::pair {"Land 1", "./Scripts/Land1.txt"}, std::pair {"Land 2", "./Scripts/Land2.txt"},
-			    std::pair {"Land 3", "./Scripts/Land3.txt"}, std::pair {"Land 4", "./Scripts/Land4.txt"},
-			    std::pair {"Land 5", "./Scripts/Land5.txt"}, std::pair {"God's Playground", "./Scripts/LandT.txt"},
+			    std::pair {"Land 1", "Land1.txt"}, std::pair {"Land 2", "Land2.txt"},
+			    std::pair {"Land 3", "Land3.txt"}, std::pair {"Land 4", "Land4.txt"},
+			    std::pair {"Land 5", "Land5.txt"}, std::pair {"God's Playground", "LandT.txt"},
 			};
 			constexpr std::array<std::pair<std::string_view, std::string_view>, 3> PlaygroundIslands = {
-			    std::pair {"Two Gods", "./Scripts/Playgrounds/TwoGods.txt"},
-			    std::pair {"Three Gods", "./Scripts/Playgrounds/ThreeGods.txt"},
-			    std::pair {"Four Gods", "./Scripts/Playgrounds/FourGods.txt"},
+			    std::pair {"Two Gods", "TwoGods.txt"},
+			    std::pair {"Three Gods", "ThreeGods.txt"},
+			    std::pair {"Four Gods", "FourGods.txt"},
 			};
 
-			auto menu_item = [&game](auto label, auto path) {
+			auto menu_item = [&game](const auto& label, const fs::path& path) {
 				if (ImGui::MenuItem(label.data()))
-					game.LoadMap(path.data());
+					game.LoadMap(path);
 				if (ImGui::IsItemHovered())
-					ImGui::SetTooltip("%s", path.data());
+					ImGui::SetTooltip("%s", path.generic_string().c_str());
 			};
 
-			ImGui::MenuItem("Story Islands", NULL, false, false);
+			auto& filesystem = Game::instance()->GetFileSystem();
+
+			ImGui::MenuItem("Story Islands", nullptr, false, false);
 			for (auto& [label, path] : RegularIslands)
 			{
-				menu_item(label, path);
+				menu_item(label, filesystem.ScriptsPath() / path);
 			}
 			ImGui::Separator();
-			ImGui::MenuItem("Playground Islands", NULL, false, false);
+			ImGui::MenuItem("Playground Islands", nullptr, false, false);
 			for (auto& [label, path] : PlaygroundIslands)
 			{
-				menu_item(label, path);
+				menu_item(label, filesystem.PlaygroundPath() / path);
 			}
 
 			ImGui::EndMenu();


### PR DESCRIPTION
Cleaning up the file system interface a little by using `fs::path` instead of string where it is logical.
Moving free uses of hard coded file paths to centralized place.