### PR TITLE
Fix Warnings on Builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 include(CheckIncludeFileCXX)
 check_include_file_cxx(filesystem HAS_FILESYSTEM)
 
+option(OPENBLACK_WARNINGS_AS_ERRORS "Treat warnings as errors (disable easier prototyping, enable for CI)" OFF)
+
 # Special case for SDL2 dependency, goal is to find a config that exports SDL2::SDL2 target
 # libsdl2-dev has a `sdl2-config.cmake` that doesn't export this, but vcpkg does..
 find_package(SDL2 CONFIG QUIET)

--- a/azure-pipelines/templates/linux-build.yml
+++ b/azure-pipelines/templates/linux-build.yml
@@ -1,7 +1,7 @@
 steps:
 - bash: |
     cmake --version
-    cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=${{ parameters.BuildConfiguration }} -DVCPKG_TARGET_TRIPLET=x64-linux -Dbgfx_DIR=/bgfx-install/lib/cmake/bgfx -G Ninja
+    cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=${{ parameters.BuildConfiguration }} -DVCPKG_TARGET_TRIPLET=x64-linux -Dbgfx_DIR=/bgfx-install/lib/cmake/bgfx -DOPENBLACK_WARNINGS_AS_ERRORS=ON -G Ninja
   displayName: 'CMake'
 - bash: |
     cmake --build build

--- a/azure-pipelines/templates/windows-build.yml
+++ b/azure-pipelines/templates/windows-build.yml
@@ -10,7 +10,13 @@ steps:
     displayName: 'CMake'
     inputs:
       workingDirectory: 'build'
-      cmakeArgs: '-DCMAKE_TOOLCHAIN_FILE=c:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=${{ parameters.BuildPlatform }}-windows -A ${{ parameters.MSBuildPlatform }} -Dbgfx_DIR=c:/bgfx/lib/cmake/bgfx ..'
+      # TODO: Add -DOPENBLACK_WARNINGS_AS_ERRORS=ON
+      cmakeArgs: >-
+        -DCMAKE_TOOLCHAIN_FILE=c:/vcpkg/scripts/buildsystems/vcpkg.cmake
+        -DVCPKG_TARGET_TRIPLET=${{ parameters.BuildPlatform }}-windows
+        -A ${{ parameters.MSBuildPlatform }}
+        -Dbgfx_DIR=c:/bgfx/lib/cmake/bgfx
+        ..
   - task: VSBuild@1
     displayName: 'Build'
     inputs:

--- a/src/3D/Camera.h
+++ b/src/3D/Camera.h
@@ -27,10 +27,10 @@ public:
 	Camera(glm::vec3 position, glm::vec3 rotation)
 	    : _position(position)
 	    , _rotation(glm::radians(rotation))
+	    , _dv(0.0f, 0.0f, 0.0f)
 	    , _projectionMatrix(1.0f)
 	    , _velocity(0.0f, 0.0f, 0.0f)
 	    , _movementSpeed(0.0005f)
-	    , _dv(0.0f, 0.0f, 0.0f)
 	    , _freeLookSensitivity(1.0f)
 	{
 	}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,37 +66,6 @@ list(APPEND OPENBLACK_SHADERS ${OPENBLACK_VERTEX_SHADERS})
 list(APPEND OPENBLACK_SHADERS ${OPENBLACK_FRAGMENT_SHADERS})
 list(APPEND OPENBLACK_SHADERS ${OPENBLACK_VARYING_DEF_FILE})
 
