### PR TITLE
Add Villager Names

### DIFF
--- a/src/3D/Camera.cpp
+++ b/src/3D/Camera.cpp
@@ -102,6 +102,29 @@ void Camera::DeprojectScreenToWorld(const glm::ivec2 screenPosition, const glm::
 	out_worldDirection = rayDirWorldSpace;
 }
 
+bool Camera::ProjectWorldToScreen(const glm::vec3 worldPosition, const glm::vec4 viewport, glm::vec3& out_screenPosition) const
+{
+	out_screenPosition = glm::project(worldPosition, GetViewMatrix(), GetProjectionMatrix(), viewport);
+	if (out_screenPosition.x < viewport.x || out_screenPosition.y < viewport.y || out_screenPosition.x > viewport.z ||
+	    out_screenPosition.y > viewport.w)
+	{
+		return false;
+	}
+	if (out_screenPosition.z > 1.0f)
+	{
+		// Behind Camera
+		return false;
+	}
+
+	if (out_screenPosition.z < 0.0f)
+	{
+		// Clipped
+		return false;
+	}
+
+	return true;
+}
+
 void Camera::ProcessSDLEvent(const SDL_Event& e)
 {
 	if (e.type == SDL_KEYDOWN || e.type == SDL_KEYUP)

--- a/src/3D/Camera.h
+++ b/src/3D/Camera.h
@@ -62,6 +62,7 @@ public:
 
 	void DeprojectScreenToWorld(const glm::ivec2 screenPosition, const glm::ivec2 screenSize, glm::vec3& out_worldOrigin,
 	                            glm::vec3& out_worldDirection);
+	bool ProjectWorldToScreen(const glm::vec3 worldPosition, const glm::vec4 viewport, glm::vec3& out_screenPosition) const;
 
 	void Update(std::chrono::microseconds dt);
 	void ProcessSDLEvent(const SDL_Event&);

--- a/src/Entities/Registry.cpp
+++ b/src/Entities/Registry.cpp
@@ -53,35 +53,32 @@ void Registry::PrepareDrawDescs(bool drawBoundingBox)
 	std::map<MeshId, uint32_t> meshIds;
 
 	// Trees
-	_registry.view<const Tree, const Transform>().each(
-	    [&meshIds, &instanceCount](const Tree& entity, const Transform& transform) {
-		    const auto meshId = treeMeshLookup[entity.treeInfo];
-		    auto count = meshIds.insert(std::make_pair(meshId, 0));
-		    count.first->second++;
-		    instanceCount++;
-	    });
+	Each<const Tree, const Transform>([&meshIds, &instanceCount](const Tree& entity, const Transform& transform) {
+		const auto meshId = treeMeshLookup[entity.treeInfo];
+		auto count = meshIds.insert(std::make_pair(meshId, 0));
+		count.first->second++;
+		instanceCount++;
+	});
 
 	// Abodes
-	_registry.view<const Abode, const Transform>().each(
-	    [&meshIds, &instanceCount](const Abode& entity, const Transform& transform) {
-		    const auto meshId = abodeMeshLookup[entity.abodeInfo];
-		    auto count = meshIds.insert(std::make_pair(meshId, 0));
-		    count.first->second++;
-		    instanceCount++;
-	    });
+	Each<const Abode, const Transform>([&meshIds, &instanceCount](const Abode& entity, const Transform& transform) {
+		const auto meshId = abodeMeshLookup[entity.abodeInfo];
+		auto count = meshIds.insert(std::make_pair(meshId, 0));
+		count.first->second++;
+		instanceCount++;
+	});
 
 	// Villagers
-	_registry.view<const Villager, const Transform>().each(
-	    [&meshIds, &instanceCount](const Villager& villager, const Transform& transform) {
-		    const auto villagerType = villager.GetVillagerType();
-		    const auto meshId = villagerMeshLookup[villagerType];
-		    auto count = meshIds.insert(std::make_pair(meshId, 0));
-		    count.first->second++;
-		    instanceCount++;
-	    });
+	Each<const Villager, const Transform>([&meshIds, &instanceCount](const Villager& villager, const Transform& transform) {
+		const auto villagerType = villager.GetVillagerType();
+		const auto meshId = villagerMeshLookup[villagerType];
+		auto count = meshIds.insert(std::make_pair(meshId, 0));
+		count.first->second++;
+		instanceCount++;
+	});
 
 	// Animated Statics
-	_registry.view<const AnimatedStatic, const Transform>().each(
+	Each<const AnimatedStatic, const Transform>(
 	    [&meshIds, &instanceCount](const AnimatedStatic& entity, const Transform& transform) {
 		    // temporary-ish:
 		    MeshPackId meshId = MeshPackId::Dummy;
@@ -103,7 +100,7 @@ void Registry::PrepareDrawDescs(bool drawBoundingBox)
 	    });
 
 	// Mobile Statics
-	_registry.view<const MobileStatic, const Transform>().each(
+	Each<const MobileStatic, const Transform>(
 	    [&meshIds, &instanceCount](const MobileStatic& entity, const Transform& transform) {
 		    const auto meshId = mobileStaticMeshLookup[entity.type];
 		    auto count = meshIds.insert(std::make_pair(meshId, 0));
@@ -112,34 +109,31 @@ void Registry::PrepareDrawDescs(bool drawBoundingBox)
 	    });
 
 	// Features
-	_registry.view<const Feature, const Transform>().each(
-	    [&meshIds, &instanceCount](const Feature& entity, const Transform& transform) {
-		    const auto meshId = featureMeshLookup[entity.type];
-		    auto count = meshIds.insert(std::make_pair(meshId, 0));
-		    count.first->second++;
-		    instanceCount++;
-	    });
+	Each<const Feature, const Transform>([&meshIds, &instanceCount](const Feature& entity, const Transform& transform) {
+		const auto meshId = featureMeshLookup[entity.type];
+		auto count = meshIds.insert(std::make_pair(meshId, 0));
+		count.first->second++;
+		instanceCount++;
+	});
 
 	// Fields
-	_registry.view<const Field, const Transform>().each(
-	    [&meshIds, &instanceCount](const Field& entity, const Transform& transform) {
-		    const auto meshId = MeshPackId::TreeWheat;
-		    auto count = meshIds.insert(std::make_pair(static_cast<MeshId>(meshId), 0));
-		    count.first->second++;
-		    instanceCount++;
-	    });
+	Each<const Field, const Transform>([&meshIds, &instanceCount](const Field& entity, const Transform& transform) {
+		const auto meshId = MeshPackId::TreeWheat;
+		auto count = meshIds.insert(std::make_pair(static_cast<MeshId>(meshId), 0));
+		count.first->second++;
+		instanceCount++;
+	});
 
 	// Forests
-	_registry.view<const Forest, const Transform>().each(
-	    [&meshIds, &instanceCount](const Forest& entity, const Transform& transform) {
-		    const auto meshId = MeshPackId::FeatureForest;
-		    auto count = meshIds.insert(std::make_pair(static_cast<MeshId>(meshId), 0));
-		    count.first->second++;
-		    instanceCount++;
-	    });
+	Each<const Forest, const Transform>([&meshIds, &instanceCount](const Forest& entity, const Transform& transform) {
+		const auto meshId = MeshPackId::FeatureForest;
+		auto count = meshIds.insert(std::make_pair(static_cast<MeshId>(meshId), 0));
+		count.first->second++;
+		instanceCount++;
+	});
 
 	// Mobile Objects
-	_registry.view<const MobileObject, const Transform>().each(
+	Each<const MobileObject, const Transform>(
 	    [&meshIds, &instanceCount](const MobileObject& entity, const Transform& transform) {
 		    const auto meshId = mobileObjectMeshLookup[entity.type];
 		    auto count = meshIds.insert(std::make_pair(meshId, 0));
@@ -148,13 +142,12 @@ void Registry::PrepareDrawDescs(bool drawBoundingBox)
 	    });
 
 	// Hands
-	_registry.view<const Hand, const Transform>().each(
-	    [&meshIds, &instanceCount](const Hand& entity, const Transform& transform) {
-		    const auto meshId = MeshId(999);
-		    auto count = meshIds.insert(std::make_pair(meshId, 0));
-		    count.first->second++;
-		    instanceCount++;
-	    });
+	Each<const Hand, const Transform>([&meshIds, &instanceCount](const Hand& entity, const Transform& transform) {
+		const auto meshId = MeshId(999);
+		auto count = meshIds.insert(std::make_pair(meshId, 0));
+		count.first->second++;
+		instanceCount++;
+	});
 
 	if (drawBoundingBox)
 	{
@@ -221,7 +214,7 @@ void Registry::PrepareDrawUploadUniforms(bool drawBoundingBox)
 	std::map<MeshId, uint32_t> uniformOffsets;
 
 	// Trees
-	_registry.view<const Tree, const Transform>().each(
+	Each<const Tree, const Transform>(
 	    [&renderCtx, &uniformOffsets, prepareDrawBoundingBox](const Tree& entity, const Transform& transform) {
 		    const auto meshId = treeMeshLookup[entity.treeInfo];
 		    auto offset = uniformOffsets.insert(std::make_pair(meshId, 0));
@@ -232,7 +225,7 @@ void Registry::PrepareDrawUploadUniforms(bool drawBoundingBox)
 	    });
 
 	// Abodes
-	_registry.view<const Abode, const Transform>().each(
+	Each<const Abode, const Transform>(
 	    [&renderCtx, &uniformOffsets, prepareDrawBoundingBox](const Abode& entity, const Transform& transform) {
 		    const auto meshId = abodeMeshLookup[entity.abodeInfo];
 		    auto offset = uniformOffsets.insert(std::make_pair(meshId, 0));
@@ -243,7 +236,7 @@ void Registry::PrepareDrawUploadUniforms(bool drawBoundingBox)
 	    });
 
 	// Villagers
-	_registry.view<const Villager, const Transform>().each(
+	Each<const Villager, const Transform>(
 	    [this, &renderCtx, &uniformOffsets, prepareDrawBoundingBox](const Villager& villager, const Transform& transform) {
 		    const auto villagerType = villager.GetVillagerType();
 		    const auto meshId = villagerMeshLookup[villagerType];
@@ -255,7 +248,7 @@ void Registry::PrepareDrawUploadUniforms(bool drawBoundingBox)
 	    });
 
 	// Animated Statics
-	_registry.view<const AnimatedStatic, const Transform>().each(
+	Each<const AnimatedStatic, const Transform>(
 	    [&renderCtx, &uniformOffsets, prepareDrawBoundingBox](const AnimatedStatic& entity, const Transform& transform) {
 		    // temporary-ish:
 		    MeshPackId meshPackId = MeshPackId::Dummy;
@@ -280,7 +273,7 @@ void Registry::PrepareDrawUploadUniforms(bool drawBoundingBox)
 	    });
 
 	// Mobile Statics
-	_registry.view<const MobileStatic, const Transform>().each(
+	Each<const MobileStatic, const Transform>(
 	    [&renderCtx, &uniformOffsets, prepareDrawBoundingBox](const MobileStatic& entity, const Transform& transform) {
 		    const auto meshId = mobileStaticMeshLookup[entity.type];
 		    auto offset = uniformOffsets.insert(std::make_pair(meshId, 0));
@@ -291,7 +284,7 @@ void Registry::PrepareDrawUploadUniforms(bool drawBoundingBox)
 	    });
 
 	// Features
-	_registry.view<const Feature, const Transform>().each(
+	Each<const Feature, const Transform>(
 	    [&renderCtx, &uniformOffsets, prepareDrawBoundingBox](const Feature& entity, const Transform& transform) {
 		    const auto meshId = featureMeshLookup[entity.type];
 		    auto offset = uniformOffsets.insert(std::make_pair(meshId, 0));
@@ -302,7 +295,7 @@ void Registry::PrepareDrawUploadUniforms(bool drawBoundingBox)
 	    });
 
 	// Fields
-	_registry.view<const Field, const Transform>().each(
+	Each<const Field, const Transform>(
 	    [&renderCtx, &uniformOffsets, prepareDrawBoundingBox](const Field& entity, const Transform& transform) {
 		    const MeshId meshId = static_cast<MeshId>(MeshPackId::TreeWheat);
 		    auto offset = uniformOffsets.insert(std::make_pair(meshId, 0));
@@ -313,7 +306,7 @@ void Registry::PrepareDrawUploadUniforms(bool drawBoundingBox)
 	    });
 
 	// Forests
-	_registry.view<const Forest, const Transform>().each(
+	Each<const Forest, const Transform>(
 	    [&renderCtx, &uniformOffsets, prepareDrawBoundingBox](const Forest& entity, const Transform& transform) {
 		    const MeshId meshId = static_cast<MeshId>(MeshPackId::FeatureForest);
 		    auto offset = uniformOffsets.insert(std::make_pair(meshId, 0));
@@ -324,7 +317,7 @@ void Registry::PrepareDrawUploadUniforms(bool drawBoundingBox)
 	    });
 
 	// Mobile Objects
-	_registry.view<const MobileObject, const Transform>().each(
+	Each<const MobileObject, const Transform>(
 	    [&renderCtx, &uniformOffsets, prepareDrawBoundingBox](const MobileObject& entity, const Transform& transform) {
 		    const auto meshId = mobileObjectMeshLookup[entity.type];
 		    auto offset = uniformOffsets.insert(std::make_pair(meshId, 0));
@@ -335,7 +328,7 @@ void Registry::PrepareDrawUploadUniforms(bool drawBoundingBox)
 	    });
 
 	// Hands
-	_registry.view<const Hand, const Transform>().each(
+	Each<const Hand, const Transform>(
 	    [&renderCtx, &uniformOffsets, prepareDrawBoundingBox](const Hand& entity, const Transform& transform) {
 		    MeshId meshId = 999;
 		    auto offset = uniformOffsets.insert(std::make_pair(meshId, 0));
@@ -372,12 +365,12 @@ void Registry::PrepareDraw(bool drawBoundingBox, bool drawFootpaths, bool drawSt
 		if (drawFootpaths)
 		{
 			uint32_t nodeCount = 0;
-			_registry.view<const Footpath>().each(
+			Each<const Footpath>(
 			    [&nodeCount](const Footpath& ent) { nodeCount += 2 * std::max(static_cast<int>(ent.nodes.size()) - 1, 0); });
 
 			std::vector<graphics::DebugLines::Vertex> edges;
 			edges.reserve(nodeCount);
-			_registry.view<const Footpath>().each([&edges](const Footpath& ent) {
+			Each<const Footpath>([&edges](const Footpath& ent) {
 				const auto color = glm::vec4(0, 1, 0, 1);
 				const auto offset = glm::vec3(0, 1, 0);
 				for (int i = 0; i < static_cast<int>(ent.nodes.size()) - 1; ++i)
@@ -396,7 +389,7 @@ void Registry::PrepareDraw(bool drawBoundingBox, bool drawFootpaths, bool drawSt
 		if (drawStreams)
 		{
 			uint32_t edgeCount = 0;
-			_registry.view<const Stream>().each([&edgeCount](const Stream& ent) {
+			Each<const Stream>([&edgeCount](const Stream& ent) {
 				for (const auto& from : ent.nodes)
 				{
 					edgeCount += from.edges.size();
@@ -404,7 +397,7 @@ void Registry::PrepareDraw(bool drawBoundingBox, bool drawFootpaths, bool drawSt
 			});
 			std::vector<graphics::DebugLines::Vertex> edges;
 			edges.reserve(edgeCount * 2);
-			_registry.view<const Stream>().each([&edges](const Stream& ent) {
+			Each<const Stream>([&edges](const Stream& ent) {
 				const auto color = glm::vec4(1, 0, 0, 1);
 				for (const auto& from : ent.nodes)
 				{

--- a/src/Entities/Registry.h
+++ b/src/Entities/Registry.h
@@ -57,6 +57,16 @@ public:
 	{
 		return _registry.get<Component>(entity);
 	}
+	template <typename... Components, typename Func>
+	decltype(auto) Each(Func func)
+	{
+		return _registry.view<Components...>().each(func);
+	}
+	template <typename... Components, typename Func>
+	decltype(auto) Each(Func func) const
+	{
+		return _registry.view<const Components...>().each(func);
+	}
 
 private:
 	void PrepareDrawDescs(bool drawBoundingBox);

--- a/src/Game.h
+++ b/src/Game.h
@@ -83,6 +83,8 @@ public:
 		bool waterDebug {false};
 		bool showProfiler {false};
 		bool showLandIsland {false};
+		bool showVillagerNames {false};
+		bool debugVillagerNames {false};
 
 		bool drawSky {true};
 		bool drawWater {true};

--- a/src/Gui.cpp
+++ b/src/Gui.cpp
@@ -816,7 +816,9 @@ void Gui::RenderVillagerName(const std::string& name, const std::string& text, c
 
 	ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
 	const auto boxWidth = ImGui::CalcTextSize(fullText.c_str()).x + 2 * ImGui::GetStyle().WindowPadding.x;
-	ImGui::SetNextWindowPos(ImVec2(pos.x + boxWidth / 2.0f, pos.y - arrow_length), ImGuiCond_Always, ImVec2(1.0f, 1.0f));
+	ImVec2 windowPos(std::clamp(pos.x, boxWidth / 2.0f, ImGui::GetIO().DisplaySize.x - boxWidth / 2.0f) + boxWidth / 2.0f,
+	                 pos.y - arrow_length);
+	ImGui::SetNextWindowPos(windowPos, ImGuiCond_Always, ImVec2(1.0f, 1.0f));
 	ImGui::SetNextWindowBgAlpha(0.35f);
 
 	if (ImGui::Begin(("Villager overlay #" + name).c_str(), nullptr, boxOverlayFlags))
@@ -835,7 +837,8 @@ void Gui::ShowVillagerNames(const Game& game)
 
 	uint32_t i = 0;
 	const auto& camera = game.GetCamera();
-	const glm::vec4 viewport = glm::vec4(0, 0, displaySize.x, displaySize.y);
+	const glm::vec4 viewport =
+	    glm::vec4(ImGui::GetStyle().WindowPadding.x, 0, displaySize.x - ImGui::GetStyle().WindowPadding.x, displaySize.y);
 	game.GetEntityRegistry().Each<const Villager, const Transform>(
 	    [this, &i, camera, viewport](const Villager& entity, const Transform& transform) {
 		    ++i;

--- a/src/Gui.cpp
+++ b/src/Gui.cpp
@@ -849,6 +849,14 @@ void Gui::ShowVillagerNames(const Game& game)
 			    return;
 		    }
 
+		    // 3.5 was measured in vanilla but it is possible that it is configurable
+		    float max_distance = 3.5f;
+		    const glm::vec3 relativePosition = (camera.GetPosition() - transform.position) / 100.0f;
+		    if (glm::dot(relativePosition, relativePosition) > max_distance * max_distance)
+		    {
+			    return;
+		    }
+
 		    // TODO(bwrsandman): Get owner player and associated color
 		    glm::vec4 color = glm::vec4(1.0f, 0.0f, 0.0f, 1.0f);
 		    // Female villagers have a lighter colour

--- a/src/Gui.h
+++ b/src/Gui.h
@@ -12,6 +12,7 @@
 #include "Graphics/RenderPass.h"
 
 #include <bgfx/bgfx.h>
+#include <glm/fwd.hpp>
 #include <imgui.h>
 
 #include <array>
@@ -88,7 +89,8 @@ private:
 	void RenderDrawDataBgfx(ImDrawData* drawData);
 
 	void RenderArrow(const std::string& name, const ImVec2& pos, const ImVec2& size) const;
-	void RenderVillagerName(const std::string& name, const std::string& text, const ImVec2& pos, float arrow_length) const;
+	void RenderVillagerName(const std::string& name, const std::string& text, const glm::vec4& color, const ImVec2& pos,
+	                        float arrow_length) const;
 	bool ShowMenu(Game& game);
 	void ShowVillagerNames(const Game& game);
 	void ShowProfilerWindow(Game& game);

--- a/src/Gui.h
+++ b/src/Gui.h
@@ -17,6 +17,7 @@
 
 #include <array>
 #include <memory>
+#include <optional>
 
 typedef struct SDL_Window SDL_Window;
 typedef struct SDL_Cursor SDL_Cursor;
@@ -89,8 +90,9 @@ private:
 	void RenderDrawDataBgfx(ImDrawData* drawData);
 
 	void RenderArrow(const std::string& name, const ImVec2& pos, const ImVec2& size) const;
-	void RenderVillagerName(const std::string& name, const std::string& text, const glm::vec4& color, const ImVec2& pos,
-	                        float arrow_length) const;
+	std::optional<glm::uvec4> RenderVillagerName(const std::vector<glm::vec4>& coveredAreas, const std::string& name,
+	                                             const std::string& text, const glm::vec4& color, const ImVec2& pos,
+	                                             float arrowLength) const;
 	bool ShowMenu(Game& game);
 	void ShowVillagerNames(const Game& game);
 	void ShowProfilerWindow(Game& game);
@@ -123,6 +125,7 @@ private:
 	};
 
 	ImGuiContext* _imgui;
+	ImVec2 _menuBarSize;
 	uint64_t _time;
 	CircularBuffer<float, 100> _times;
 	CircularBuffer<float, 100> _fps;

--- a/src/Gui.h
+++ b/src/Gui.h
@@ -16,6 +16,7 @@
 #include <imgui.h>
 
 #include <array>
+#include <functional>
 #include <memory>
 #include <optional>
 
@@ -92,7 +93,7 @@ private:
 	void RenderArrow(const std::string& name, const ImVec2& pos, const ImVec2& size) const;
 	std::optional<glm::uvec4> RenderVillagerName(const std::vector<glm::vec4>& coveredAreas, const std::string& name,
 	                                             const std::string& text, const glm::vec4& color, const ImVec2& pos,
-	                                             float arrowLength) const;
+	                                             float arrowLength, std::function<void(void)> debugCallback) const;
 	bool ShowMenu(Game& game);
 	void ShowVillagerNames(const Game& game);
 	void ShowProfilerWindow(Game& game);

--- a/src/Gui.h
+++ b/src/Gui.h
@@ -87,7 +87,10 @@ private:
 	bool CreateDeviceObjectsBgfx();
 	void RenderDrawDataBgfx(ImDrawData* drawData);
 
+	void RenderArrow(const std::string& name, const ImVec2& pos, const ImVec2& size) const;
+	void RenderVillagerName(const std::string& name, const std::string& text, const ImVec2& pos, float arrow_length) const;
 	bool ShowMenu(Game& game);
+	void ShowVillagerNames(const Game& game);
 	void ShowProfilerWindow(Game& game);
 	void ShowWaterFramebuffer(const Game& game);
 	void ShowLandIslandWindow(Game& game);


### PR DESCRIPTION
PR depends on other PRs before being merged:
- [x] UI refactoring #257 

Add view of villager names as is in Vanilla when pressing the "S" key

The option is enabled in the menu under Debug/Villager Names/Show
![Screenshot from 2020-11-22 02-53-55](https://user-images.githubusercontent.com/1013356/99898249-006b7880-2c6e-11eb-9797-cd03f6fdf488.png)

The villager names are rendered with the default font (TODO: use font from assets. They need to be loaded as ImGui font) in ImGui. The tint of the window might be different from vanilla as well as the default height and shape of the arrows.
Vanilla also used arrows for every window even if they were stacked. This was not done in this PR.

I replicated the way that vanilla prevents overlapping boxes: by testing for intersection at insert time and moving up if there is.
There is some depth-based culling and possible line of sight culling in vanilla which was not done in this PR.

The color of the text is based on the owner player (currently not implemented so player 1 color is used and hard coded) and on the sex value of the villager (lighter means female).

![Screenshot from 2020-11-22 02-58-48](https://user-images.githubusercontent.com/1013356/99898344-b8992100-2c6e-11eb-85c9-3451c5f40ce3.png)

Additionally, since we are leveraging ImGui, I added a villager name debug mode which uses a callback to inspect and modify entities during runtime.

![Screenshot from 2020-11-22 03-00-25](https://user-images.githubusercontent.com/1013356/99898361-e2524800-2c6e-11eb-8544-0b4f7c08dd15.png)

Additionally, there has been a little re-factor of Gui.cpp, mainly clean-up and making functions smaller by adding domain-specific functions for different menus and sub-uis.