### PR TITLE
camera-fix - This fixes velocity issues when rotating and moving at the same time

### DIFF
--- a/src/3D/Camera.cpp
+++ b/src/3D/Camera.cpp
@@ -129,7 +129,6 @@ void Camera::handleKeyboardInput(const SDL_Event& e)
 	else if (e.key.keysym.scancode == SDL_SCANCODE_SPACE)
 		_dv.y += (e.type == SDL_KEYDOWN) ? 1.0f : -1.0f;
 
-
 	glm::mat3 rotation = glm::transpose(GetViewMatrix());
 	_velocity = rotation * _dv;
 }

--- a/src/3D/Camera.cpp
+++ b/src/3D/Camera.cpp
@@ -145,6 +145,8 @@ void Camera::handleMouseInput(const SDL_Event& e)
 		rot.x -= e.motion.yrel * _freeLookSensitivity * 0.1f;
 
 		SetRotation(rot);
+		glm::mat3 viewRotation = glm::transpose(GetViewMatrix());
+		_velocity = viewRotation * _dv;
 	}
 	else if (e.type == SDL_MOUSEMOTION && e.motion.state & SDL_BUTTON(SDL_BUTTON_LEFT))
 	{

--- a/src/3D/Camera.cpp
+++ b/src/3D/Camera.cpp
@@ -116,22 +116,22 @@ void Camera::handleKeyboardInput(const SDL_Event& e)
 	if (e.key.repeat > 0)
 		return;
 
-	glm::vec3 dv(0, 0, 0);
 	if (e.key.keysym.scancode == SDL_SCANCODE_W)
-		dv.z = (e.type == SDL_KEYDOWN) ? 1.0f : -1.0f;
+		_dv.z += (e.type == SDL_KEYDOWN) ? 1.0f : -1.0f;
 	else if (e.key.keysym.scancode == SDL_SCANCODE_S)
-		dv.z = (e.type == SDL_KEYDOWN) ? -1.0f : 1.0f;
+		_dv.z += (e.type == SDL_KEYDOWN) ? -1.0f : 1.0f;
 	else if (e.key.keysym.scancode == SDL_SCANCODE_A)
-		dv.x = (e.type == SDL_KEYDOWN) ? -1.0f : 1.0f;
+		_dv.x += (e.type == SDL_KEYDOWN) ? -1.0f : 1.0f;
 	else if (e.key.keysym.scancode == SDL_SCANCODE_D)
-		dv.x = (e.type == SDL_KEYDOWN) ? 1.0f : -1.0f;
+		_dv.x += (e.type == SDL_KEYDOWN) ? 1.0f : -1.0f;
 	else if (e.key.keysym.scancode == SDL_SCANCODE_LCTRL)
-		dv.y = (e.type == SDL_KEYDOWN) ? -1.0f : 1.0f;
+		_dv.y += (e.type == SDL_KEYDOWN) ? -1.0f : 1.0f;
 	else if (e.key.keysym.scancode == SDL_SCANCODE_SPACE)
-		dv.y = (e.type == SDL_KEYDOWN) ? 1.0f : -1.0f;
+		_dv.y += (e.type == SDL_KEYDOWN) ? 1.0f : -1.0f;
+
 
 	glm::mat3 rotation = glm::transpose(GetViewMatrix());
-	_velocity += rotation * dv;
+	_velocity = rotation * _dv;
 }
 
 void Camera::handleMouseInput(const SDL_Event& e)

--- a/src/3D/Camera.h
+++ b/src/3D/Camera.h
@@ -30,6 +30,7 @@ public:
 	    , _projectionMatrix(1.0f)
 	    , _velocity(0.0f, 0.0f, 0.0f)
 	    , _movementSpeed(0.0005f)
+	    , _dv(0.0f, 0.0f, 0.0f)
 	    , _freeLookSensitivity(1.0f)
 	{
 	}
@@ -73,6 +74,7 @@ public:
 protected:
 	glm::vec3 _position;
 	glm::vec3 _rotation;
+	glm::vec3 _dv;
 
 	glm::mat4 _projectionMatrix;
 


### PR DESCRIPTION
This has two things:

* If you tried to move and rotate the camera at the same time you won't be able to stop moving as the view matrix will have changed since the `_velocity` was last set.
* Unintentionally, my changes made it possible to recalculate velocity on camera rotation (view matrix change).