-if(MSVC)
-  set(CMAKE_CONFIGURATION_TYPES
-      Debug Release
-      CACHE STRING "" FORCE)
-
-  # Suppress WinMain(), provided by SDL
-  add_definitions(-DSDL_MAIN_HANDLED)
-  # Get rid of useless crud from windows.h
-  add_definitions(-DNOMINMAX -DWIN32_LEAN_AND_MEAN)
-  # disable CRT warnings on windows cause they're annoying as shit and we use C
-  # functions everywhere
-  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-
-  # /W4                 - Level 4 warnings /MP                 - Multi-threaded
-  # compilation /permissive-        - Enables stricter C++ standards conformance
-  # checks
-  add_compile_options(/W4 /MP /permissive-)
-
-  set(CMAKE_EXE_LINKER_FLAGS_DEBUG
-      "${CMAKE_EXE_LINKER_FLAGS_DEBUG} /SAFESEH:NO")
-  set(CMAKE_EXE_LINKER_FLAGS_MINSIZEREL
-      "${CMAKE_EXE_LINKER_FLAGS_MINSIZEREL} /SAFESEH:NO")
-  set(CMAKE_EXE_LINKER_FLAGS_RELEASE
-      "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /SAFESEH:NO")
-  set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO
-      "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} /SAFESEH:NO")
-else(MSVC)
-  add_compile_options(-Wall -Wextra -pedantic -Wno-unused-private-field
-                      -Wno-unused-variable -Wno-unused-parameter)
-endif(MSVC)
-
 add_executable(
   openblack
   ${OPENBLACK_SOURCES}
@@ -114,7 +83,9 @@ target_include_directories(
                     ${CMAKE_CURRENT_BINARY_DIR}/../include)
 target_link_libraries(
   openblack
-  PRIVATE l3d
+  PRIVATE
+          "$<$<CXX_COMPILER_ID:MSVC>:-SAFESEH:NO>"
+          l3d
           pack
           lnd
           anm
@@ -155,6 +126,31 @@ endif()
 target_compile_definitions(openblack PRIVATE "$<$<CONFIG:DEBUG>:OPENBLACK_DEBUG>")
 
 if(MSVC)
+  set(CMAKE_CONFIGURATION_TYPES
+    Debug Release
+    CACHE STRING "" FORCE)
+
+  target_compile_definitions(openblack
+    PRIVATE
+    # Suppress WinMain(), provided by SDL
+    SDL_MAIN_HANDLED
+    # Get rid of useless crud from windows.h
+    NOMINMAX
+    WIN32_LEAN_AND_MEAN
+    # disable CRT warnings on windows cause they're annoying as shit and we use C
+    # functions everywhere
+    _CRT_SECURE_NO_WARNINGS
+    )
+
+  target_compile_options(openblack PRIVATE
+    # Level 4 warnings
+    /W4
+    # Multi-threaded
+    /MP
+    # Enables stricter C++ standards conformance checks
+    /permissive-
+    )
+
   # Debug builds create a debug console
   set_target_properties(openblack PROPERTIES LINK_FLAGS_DEBUG
                                              "/SUBSYSTEM:CONSOLE")
@@ -170,6 +166,21 @@ if(MSVC)
                                              "CONSOLE")
   set_target_properties(openblack PROPERTIES LINK_FLAGS_MINSIZEREL
                                              "/SUBSYSTEM:CONSOLE")
+
+  if (OPENBLACK_WARNINGS_AS_ERRORS)
+    target_compile_options(openblack PRIVATE /WX)
+  endif()
+else()
+  target_compile_options(openblack PRIVATE
+    -Wall
+    -Wextra
+    -pedantic
+    -Wno-unused-private-field
+    -Wno-unused-variable
+    -Wno-unused-parameter)
+  if (OPENBLACK_WARNINGS_AS_ERRORS)
+    target_compile_options(openblack PRIVATE -Werror)
+  endif()
 endif()
 
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT

--- a/src/Common/FileStream.cpp
+++ b/src/Common/FileStream.cpp
@@ -83,8 +83,11 @@ void FileStream::Seek(std::size_t position, SeekMode seek)
 
 void FileStream::Read(void* buffer, std::size_t length)
 {
-	// todo: error check
-	std::fread(buffer, length, 1, _file);
+	size_t size = std::fread(buffer, 1, length, _file);
+	if (size != length)
+	{
+		throw std::runtime_error(fmt::format("Error while reading file"));
+	}
 }
 
 } // namespace openblack

