### PR TITLE
fot: Add footpath file parsing

### DIFF
--- a/src/Common/FileSystem.h
+++ b/src/Common/FileSystem.h
@@ -35,6 +35,8 @@ public:
 
 	static inline fs::path MiscPath() { return DataPath() / "Misc"; }
 
+	static inline fs::path LandscapePath() { return DataPath() / "Landscape"; }
+
 	static inline fs::path TexturePath() { return DataPath() / "Textures"; }
 
 	static inline fs::path WeatherSystemPath() { return DataPath() / "WeatherSystem"; }

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -38,6 +38,7 @@
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/spdlog.h>
 
+#include <Serializer/FotFile.h>
 #include <cstdint>
 #include <string>
 
@@ -391,6 +392,22 @@ void Game::LoadMap(const fs::path& path)
 
 	Script script(this);
 	script.Load(source);
+
+	// Each released map comes with an optional .fot file which contains the footpath information for the map
+	auto stem = path.stem().generic_string();
+	std::transform(stem.begin(), stem.end(), stem.begin(), [](auto c) { return std::tolower(c); });
+	auto fot_path = _fileSystem->LandscapePath() / fmt::format("{}.fot", stem);
+
+	if (_fileSystem->Exists(fot_path))
+	{
+		FotFile fotFile(*this);
+		fotFile.Load(fot_path);
+	}
+	else
+	{
+		spdlog::warn("The map at {} does not come with a footpath file. Expected {}", path.generic_string(),
+		             fot_path.generic_string());
+	}
 }
 
 void Game::LoadLandscape(const fs::path& path)

--- a/src/LHScriptX/FeatureScriptCommands.cpp
+++ b/src/LHScriptX/FeatureScriptCommands.cpp
@@ -719,7 +719,7 @@ void FeatureScriptCommands::CreateFootpath(int32_t footpathId)
 {
 	auto& registry = Game::instance()->GetEntityRegistry();
 	const auto entity = registry.Create();
-	registry.Assign<Footpath>(entity, footpathId);
+	registry.Assign<Footpath>(entity);
 	auto& registryContext = registry.Context();
 	registryContext.footpaths.insert({footpathId, entity});
 }

--- a/src/LHScriptX/ScriptingBindingUtils.h
+++ b/src/LHScriptX/ScriptingBindingUtils.h
@@ -17,19 +17,19 @@ namespace openblack::lhscriptx
 {
 
 template <typename T>
-ParameterType ParameterTypeStaticLookUp;
+static ParameterType ParameterTypeStaticLookUp;
 
 template <>
-constexpr ParameterType ParameterTypeStaticLookUp<glm::vec3> = ParameterType::Vector;
+inline ParameterType ParameterTypeStaticLookUp<glm::vec3> = ParameterType::Vector;
 
 template <>
-constexpr ParameterType ParameterTypeStaticLookUp<const std::string&> = ParameterType::String;
+inline ParameterType ParameterTypeStaticLookUp<const std::string&> = ParameterType::String;
 
 template <>
-constexpr ParameterType ParameterTypeStaticLookUp<float> = ParameterType::Float;
+inline ParameterType ParameterTypeStaticLookUp<float> = ParameterType::Float;
 
 template <>
-constexpr ParameterType ParameterTypeStaticLookUp<int32_t> = ParameterType::Number;
+inline ParameterType ParameterTypeStaticLookUp<int32_t> = ParameterType::Number;
 
 template <typename T>
 T GetParamValue(const ScriptCommandContext& ctx, int index);

--- a/src/Serializer/Common.h
+++ b/src/Serializer/Common.h
@@ -9,20 +9,18 @@
 
 #pragma once
 
-#include <glm/vec3.hpp>
-#include <vector>
+#include <cstdint>
 
-namespace openblack
+namespace openblack::serializer
 {
 
-struct FootpathNode
+#pragma pack(push, 1)
+struct MapCoords
 {
-	glm::vec3 position;
+	uint32_t x;
+	uint32_t z;
+	float altitude;
 };
+#pragma pack(pop)
 
-struct Footpath
-{
-	std::vector<FootpathNode> nodes;
-};
-
-} // namespace openblack
+} // namespace openblack::serializer

