### PR TITLE
Use bundled fmt/fmt.h from spdlog

### DIFF
--- a/src/Serializer/GameThingSerializer.cpp
+++ b/src/Serializer/GameThingSerializer.cpp
@@ -11,7 +11,7 @@
 
 #include <cassert>
 
-#include <fmt/format.h>
+#include <spdlog/fmt/fmt.h>
 #include <spdlog/spdlog.h>
 
 #include "Common/FileStream.h"


### PR DESCRIPTION
In GameThingSerializer `fmt/fmt.h` can't be found as it is not a direct
dependency provided by CMake. Use the bundled `fmt.h` from spdlog
instead.