### PR TITLE
Villager abode assign

### DIFF
--- a/src/ECS/Archetypes/TownArchetype.cpp
+++ b/src/ECS/Archetypes/TownArchetype.cpp
@@ -25,7 +25,7 @@ entt::entity TownArchetype::Create(int id, const glm::vec3& position, [[maybe_un
 
 	// const auto& info = Game::instance()->GetInfoConstants().town;
 
-	registry.Assign<Town>(entity, id);
+	registry.Assign<Town>(entity, static_cast<uint32_t>(id));
 	registry.Assign<Transform>(entity, position);
 	registry.Assign<Tribe>(entity, tribe);
 	registry.Assign<Transform>(entity, position, glm::mat3(1.0f), glm::vec3(1.0f));

--- a/src/ECS/Archetypes/TownArchetype.cpp
+++ b/src/ECS/Archetypes/TownArchetype.cpp
@@ -9,6 +9,7 @@
 
 #include "TownArchetype.h"
 
+#include "ECS/Components/Town.h"
 #include "ECS/Components/Transform.h"
 #include "ECS/Registry.h"
 #include "Game.h"
@@ -25,6 +26,7 @@ entt::entity TownArchetype::Create(int id, const glm::vec3& position, [[maybe_un
 	// const auto& info = Game::instance()->GetInfoConstants().town;
 
 	registry.Assign<Town>(entity, id);
+	registry.Assign<Transform>(entity, position);
 	registry.Assign<Tribe>(entity, tribe);
 	registry.Assign<Transform>(entity, position, glm::mat3(1.0f), glm::vec3(1.0f));
 	auto& registryContext = registry.Context();

--- a/src/ECS/Archetypes/VillagerArchetype.cpp
+++ b/src/ECS/Archetypes/VillagerArchetype.cpp
@@ -16,11 +16,13 @@
 #include "ECS/Components/Transform.h"
 #include "ECS/Components/Villager.h"
 #include "ECS/Registry.h"
+#include "ECS/Systems/TownSystem.h"
 #include "Game.h"
 
 using namespace openblack;
 using namespace openblack::ecs::archetypes;
 using namespace openblack::ecs::components;
+using namespace openblack::ecs::systems;
 
 entt::entity VillagerArchetype::Create([[maybe_unused]] const glm::vec3& abodePosition, const glm::vec3& position,
                                        VillagerInfo type, uint32_t age)
@@ -31,15 +33,23 @@ entt::entity VillagerArchetype::Create([[maybe_unused]] const glm::vec3& abodePo
 	const auto& info = Game::instance()->GetInfoConstants().villager[static_cast<size_t>(type)];
 
 	registry.Assign<Transform>(entity, position, glm::eulerAngleY(glm::radians(180.0f)), glm::vec3(1.0));
-	uint32_t health = 100;
-	uint32_t hunger = 100;
+	const uint32_t health = 100;
+	const uint32_t hunger = 100;
 
-	auto lifeStage = age < 18 ? Villager::LifeStage::Child : Villager::LifeStage::Adult;
-	auto sex = info.villagerNumber == VillagerNumber::Housewife ? Villager::Sex::FEMALE : Villager::Sex::MALE;
-	auto task = Villager::Task::IDLE;
+	const auto lifeStage = age < 18 ? Villager::LifeStage::Child : Villager::LifeStage::Adult;
+	const auto sex = info.villagerNumber == VillagerNumber::Housewife ? Villager::Sex::FEMALE : Villager::Sex::MALE;
+	const auto task = Villager::Task::IDLE;
+
+	// TODO(bwrsandman): Might be better to make a FindClosestAbode
+	const entt::entity town = TownSystem::instance().FindClosestTown(abodePosition);
+	entt::entity abode = entt::null;
+	if (town != entt::null)
+	{
+		abode = TownSystem::instance().FindAbodeWithSpace(town);
+	}
 
 	registry.Assign<Villager>(entity, health, static_cast<uint32_t>(age), hunger, lifeStage, sex, info.tribeType,
-	                          info.villagerNumber, task);
+	                          info.villagerNumber, task, town, abode);
 	registry.Assign<Mesh>(entity, info.meshId, static_cast<int8_t>(0), static_cast<int8_t>(0));
 
 	return entity;

--- a/src/ECS/Components/Abode.h
+++ b/src/ECS/Components/Abode.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <set>
+
 #include "Enums.h"
 
 namespace openblack::ecs::components
@@ -22,6 +24,8 @@ struct Abode
 	// by the villagers
 	uint32_t foodAmount;
 	uint32_t woodAmount;
+	/// Villager
+	std::set<entt::entity> inhabitants;
 };
 
 } // namespace openblack::ecs::components

--- a/src/ECS/Components/Town.h
+++ b/src/ECS/Components/Town.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <set>
 #include <string>
 #include <unordered_map>
 
@@ -17,11 +18,10 @@ namespace openblack::ecs::components
 
 struct Town
 {
-	using Id = int;
-
-	Id id;
+	uint32_t id;
 	std::unordered_map<std::string, float> beliefs;
 	bool uninhabitable = false;
+	std::set<entt::entity> homelessVillagers;
 };
 
 } // namespace openblack::ecs::components

--- a/src/ECS/Components/Villager.h
+++ b/src/ECS/Components/Villager.h
@@ -15,6 +15,8 @@
 #include <string_view>
 #include <tuple>
 
+#include <entt/fwd.hpp>
+
 #include "Enums.h"
 
 namespace openblack::ecs::components
@@ -69,5 +71,7 @@ struct Villager
 	Tribe tribe;
 	VillagerNumber number;
 	Task task;
+	entt::entity town;
+	entt::entity abode;
 };
 } // namespace openblack::ecs::components

--- a/src/ECS/RegistryContext.h
+++ b/src/ECS/RegistryContext.h
@@ -21,6 +21,6 @@ struct RegistryContext
 {
 	std::unordered_map<components::Footpath::Id, entt::entity> footpaths;
 	std::unordered_map<components::Stream::Id, entt::entity> streams;
-	std::unordered_map<components::Town::Id, entt::entity> towns;
+	std::unordered_map<uint32_t, entt::entity> towns;
 };
 } // namespace openblack::ecs