--- a/src/Serializer/FotFile.cpp
+++ b/src/Serializer/FotFile.cpp
@@ -1,0 +1,47 @@
+#include "FotFile.h"
+#include <Entities/Components/Footpath.h>
+#include <spdlog/spdlog.h>
+
+#include "3D/LandIsland.h"
+#include "Common/FileSystem.h"
+#include "Entities/Registry.h"
+#include "Game.h"
+#include "GameThingSerializer.h"
+
+using namespace openblack;
+
+FotFile::FotFile(Game& game)
+    : _game(game)
+{
+}
+
+void FotFile::Load(const fs::path& path)
+{
+	auto stream = _game.GetFileSystem().Open(path, FileMode::Read);
+	serializer::GameThingSerializer serializer(*stream);
+	auto footpath_link_saves = serializer.DeserializeList<serializer::GameThingSerializer::FootpathLinkSave>();
+	auto footpaths = serializer.DeserializeList<serializer::GameThingSerializer::Footpath>();
+	auto& registry = _game.GetEntityRegistry();
+	const auto& island = _game.GetLandIsland();
+
+	for (const auto& footpath : footpaths)
+	{
+		const auto entity = registry.Create();
+		auto& footpath_entt = registry.Assign<Footpath>(entity);
+		footpath_entt.nodes.reserve(footpath._nodes.size());
+		for (const auto& node : footpath._nodes)
+		{
+			glm::vec3 position = glm::vec3 {
+			    10.0f * node._coords.x / static_cast<float>(0xFFFF),
+			    node._coords.altitude,
+			    10.0f * node._coords.z / static_cast<float>(0xFFFF),
+			};
+
+			// This bit is mainly for visualization, it could be that using these offsets causes uses for path planning
+			// if that is the case, this bit should be moved to rendering code
+			position.y += island.GetHeightAt({position.x, position.z});
+
+			footpath_entt.nodes.push_back({position});
+		}
+	}
+}

--- a/src/Serializer/FotFile.h
+++ b/src/Serializer/FotFile.h
@@ -9,20 +9,29 @@
 
 #pragma once
 
-#include <glm/vec3.hpp>
-#include <vector>
+#include <cstdint>
+#ifdef HAS_FILESYSTEM
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif // HAS_FILESYSTEM
 
 namespace openblack
 {
 
-struct FootpathNode
-{
-	glm::vec3 position;
-};
+class Game;
 
-struct Footpath
+class FotFile
 {
-	std::vector<FootpathNode> nodes;
+public:
+	explicit FotFile(Game& game);
+
+	void Load(const fs::path& path);
+
+private:
+	Game& _game;
 };
 
 } // namespace openblack