--- a/src/Entities/Registry.cpp
+++ b/src/Entities/Registry.cpp
@@ -237,7 +237,7 @@ void Registry::PrepareDrawUploadUniforms(bool drawBoundingBox)
 
 	// Villagers
 	Each<const Villager, const Transform>(
-	    [this, &renderCtx, &uniformOffsets, prepareDrawBoundingBox](const Villager& villager, const Transform& transform) {
+	    [&renderCtx, &uniformOffsets, prepareDrawBoundingBox](const Villager& villager, const Transform& transform) {
 		    const auto villagerType = villager.GetVillagerType();
 		    const auto meshId = villagerMeshLookup[villagerType];
 		    auto offset = uniformOffsets.insert(std::make_pair(meshId, 0));

--- a/src/GameWindow.cpp
+++ b/src/GameWindow.cpp
@@ -116,8 +116,9 @@ void GameWindow::GetNativeHandles(void*& native_window, void*& native_display) c
 		native_display = wmi.info.x11.display;
 	}
 	else
-#endif // defined(SDL_VIDEO_DRIVER_X11) \
-       // Mac
+#endif // defined(SDL_VIDEO_DRIVER_X11)
+
+	// Mac
 #if defined(SDL_VIDEO_DRIVER_COCOA)
 	    if (wmi.subsystem == SDL_SYSWM_COCOA)
 	{
@@ -125,8 +126,9 @@ void GameWindow::GetNativeHandles(void*& native_window, void*& native_display) c
 		native_display = nullptr;
 	}
 	else
-#endif // defined(SDL_VIDEO_DRIVER_COCOA) \
-       // Windows
+#endif // defined(SDL_VIDEO_DRIVER_COCOA)
+
+	// Windows
 #if defined(SDL_VIDEO_DRIVER_WINDOWS)
 	    if (wmi.subsystem == SDL_SYSWM_WINDOWS)
 	{
@@ -134,8 +136,9 @@ void GameWindow::GetNativeHandles(void*& native_window, void*& native_display) c
 		native_display = nullptr;
 	}
 	else
-#endif // defined(SDL_VIDEO_DRIVER_WINDOWS) \
-       // Steam Link
+#endif // defined(SDL_VIDEO_DRIVER_WINDOWS)
+
+	// Steam Link
 #if defined(SDL_VIDEO_DRIVER_VIVANTE)
 	    if (wmi.subsystem == SDL_SYSWM_VIVANTE)
 	{

--- a/src/Gui.cpp
+++ b/src/Gui.cpp
@@ -171,6 +171,7 @@ bool Gui::ProcessEventSdl2(const SDL_Event& event)
 		{
 			_console->Toggle();
 		}
+		[[fallthrough]];
 	case SDL_KEYUP:
 	{
 		int key = event.key.keysym.scancode;

--- a/src/Gui.cpp
+++ b/src/Gui.cpp
@@ -11,7 +11,10 @@
 
 #include <bgfx/bgfx.h>
 #include <bgfx/embedded_shader.h>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <bx/math.h>
+#pragma GCC diagnostic pop
 #include <bx/timer.h>
 #include <glm/gtx/compatibility.hpp>
 #include <imgui.h>

--- a/src/LHScriptX/Script.cpp
+++ b/src/LHScriptX/Script.cpp
@@ -111,7 +111,7 @@ ScriptCommandParameter GetParameter(Token& argument)
 
 void Script::runCommand(const std::string& identifier, const std::vector<Token>& args)
 {
-	const ScriptCommandSignature* command_signature;
+	const ScriptCommandSignature* command_signature = nullptr;
 
 	for (const auto& signature : FeatureScriptCommands::Signatures)
 	{

--- a/src/LHVMViewer.cpp
+++ b/src/LHVMViewer.cpp
@@ -582,16 +582,6 @@ void LHVMViewer::Draw(const openblack::LHVM::LHVM* lhvm)
 
 void LHVMViewer::DrawScriptsTab(const openblack::LHVM::LHVM* lhvm)
 {
-	static auto scripts_vector_getter = [](void* vec, int idx, const char** out_text) {
-		auto& vector = *static_cast<std::vector<openblack::LHVM::VMScript>*>(vec);
-		if (idx < 0 || idx >= static_cast<int>(vector.size()))
-		{
-			return false;
-		}
-		*out_text = vector.at(idx).GetName().c_str();
-		return true;
-	};
-
 	static auto vector_getter = [](void* vec, int idx, const char** out_text) {
 		auto& vector = *static_cast<std::vector<std::string>*>(vec);
 		if (idx < 0 || idx >= static_cast<int>(vector.size()))

--- a/src/LHVMViewer.cpp
+++ b/src/LHVMViewer.cpp
@@ -766,7 +766,15 @@ std::string openblack::LHVMViewer::DataToString(uint32_t data, openblack::LHVM::
 		return std::to_string(data);
 	case LHVM::VMInstruction::DataType::FLOAT:
 	case LHVM::VMInstruction::DataType::VECTOR:
-		return std::to_string(*reinterpret_cast<float*>(&data)) + "f";
+	{
+		// Strict Aliasing using the union trick
+		union
+		{
+			uint32_t u;
+			float f;
+		} f2u = {data};
+		return std::to_string(f2u.f) + "f";
+	}
 	case LHVM::VMInstruction::DataType::BOOLEAN:
 		return data ? "true" : "false";
 	default:

--- a/src/Serializer/GameThingSerializer.h
+++ b/src/Serializer/GameThingSerializer.h
@@ -92,11 +92,6 @@ public:
 	std::vector<T> DeserializeList();
 
 private:
-	Footpath* DeserializeFootpath();
-	FootpathLink* DeserializeFootpathLink();
-	FootpathNode* DeserializeFootpathNode();
-	FootpathLinkSave* DeserializeFootpathLinkSave();
-
 	FileStream& _stream;
 	uint32_t _checkSum;
 	std::vector<std::shared_ptr<GameThing>> _cache;

--- a/src/Serializer/GameThingSerializer.h
+++ b/src/Serializer/GameThingSerializer.h
@@ -44,10 +44,12 @@ public:
 		uint32_t _unknown1;
 		uint8_t _unknown2;
 
+		virtual ~GameThing() = default;
+
 		virtual bool Deserialize(GameThingSerializer& deserializer);
 	};
 
-	struct FootpathNode: GameThing
+	struct FootpathNode final: GameThing
 	{
 		MapCoords _coords;
 		uint8_t _unknown;
@@ -55,7 +57,7 @@ public:
 		bool Deserialize(GameThingSerializer& deserializer) override;
 	};
 
-	struct Footpath: GameThing
+	struct Footpath final: GameThing
 	{
 		std::vector<FootpathNode> _nodes;
 		uint32_t _unknown;
@@ -63,14 +65,14 @@ public:
 		bool Deserialize(GameThingSerializer& deserializer) override;
 	};
 
-	struct FootpathLink: GameThing
+	struct FootpathLink final: GameThing
 	{
 		std::vector<Footpath> _footpaths;
 
 		bool Deserialize(GameThingSerializer& deserializer) override;
 	};
 
-	struct FootpathLinkSave: GameThing
+	struct FootpathLinkSave final: GameThing
 	{
 		MapCoords _coords;
 		FootpathLink _link;


### PR DESCRIPTION
I took a minute and went through all the warnings I get on Linux.
Found a few soft bugs and potential undefined behaviour.
I set an option to treat warnings as errors and enabled them on azure for Linux only.
I haven't gone through the warnings on MSVC, they seem too numerous and I don't want to deal with `fopen_s`.