--- a/src/ECS/Systems/TownSystem.cpp
+++ b/src/ECS/Systems/TownSystem.cpp
@@ -9,8 +9,10 @@
 
 #include "TownSystem.h"
 
+#include "ECS/Components/Abode.h"
 #include "ECS/Components/Town.h"
 #include "ECS/Components/Transform.h"
+#include "ECS/Components/Villager.h"
 #include "ECS/Registry.h"
 #include "Game.h"
 
@@ -25,6 +27,28 @@ TownSystem& TownSystem::instance()
 
 TownSystem::TownSystem() = default;
 
+entt::entity TownSystem::FindAbodeWithSpace(entt::entity townEntity) const
+{
+	const auto& infoConstants = Game::instance()->GetInfoConstants();
+	auto& registry = Game::instance()->GetEntityRegistry();
+	const auto& town = registry.Get<Town>(townEntity);
+
+	entt::entity result = entt::null;
+	registry.Each<const Abode>([&town, &infoConstants, &result](entt::entity entity, auto component) {
+		if (result != entt::null || component.townId != town.id)
+		{
+			return;
+		}
+		const auto& info = infoConstants.abode[static_cast<size_t>(component.type)];
+		if (static_cast<int>(component.inhabitants.size()) < info.maxCapacity)
+		{
+			result = entity;
+		}
+	});
+
+	return result;
+}
+
 entt::entity TownSystem::FindClosestTown(const glm::vec3& point) const
 {
 	const auto& registry = Game::instance()->GetEntityRegistry();
@@ -32,14 +56,29 @@ entt::entity TownSystem::FindClosestTown(const glm::vec3& point) const
 	entt::entity result = entt::null;
 	auto closest = std::numeric_limits<float>::infinity();
 
-	registry.Each<const Town, const Transform>([&point, &result, &closest](entt::entity entity, auto& town, auto& transform) {
-		float distance_2 = glm::dot(point, transform.position);
-		if (distance_2 < closest)
-		{
-			closest = distance_2;
-			result = entity;
-		}
-	});
+	registry.Each<const Town, const Transform>(
+	    [&point, &result, &closest](entt::entity entity, [[maybe_unused]] auto& town, [[maybe_unused]] auto& transform) {
+		    float distance_2 = glm::dot(point, transform.position);
+		    if (distance_2 < closest)
+		    {
+			    closest = distance_2;
+			    result = entity;
+		    }
+	    });
 
 	return result;
+}
+
+void TownSystem::AddHomelessVillagerToTown(entt::entity townEntity, entt::entity villagerEntity)
+{
+	[[maybe_unused]] auto& registry = Game::instance()->GetEntityRegistry();
+	[[maybe_unused]] auto& registryContext = registry.Context();
+
+	auto& town = registry.Get<Town>(townEntity);
+	auto& villager = registry.Get<Villager>(villagerEntity);
+	// TODO(bwrsandman): if already assigned to abode or other villager homeless list, remove
+	assert(villager.abode == entt::null);
+	assert(villager.town == entt::null || villager.town == registryContext.towns[town.id]);
+	town.homelessVillagers.insert(villagerEntity);
+	villager.town = townEntity;
 }

