### PR TITLE
L3DFile: Fix extra data interpretation

### DIFF
--- a/src/3D/L3DMesh.cpp
+++ b/src/3D/L3DMesh.cpp
@@ -40,6 +40,12 @@ void L3DMesh::Load(const l3d::L3DFile& l3d)
 		                        skin.texels.size() * sizeof(skin.texels[0]));
 	}
 
+	if (static_cast<uint32_t>(_flags) & static_cast<uint32_t>(l3d::L3DMeshFlags::HasDoorPosition) &&
+	    l3d.GetExtraPoints().size() > 0)
+	{
+		_doorPos = glm::vec3(l3d.GetExtraPoints()[0].x, l3d.GetExtraPoints()[0].y, l3d.GetExtraPoints()[0].z);
+	}
+
 	std::map<uint32_t, glm::mat4> matrices;
 	auto& bones = l3d.GetBones();
 	_bonesParents.resize(bones.size());

--- a/src/3D/L3DMesh.h
+++ b/src/3D/L3DMesh.h
@@ -46,7 +46,7 @@ constexpr std::array<std::string_view, 32> L3DMeshFlagNames {
     "HasBones",
     "Unknown10",
     "Unknown11",
-    "Unknown12",
+    "HasDoorPosition",
     "Packed",
     "NoDraw",
     "Unknown15",

--- a/src/3D/L3DMesh.h
+++ b/src/3D/L3DMesh.h
@@ -16,6 +16,7 @@ namespace fs = std::filesystem;
 #include <experimental/filesystem>
 namespace fs = std::experimental::filesystem;
 #endif // HAS_FILESYSTEM
+#include <optional>
 #include <unordered_map>
 
 #include <glm/gtc/quaternion.hpp>
@@ -91,6 +92,7 @@ public:
 	[[nodiscard]] const std::unordered_map<SkinId, std::unique_ptr<graphics::Texture2D>>& GetSkins() const { return _skins; }
 	[[nodiscard]] const std::vector<uint32_t>& GetBoneParents() const { return _bonesParents; }
 	[[nodiscard]] const std::vector<glm::mat4>& GetBoneMatrices() const { return _bonesDefaultMatrices; }
+	[[nodiscard]] const std::optional<glm::vec3>& GetDoorPos() const { return _doorPos; }
 
 private:
 	l3d::L3DMeshFlags _flags;
@@ -100,6 +102,7 @@ private:
 	std::vector<std::unique_ptr<L3DSubMesh>> _subMeshes;
 	std::vector<uint32_t> _bonesParents;
 	std::vector<glm::mat4> _bonesDefaultMatrices;
+	std::optional<glm::vec3> _doorPos;
 
 public:
 	[[nodiscard]] const std::string& GetDebugName() const { return _debugName; }


### PR DESCRIPTION
This allows fetching building door positions.
The flag 0x800 is correctly labeled.
There was an error with the placement of extra data which has been corrected.
Docs are updated as well.