### PR TITLE
ci: add clang compiler test

### DIFF
--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -82,12 +82,26 @@ jobs:
 
   strategy:
     matrix:
+      linux-amd64-clang-Debug:
+        containerImage: 'openblack/compile-farm-ci:linux-amd64-gcc'
+        BuildConfiguration: Debug
+        CCompiler: /usr/bin/clang
+        CxxCompiler: /usr/bin/clang++
+      linux-amd64-clang-Release:
+        containerImage: 'openblack/compile-farm-ci:linux-amd64-gcc'
+        BuildConfiguration: Release
+        CCompiler: /usr/bin/clang
+        CxxCompiler: /usr/bin/clang++
       linux-amd64-gcc-Debug:
         containerImage: 'openblack/compile-farm-ci:linux-amd64-gcc'
         BuildConfiguration: Debug
+        CCompiler: /usr/bin/gcc
+        CxxCompiler: /usr/bin/g++
       linux-amd64-gcc-Release:
         containerImage: 'openblack/compile-farm-ci:linux-amd64-gcc'
         BuildConfiguration: Release
+        CCompiler: /usr/bin/gcc
+        CxxCompiler: /usr/bin/g++
 
   container: $[ variables['containerImage'] ]
 
@@ -96,8 +110,12 @@ jobs:
   - template: azure-pipelines/templates/linux-build.yml
     parameters:
       BuildConfiguration: $(BuildConfiguration)
+      CCompiler: $(CCompiler)
+      CxxCompiler: $(CxxCompiler)
   - template: azure-pipelines/templates/publish.yml
     parameters:
       BuildConfiguration: $(BuildConfiguration)
+      CCompiler: $(CCompiler)
+      CxxCompiler: $(CxxCompiler)
       InstallPlatform: Linux-x64
   - template: azure-pipelines/templates/test-null-renderer.yml

--- a/azure-pipelines/templates/linux-build.yml
+++ b/azure-pipelines/templates/linux-build.yml
@@ -1,7 +1,7 @@
 steps:
 - bash: |
     cmake --version
-    cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=${{ parameters.BuildConfiguration }} -DVCPKG_TARGET_TRIPLET=x64-linux -Dbgfx_DIR=/bgfx-install/lib/cmake/bgfx -G Ninja
+    cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=${{ parameters.BuildConfiguration }} -DCMAKE_C_COMPILER=${{ parameters.CCompiler }} -DCMAKE_CXX_COMPILER=${{ parameters.CxxCompiler }} -DVCPKG_TARGET_TRIPLET=x64-linux -Dbgfx_DIR=/bgfx-install/lib/cmake/bgfx -G Ninja
   displayName: 'CMake'
 - bash: |
     cmake --build build


### PR DESCRIPTION
This requires clang to be installed on the linux machine.
It will help catch clang only errors and shouldn't increase build times too much since windows build times take significantly longer than linux builds.