--- a/src/ECS/Systems/TownSystem.cpp
+++ b/src/ECS/Systems/TownSystem.cpp
@@ -1,0 +1,45 @@
+/*****************************************************************************
+ * Copyright (c) 2018-2022 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include "TownSystem.h"
+
+#include "ECS/Components/Town.h"
+#include "ECS/Components/Transform.h"
+#include "ECS/Registry.h"
+#include "Game.h"
+
+using namespace openblack::ecs::components;
+using namespace openblack::ecs::systems;
+
+TownSystem& TownSystem::instance()
+{
+	static auto instance = new TownSystem();
+	return *instance;
+}
+
+TownSystem::TownSystem() = default;
+
+entt::entity TownSystem::FindClosestTown(const glm::vec3& point) const
+{
+	const auto& registry = Game::instance()->GetEntityRegistry();
+
+	entt::entity result = entt::null;
+	auto closest = std::numeric_limits<float>::infinity();
+
+	registry.Each<const Town, const Transform>([&point, &result, &closest](entt::entity entity, auto& town, auto& transform) {
+		float distance_2 = glm::dot(point, transform.position);
+		if (distance_2 < closest)
+		{
+			closest = distance_2;
+			result = entity;
+		}
+	});
+
+	return result;
+}

--- a/src/ECS/Systems/TownSystem.h
+++ b/src/ECS/Systems/TownSystem.h
@@ -1,0 +1,28 @@
+/*****************************************************************************
+ * Copyright (c) 2018-2022 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <entt/fwd.hpp>
+#include <glm/fwd.hpp>
+
+namespace openblack::ecs::systems
+{
+
+class TownSystem
+{
+public:
+	static TownSystem& instance();
+
+	entt::entity FindClosestTown(const glm::vec3& point) const;
+
+private:
+	TownSystem();
+};
+} // namespace openblack::ecs::systems

--- a/src/ECS/Systems/TownSystem.h
+++ b/src/ECS/Systems/TownSystem.h
@@ -20,7 +20,9 @@ class TownSystem
 public:
 	static TownSystem& instance();
 
+	entt::entity FindAbodeWithSpace(entt::entity townEntity) const;
 	entt::entity FindClosestTown(const glm::vec3& point) const;
+	void AddHomelessVillagerToTown(entt::entity townEntity, entt::entity villagerEntity);
 
 private:
 	TownSystem();

--- a/src/Gui/Gui.cpp
+++ b/src/Gui/Gui.cpp
@@ -1014,6 +1014,10 @@ void Gui::ShowVillagerNames(const Game& game)
 		if (config.debugVillagerNames)
 		{
 			debugCallback = [&entity] {
+				if (entity.abode == entt::null)
+				{
+					ImGui::Text("Homeless");
+				}
 				ImGui::InputInt("Health", reinterpret_cast<int*>(&entity.health));
 				ImGui::InputInt("Age", reinterpret_cast<int*>(&entity.age));
 				ImGui::InputInt("Hunger", reinterpret_cast<int*>(&entity.hunger));


### PR DESCRIPTION
These changes assign a villager to their abodes in the same way as vanilla.
Some aspects may be unimplemented due to missing concepts such as Players.

Depends on:
- [x] #252
- [x] #258
- [x] #270
- [x] #300 + a rebase to rename Entities to ECS