--- a/src/Serializer/GameThingSerializer.cpp
+++ b/src/Serializer/GameThingSerializer.cpp
@@ -1,0 +1,189 @@
+/*****************************************************************************
+ * Copyright (c) 2018-2020 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include "GameThingSerializer.h"
+
+#include <cassert>
+
+#include <fmt/format.h>
+#include <spdlog/spdlog.h>
+
+#include "Common/FileStream.h"
+
+using namespace openblack::serializer;
+
+template <>
+GameThingType openblack::serializer::GameThingTypeEnum<GameThingSerializer::Footpath> = GameThingType::Footpath;
+
+template <>
+GameThingType openblack::serializer::GameThingTypeEnum<GameThingSerializer::FootpathLink> = GameThingType::FootpathLink;
+
+template <>
+GameThingType openblack::serializer::GameThingTypeEnum<GameThingSerializer::FootpathNode> = GameThingType::FootpathNode;
+
+template <>
+GameThingType openblack::serializer::GameThingTypeEnum<GameThingSerializer::FootpathLinkSave> = GameThingType::FootpathLinkSave;
+
+GameThingSerializer::GameThingSerializer(FileStream& stream)
+    : _stream(stream)
+    , _checkSum(0)
+{
+}
+
+template <typename T>
+T GameThingSerializer::ReadValue()
+{
+	auto result = _stream.ReadValue<T>();
+	_checkSum += static_cast<uint32_t>(*reinterpret_cast<uint8_t*>(&result)) + sizeof(result);
+	return result;
+}
+
+void GameThingSerializer::ReadChecksum()
+{
+	auto expectedSum = _checkSum;
+	auto readSum = ReadValue<uint32_t>();
+	if (expectedSum != readSum)
+	{
+		spdlog::error("Failed checksum (expected={:08X}, read={:08X}) at {:08X}", expectedSum, readSum, _stream.Position());
+		assert(false);
+	}
+}
+
+std::shared_ptr<GameThingSerializer::GameThing> GameThingSerializer::DeserializeOne(std::optional<GameThingType> required_type)
+{
+	auto offset = _stream.Position();
+	spdlog::debug("offset={}", offset);
+	auto index = ReadValue<uint32_t>();
+	spdlog::debug("index={}, len={}", index, _cache.size());
+
+	if (index == 0)
+	{
+		// TODO: not sure why there are these empty entries
+		return nullptr;
+	}
+
+	if (index == _cache.size() + 1)
+	{
+		auto type = ReadValue<GameThingType>();
+		if (type != required_type.value_or(type))
+		{
+			throw std::runtime_error(fmt::format("Type mismatch while parsing GameThing: got {} but expected {} at 0x{:08x}",
+			                                     type, *required_type, _stream.Position() - sizeof(GameThingType)));
+		}
+		auto player_id = ReadValue<uint32_t>();
+		ReadChecksum();
+		// TODO: validate checksum by adding up first byte of every read
+
+		std::shared_ptr<GameThing> thing;
+
+		switch (type)
+		{
+		case GameThingType::Footpath:
+			thing = std::make_unique<Footpath>();
+			break;
+		case GameThingType::FootpathLink:
+			thing = std::make_unique<FootpathLink>();
+			break;
+		case GameThingType::FootpathNode:
+			thing = std::make_unique<FootpathNode>();
+			break;
+		case GameThingType::FootpathLinkSave:
+			thing = std::make_unique<FootpathLinkSave>();
+			break;
+		default:
+			assert(false);
+		}
+
+		_cache.push_back(thing);
+
+		if (!thing->Deserialize(*this))
+		{
+			return nullptr;
+		}
+
+		// TODO return something?
+
+		return thing;
+	}
+	else if (index > _cache.size())
+	{
+		assert(false); // weird case
+		return nullptr;
+	}
+	else
+	{
+		// referring to a previously seen entry
+		return _cache[index - 1];
+	}
+}
+
+template <typename T>
+std::vector<T> GameThingSerializer::DeserializeList()
+{
+	auto count = ReadValue<uint32_t>();
+	std::vector<T> list;
+	list.reserve(count);
+	for (uint32_t i = 0; i < count; ++i)
+	{
+		spdlog::debug("i={}", i);
+		auto ptr = std::dynamic_pointer_cast<T>(DeserializeOne(GameThingTypeEnum<T>));
+		if (ptr)
+		{
+			list.push_back(*ptr);
+		}
+	}
+	return list;
+}
+
+bool GameThingSerializer::GameThing::Deserialize(GameThingSerializer& deserializer)
+{
+	_unknown1 = deserializer.ReadValue<uint32_t>();
+	_unknown2 = deserializer.ReadValue<uint8_t>();
+	return true;
+}
+
+bool GameThingSerializer::Footpath::Deserialize(GameThingSerializer& deserializer)
+{
+	GameThing::Deserialize(deserializer);
+	_nodes = deserializer.DeserializeList<FootpathNode>();
+	_unknown = deserializer.ReadValue<uint32_t>();
+	return true;
+}
+
+bool GameThingSerializer::FootpathLink::Deserialize(GameThingSerializer& deserializer)
+{
+	GameThing::Deserialize(deserializer);
+	_footpaths = deserializer.DeserializeList<Footpath>();
+	return true;
+}
+
+bool GameThingSerializer::FootpathNode::Deserialize(GameThingSerializer& deserializer)
+{
+	GameThing::Deserialize(deserializer);
+	_coords = deserializer.ReadValue<MapCoords>();
+	_unknown = deserializer.ReadValue<uint8_t>();
+	return true;
+}
+
+bool GameThingSerializer::FootpathLinkSave::Deserialize(GameThingSerializer& deserializer)
+{
+	GameThing::Deserialize(deserializer);
+	_coords = deserializer.ReadValue<MapCoords>();
+	auto thing = deserializer.DeserializeOne(GameThingType::FootpathLink);
+	if (thing)
+	{
+		assert(dynamic_cast<FootpathLink*>(thing.get()));
+		_link = *dynamic_cast<FootpathLink*>(thing.get());
+		return true;
+	}
+	return false;
+}
+
+// Force initialization of template function
+template std::vector<GameThingSerializer::FootpathLinkSave> GameThingSerializer::DeserializeList();

--- a/src/Serializer/GameThingSerializer.h
+++ b/src/Serializer/GameThingSerializer.h
@@ -1,0 +1,102 @@
+/*****************************************************************************
+ * Copyright (c) 2018-2020 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <type_traits>
+#include <vector>
+
+#include "Common.h"
+
+namespace openblack
+{
+class FileStream;
+}
+
+namespace openblack::serializer
+{
+
+enum class GameThingType : uint32_t
+{
+	Footpath = 0x1,
+	FootpathLink = 0x2,
+	FootpathNode = 0x3,
+	FootpathLinkSave = 0x4,
+};
+
+template <typename T>
+GameThingType GameThingTypeEnum;
+
+class GameThingSerializer
+{
+public:
+	struct GameThing
+	{
+		uint32_t _unknown1;
+		uint8_t _unknown2;
+
+		virtual bool Deserialize(GameThingSerializer& deserializer);
+	};
+
+	struct FootpathNode: GameThing
+	{
+		MapCoords _coords;
+		uint8_t _unknown;
+
+		bool Deserialize(GameThingSerializer& deserializer) override;
+	};
+
+	struct Footpath: GameThing
+	{
+		std::vector<FootpathNode> _nodes;
+		uint32_t _unknown;
+
+		bool Deserialize(GameThingSerializer& deserializer) override;
+	};
+
+	struct FootpathLink: GameThing
+	{
+		std::vector<Footpath> _footpaths;
+
+		bool Deserialize(GameThingSerializer& deserializer) override;
+	};
+
+	struct FootpathLinkSave: GameThing
+	{
+		MapCoords _coords;
+		FootpathLink _link;
+
+		bool Deserialize(GameThingSerializer& deserializer) override;
+	};
+
+	explicit GameThingSerializer(FileStream& stream);
+
+	template <typename T>
+	T ReadValue();
+
+	void ReadChecksum();
+
+	std::shared_ptr<GameThing> DeserializeOne(std::optional<GameThingType> required_type = std::nullopt);
+	template <typename T>
+	std::vector<T> DeserializeList();
+
+private:
+	Footpath* DeserializeFootpath();
+	FootpathLink* DeserializeFootpathLink();
+	FootpathNode* DeserializeFootpathNode();
+	FootpathLinkSave* DeserializeFootpathLinkSave();
+
+	FileStream& _stream;
+	uint32_t _checkSum;
+	std::vector<std::shared_ptr<GameThing>> _cache;
+};
+} // namespace openblack::serializer


### PR DESCRIPTION
Each released Scene is accompanied by a `Landscape/*.fot` file which contains footpath information and is of the same type as saved game file format. 

This also means that this parser is the beginning of a save file parser.

![Screenshot from 2020-10-16 21-53-30](https://user-images.githubusercontent.com/1013356/96326105-eea60e00-0ffb-11eb-9099-fa652328f640.png)
![Screenshot from 2020-10-16 21-53-52](https://user-images.githubusercontent.com/1013356/96326108-f2399500-0ffb-11eb-8855-6a2dcff0f8aa.png)
![Screenshot from 2020-10-16 21-54-10](https://user-images.githubusercontent.com/1013356/96326109-f49bef00-0ffb-11eb-9c28-cda28f140e8e.png)
![Screenshot from 2020-10-16 21-54-48](https://user-images.githubusercontent.com/1013356/96326110-f6fe4900-0ffb-11eb-8ef0-0ba835400a1b.png)
![Screenshot from 2020-10-16 21-55-24](https://user-images.githubusercontent.com/1013356/96326114-f9f93980-0ffb-11eb-942b-f44332e97cc0.png)
