### PR TITLE
Add Map Grid Acceleration Structure

### DIFF
--- a/apps/l3dtool/l3dtool.cpp
+++ b/apps/l3dtool/l3dtool.cpp
@@ -223,7 +223,11 @@ int PrintMeshHeaders(openblack::l3d::L3DFile& l3d)
 	using Flags = openblack::l3d::L3DSubmeshHeader::Flags;
 	auto flagToString = [](Flags flags) {
 		std::string result;
-		result += "LOD" + std::to_string(flags.lod);
+		if (flags.hasBones)
+		{
+			result += "hasBones";
+		}
+		result += "|LOD" + std::to_string(flags.lod);
 		result += "|status=" + std::to_string(flags.status);
 		if (flags.unknown1)
 		{
@@ -600,6 +604,7 @@ int WriteFile(const Arguments::Write& args)
 		auto& gltfMesh = gltf.meshes[gltfNode.mesh];
 		using L3DSubmeshHeader = openblack::l3d::L3DSubmeshHeader;
 		L3DSubmeshHeader submesh;
+		submesh.flags.hasBones = false;
 		submesh.flags.lod = 0;
 		submesh.flags.status = 0;
 		submesh.flags.unknown1 = 0b0101;
@@ -625,6 +630,7 @@ int WriteFile(const Arguments::Write& args)
 			}
 			if (skelton >= 0)
 			{
+				submesh.flags.hasBones = true;
 				std::vector<openblack::l3d::L3DBone> bones;
 				std::function<void(const std::vector<int>&, uint32_t parent)> buildJoints;
 				buildJoints = [&gltf, &bones, &buildJoints](const std::vector<int>& children, uint32_t parentId) {

--- a/components/l3d/include/L3DFile.h
+++ b/components/l3d/include/L3DFile.h
@@ -127,7 +127,8 @@ struct L3DSubmeshHeader
 #pragma pack(push, 1)
 	struct alignas(4) Flags
 	{
-		uint32_t lod : 3;
+		uint32_t hasBones : 1;
+		uint32_t lod : 2;
 		uint32_t status : 6;
 		uint32_t unknown1 : 3; // always 0b0101
 		uint32_t isWindow : 1;

--- a/components/l3d/src/L3DFile.cpp
+++ b/components/l3d/src/L3DFile.cpp
@@ -267,10 +267,10 @@ void L3DFile::ReadFile(std::istream& stream)
 			Fail("Submesh header is beyond the end of the file");
 		}
 		stream.seekg(offset);
-		_submeshHeaders.emplace_back();
-		stream.read(reinterpret_cast<char*>(&_submeshHeaders.back()), sizeof(_submeshHeaders[0]));
-		totalPrimitives += _submeshHeaders.back().numPrimitives;
-		totalBones += _submeshHeaders.back().numBones;
+		auto& header = _submeshHeaders.emplace_back();
+		stream.read(reinterpret_cast<char*>(&header), sizeof(header));
+		totalPrimitives += header.numPrimitives;
+		totalBones += header.numBones;
 	}
 
 	// Reserve space and read skins
@@ -278,8 +278,8 @@ void L3DFile::ReadFile(std::istream& stream)
 	for (auto offset : skinOffsets)
 	{
 		stream.seekg(offset);
-		_skins.emplace_back();
-		stream.read(reinterpret_cast<char*>(&_skins.back()), sizeof(_skins[0]));
+		auto& skin = _skins.emplace_back();
+		stream.read(reinterpret_cast<char*>(&skin), sizeof(skin));
 	}
 
 	// Reserve space for primitive offsets

--- a/src/3D/AxisAlignedBoundingBox.h
+++ b/src/3D/AxisAlignedBoundingBox.h
@@ -7,7 +7,10 @@
  * openblack is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
+#pragma once
+
 #include <glm/vec3.hpp>
+#include <glm/vector_relational.hpp>
 
 namespace openblack
 {
@@ -17,8 +20,12 @@ struct AxisAlignedBoundingBox
 	glm::vec3 minima;
 	glm::vec3 maxima;
 
-	[[nodiscard]] inline glm::vec3 center() const { return (maxima + minima) * 0.5f; }
-	[[nodiscard]] inline glm::vec3 size() const { return maxima - minima; }
+	[[nodiscard]] inline glm::vec3 Center() const { return (maxima + minima) * 0.5f; }
+	[[nodiscard]] inline glm::vec3 Size() const { return maxima - minima; }
+	[[nodiscard]] inline bool Contains(const glm::vec3& point) const
+	{
+		return glm::all(glm::greaterThanEqual(point, minima) && glm::lessThanEqual(point, maxima));
+	}
 };
 
 } // namespace openblack

--- a/src/3D/L3DMesh.cpp
+++ b/src/3D/L3DMesh.cpp
@@ -29,6 +29,7 @@ L3DMesh::L3DMesh(const std::string& debugName)
     : _flags(static_cast<l3d::L3DMeshFlags>(0))
     , _debugName(debugName)
     , _physicsMass(1.0f) // TODO(bwrsandman): Find somewhere in file a value
+    , _boundingBox {glm::vec3(FLT_MAX, FLT_MAX, FLT_MAX), glm::vec3(-FLT_MAX, -FLT_MAX, -FLT_MAX)}
 {
 }
 
@@ -91,6 +92,10 @@ void L3DMesh::Load(const l3d::L3DFile& l3d)
 			_physicsMesh.reset(physicsMesh);
 			// FIXME(bwrsandman): Some meshes have multiple physics meshes
 		}
+		const auto& bb = subMesh->GetBoundingBox();
+		_boundingBox.minima = glm::min(_boundingBox.minima, bb.minima);
+		_boundingBox.maxima = glm::max(_boundingBox.maxima, bb.maxima);
+
 		_subMeshes.emplace_back(std::move(subMesh));
 	}
 	// TODO(bwrsandman): if no physics mesh was found, make physics mesh the bounding box

--- a/src/3D/L3DMesh.h
+++ b/src/3D/L3DMesh.h
@@ -99,6 +99,7 @@ public:
 	[[nodiscard]] btConvexShape& GetPhysicsMesh() { return *_physicsMesh; }
 	[[nodiscard]] const btConvexShape& GetPhysicsMesh() const { return *_physicsMesh; }
 	[[nodiscard]] float GetMass() const { return _physicsMass; }
+	[[nodiscard]] AxisAlignedBoundingBox GetBoundingBox() const { return _boundingBox; }
 
 private:
 	l3d::L3DMeshFlags _flags;
@@ -112,6 +113,7 @@ private:
 	/// Bounding box if no physics mesh was found
 	std::unique_ptr<btConvexShape> _physicsMesh;
 	float _physicsMass;
+	AxisAlignedBoundingBox _boundingBox;
 
 public:
 	[[nodiscard]] const std::string& GetDebugName() const { return _debugName; }

--- a/src/3D/L3DSubMesh.h
+++ b/src/3D/L3DSubMesh.h
@@ -62,7 +62,7 @@ public:
 	[[nodiscard]] openblack::l3d::L3DSubmeshHeader::Flags GetFlags() const { return _flags; }
 	[[nodiscard]] bool isPhysics() const { return _flags.isPhysics; }
 	[[nodiscard]] graphics::Mesh& GetMesh() const;
-	[[nodiscard]] AxisAlignedBoundingBox GetBoundingBox() const { return _boundingBox; }
+	[[nodiscard]] const AxisAlignedBoundingBox& GetBoundingBox() const { return _boundingBox; }
 	[[nodiscard]] const std::vector<Primitive>& GetPrimitives() const { return _primitives; }
 
 private:

--- a/src/ECS/Archetypes/AbodeArchetype.cpp
+++ b/src/ECS/Archetypes/AbodeArchetype.cpp
@@ -13,6 +13,7 @@
 #include <spdlog/spdlog.h>
 
 #include "ECS/Components/Abode.h"
+#include "ECS/Components/Fixed.h"
 #include "ECS/Components/Mesh.h"
 #include "ECS/Components/Transform.h"
 #include "ECS/Registry.h"
@@ -50,6 +51,7 @@ entt::entity AbodeArchetype::Create(uint32_t townId, const glm::vec3& position, 
 	const auto& info = Game::instance()->GetInfoConstants().abode[static_cast<size_t>(type)];
 
 	registry.Assign<Transform>(entity, position, glm::mat3(glm::eulerAngleY(-yAngleRadians)), glm::vec3(scale));
+	registry.Assign<Fixed>(entity);
 	registry.Assign<Abode>(entity, info.abodeNumber, townId, foodAmount, woodAmount);
 	registry.Assign<Mesh>(entity, info.meshId, static_cast<int8_t>(0), static_cast<int8_t>(0));
 

--- a/src/ECS/Archetypes/AnimatedStaticArchetype.cpp
+++ b/src/ECS/Archetypes/AnimatedStaticArchetype.cpp
@@ -13,6 +13,7 @@
 #include <glm/gtx/euler_angles.hpp>
 
 #include "ECS/Components/AnimatedStatic.h"
+#include "ECS/Components/Fixed.h"
 #include "ECS/Components/Mesh.h"
 #include "ECS/Components/Transform.h"
 #include "ECS/Registry.h"
@@ -32,6 +33,7 @@ entt::entity AnimatedStaticArchetype::Create(const glm::vec3& position, Animated
 
 	// The exact same as Feature but info is different and type is a different enum
 	registry.Assign<Transform>(entity, position, glm::eulerAngleY(-yAngleRadians), glm::vec3(scale));
+	registry.Assign<Fixed>(entity);
 	// const auto& feature = registry.Assign<Feature>(entity, type);
 	registry.Assign<Mesh>(entity, info.meshId, static_cast<int8_t>(0), static_cast<int8_t>(1));
 

--- a/src/ECS/Archetypes/AnimatedStaticArchetype.cpp
+++ b/src/ECS/Archetypes/AnimatedStaticArchetype.cpp
@@ -18,6 +18,7 @@
 #include "ECS/Components/Transform.h"
 #include "ECS/Registry.h"
 #include "Game.h"
+#include "Utils.h"
 
 using namespace openblack;
 using namespace openblack::ecs::archetypes;
@@ -32,8 +33,9 @@ entt::entity AnimatedStaticArchetype::Create(const glm::vec3& position, Animated
 	const auto& info = Game::instance()->GetInfoConstants().animatedStatic[static_cast<size_t>(type)];
 
 	// The exact same as Feature but info is different and type is a different enum
-	registry.Assign<Transform>(entity, position, glm::eulerAngleY(-yAngleRadians), glm::vec3(scale));
-	registry.Assign<Fixed>(entity);
+	const auto& transform = registry.Assign<Transform>(entity, position, glm::eulerAngleY(-yAngleRadians), glm::vec3(scale));
+	const auto [point, radius] = GetFixedObstacleBoundingCircle(info.meshId, transform);
+	registry.Assign<Fixed>(entity, point, radius);
 	// const auto& feature = registry.Assign<Feature>(entity, type);
 	registry.Assign<Mesh>(entity, info.meshId, static_cast<int8_t>(0), static_cast<int8_t>(1));
 

--- a/src/ECS/Archetypes/BigForestArchetype.cpp
+++ b/src/ECS/Archetypes/BigForestArchetype.cpp
@@ -11,6 +11,7 @@
 
 #include <glm/gtx/euler_angles.hpp>
 
+#include "ECS/Components/Fixed.h"
 #include "ECS/Components/Forest.h"
 #include "ECS/Components/Mesh.h"
 #include "ECS/Components/Transform.h"
@@ -30,6 +31,7 @@ entt::entity BigForestArchetype::Create(const glm::vec3& position, BigForestInfo
 	const auto& info = Game::instance()->GetInfoConstants().bigForest[static_cast<size_t>(type)];
 
 	registry.Assign<Transform>(entity, position, glm::eulerAngleY(-yAngleRadians), glm::vec3(scale));
+	registry.Assign<Fixed>(entity);
 	registry.Assign<Forest>(entity);
 	registry.Assign<BigForest>(entity);
 	registry.Assign<Mesh>(entity, info.meshId, static_cast<int8_t>(0), static_cast<int8_t>(1));

--- a/src/ECS/Archetypes/BigForestArchetype.cpp
+++ b/src/ECS/Archetypes/BigForestArchetype.cpp
@@ -17,6 +17,7 @@
 #include "ECS/Components/Transform.h"
 #include "ECS/Registry.h"
 #include "Game.h"
+#include "Utils.h"
 
 using namespace openblack;
 using namespace openblack::ecs::archetypes;
@@ -30,8 +31,9 @@ entt::entity BigForestArchetype::Create(const glm::vec3& position, BigForestInfo
 
 	const auto& info = Game::instance()->GetInfoConstants().bigForest[static_cast<size_t>(type)];
 
-	registry.Assign<Transform>(entity, position, glm::eulerAngleY(-yAngleRadians), glm::vec3(scale));
-	registry.Assign<Fixed>(entity);
+	const auto& transform = registry.Assign<Transform>(entity, position, glm::eulerAngleY(-yAngleRadians), glm::vec3(scale));
+	const auto [point, radius] = GetFixedObstacleBoundingCircle(info.meshId, transform);
+	registry.Assign<Fixed>(entity, point, radius);
 	registry.Assign<Forest>(entity);
 	registry.Assign<BigForest>(entity);
 	registry.Assign<Mesh>(entity, info.meshId, static_cast<int8_t>(0), static_cast<int8_t>(1));

--- a/src/ECS/Archetypes/FeatureArchetype.cpp
+++ b/src/ECS/Archetypes/FeatureArchetype.cpp
@@ -15,6 +15,7 @@
 #include "3D/L3DMesh.h"
 #include "3D/MeshPack.h"
 #include "ECS/Components/Feature.h"
+#include "ECS/Components/Fixed.h"
 #include "ECS/Components/Mesh.h"
 #include "ECS/Components/RigidBody.h"
 #include "ECS/Components/Transform.h"
@@ -33,6 +34,7 @@ entt::entity FeatureArchetype::Create(const glm::vec3& position, FeatureInfo typ
 	const auto& info = Game::instance()->GetInfoConstants().feature[static_cast<size_t>(type)];
 
 	const auto& transform = registry.Assign<Transform>(entity, position, glm::eulerAngleY(-yAngleRadians), glm::vec3(scale));
+	registry.Assign<Fixed>(entity);
 	registry.Assign<Feature>(entity, type);
 	const auto& mesh = registry.Assign<Mesh>(entity, info.meshId, static_cast<int8_t>(0), static_cast<int8_t>(1));
 

--- a/src/ECS/Archetypes/FeatureArchetype.cpp
+++ b/src/ECS/Archetypes/FeatureArchetype.cpp
@@ -21,6 +21,7 @@
 #include "ECS/Components/Transform.h"
 #include "ECS/Registry.h"
 #include "Game.h"
+#include "Utils.h"
 
 using namespace openblack;
 using namespace openblack::ecs::archetypes;
@@ -34,7 +35,8 @@ entt::entity FeatureArchetype::Create(const glm::vec3& position, FeatureInfo typ
 	const auto& info = Game::instance()->GetInfoConstants().feature[static_cast<size_t>(type)];
 
 	const auto& transform = registry.Assign<Transform>(entity, position, glm::eulerAngleY(-yAngleRadians), glm::vec3(scale));
-	registry.Assign<Fixed>(entity);
+	const auto [point, radius] = GetFixedObstacleBoundingCircle(info.meshId, transform);
+	registry.Assign<Fixed>(entity, point, radius);
 	registry.Assign<Feature>(entity, type);
 	const auto& mesh = registry.Assign<Mesh>(entity, info.meshId, static_cast<int8_t>(0), static_cast<int8_t>(1));
 

--- a/src/ECS/Archetypes/MobileObjectArchetype.cpp
+++ b/src/ECS/Archetypes/MobileObjectArchetype.cpp
@@ -31,6 +31,7 @@ entt::entity MobileObjectArchetype::Create(const glm::vec3& position, MobileObje
 	const auto& info = Game::instance()->GetInfoConstants().mobileObject[static_cast<size_t>(type)];
 
 	registry.Assign<Transform>(entity, position, glm::eulerAngleY(-yAngleRadians), glm::vec3(scale));
+	registry.Assign<Mobile>(entity);
 	registry.Assign<MobileObject>(entity, type);
 	registry.Assign<Mesh>(entity, info.meshId, static_cast<int8_t>(0), static_cast<int8_t>(1));
 

--- a/src/ECS/Archetypes/MobileStaticArchetype.cpp
+++ b/src/ECS/Archetypes/MobileStaticArchetype.cpp
@@ -35,6 +35,7 @@ entt::entity MobileStaticArchetype::Create(const glm::vec3& position, MobileStat
 
 	registry.Assign<Transform>(entity, position + offset, glm::eulerAngleXYZ(-xAngleRadians, -yAngleRadians, -zAngleRadians),
 	                           glm::vec3(scale));
+	registry.Assign<Mobile>(entity);
 	registry.Assign<MobileStatic>(entity, type);
 	registry.Assign<Mesh>(entity, info.meshId, static_cast<int8_t>(0), static_cast<int8_t>(1));
 

--- a/src/ECS/Archetypes/TreeArchetype.cpp
+++ b/src/ECS/Archetypes/TreeArchetype.cpp
@@ -11,6 +11,7 @@
 
 #include <glm/gtx/euler_angles.hpp>
 
+#include "ECS/Components/Fixed.h"
 #include "ECS/Components/Mesh.h"
 #include "ECS/Components/Transform.h"
 #include "ECS/Components/Tree.h"
@@ -30,6 +31,7 @@ entt::entity TreeArchetype::Create([[maybe_unused]] uint32_t forestId, const glm
 	const auto& info = Game::instance()->GetInfoConstants().tree[static_cast<size_t>(type)];
 
 	registry.Assign<Transform>(entity, position, glm::eulerAngleY(-yAngleRadians), glm::vec3(scale));
+	registry.Assign<Fixed>(entity);
 	registry.Assign<Tree>(entity, type, maxSize);
 	registry.Assign<Mesh>(entity, info.normal, static_cast<int8_t>(0), static_cast<int8_t>(-1));
 

--- a/src/ECS/Archetypes/TreeArchetype.cpp
+++ b/src/ECS/Archetypes/TreeArchetype.cpp
@@ -17,6 +17,7 @@
 #include "ECS/Components/Tree.h"
 #include "ECS/Registry.h"
 #include "Game.h"
+#include "Utils.h"
 
 using namespace openblack;
 using namespace openblack::ecs::archetypes;
@@ -30,8 +31,9 @@ entt::entity TreeArchetype::Create([[maybe_unused]] uint32_t forestId, const glm
 
 	const auto& info = Game::instance()->GetInfoConstants().tree[static_cast<size_t>(type)];
 
-	registry.Assign<Transform>(entity, position, glm::eulerAngleY(-yAngleRadians), glm::vec3(scale));
-	registry.Assign<Fixed>(entity);
+	const auto& transform = registry.Assign<Transform>(entity, position, glm::eulerAngleY(-yAngleRadians), glm::vec3(scale));
+	const auto [point, radius] = GetFixedObstacleBoundingCircle(info.normal, transform);
+	registry.Assign<Fixed>(entity, point, radius);
 	registry.Assign<Tree>(entity, type, maxSize);
 	registry.Assign<Mesh>(entity, info.normal, static_cast<int8_t>(0), static_cast<int8_t>(-1));
 

--- a/src/ECS/Archetypes/Utils.cpp
+++ b/src/ECS/Archetypes/Utils.cpp
@@ -1,0 +1,37 @@
+/*****************************************************************************
+ * Copyright (c) 2018-2022 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include "Utils.h"
+
+#include <glm/glm.hpp>
+#include <glm/gtx/component_wise.hpp>
+#include <glm/gtx/vec_swizzle.hpp>
+
+#include "3D/L3DMesh.h"
+#include "3D/MeshPack.h"
+#include "ECS/Components/Transform.h"
+#include "Game.h"
+
+using namespace openblack;
+using namespace openblack::ecs::components;
+
+std::pair<glm::vec2, float> openblack::ecs::archetypes::GetFixedObstacleBoundingCircle(MeshId meshId,
+                                                                                       const Transform& transform)
+{
+	const auto& bb = Game::instance()->GetMeshPack().GetMesh(meshId).GetBoundingBox();
+	const auto bbSize = glm::max(glm::vec2(1.0f, 1.0f), glm::xz(bb.Size() * 0.5f * transform.scale));
+	glm::mat4 modelMatrix = glm::mat4(1.0f);
+	modelMatrix = glm::translate(modelMatrix, transform.position);
+	modelMatrix *= glm::mat4(transform.rotation);
+	modelMatrix = glm::scale(modelMatrix, transform.scale);
+	const auto point = glm::xz(glm::vec4(bb.Center(), 1.0f) * glm::transpose(modelMatrix));
+	const auto radius = (glm::compMax(bbSize) / glm::compMin(bbSize) > 1.4) ? glm::length(bbSize) : glm::compMax(bbSize);
+
+	return std::make_pair(point, radius);
+}

--- a/src/ECS/Archetypes/Utils.h
+++ b/src/ECS/Archetypes/Utils.h
@@ -7,21 +7,21 @@
  * openblack is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#pragma once
+#include <tuple>
+
+#include <glm/vec2.hpp>
+
+namespace openblack
+{
+enum class MeshId : uint32_t;
+}
 
 namespace openblack::ecs::components
 {
+struct Transform;
+}
 
-struct Fixed
+namespace openblack::ecs::archetypes
 {
-	Fixed(const glm::vec2& boundingCenter, float boundingRadius)
-	    : boundingCenter(boundingCenter)
-	    , boundingRadius(boundingRadius)
-	{
-	}
-
-	glm::vec2 boundingCenter;
-	float boundingRadius;
-};
-
-} // namespace openblack::ecs::components
+std::pair<glm::vec2, float> GetFixedObstacleBoundingCircle(MeshId meshId, const components::Transform& transform);
+}

--- a/src/ECS/Archetypes/VillagerArchetype.cpp
+++ b/src/ECS/Archetypes/VillagerArchetype.cpp
@@ -13,6 +13,7 @@
 #include <glm/vec3.hpp>
 
 #include "ECS/Components/Mesh.h"
+#include "ECS/Components/Mobile.h"
 #include "ECS/Components/Transform.h"
 #include "ECS/Components/Villager.h"
 #include "ECS/Registry.h"
@@ -33,6 +34,7 @@ entt::entity VillagerArchetype::Create([[maybe_unused]] const glm::vec3& abodePo
 	const auto& info = Game::instance()->GetInfoConstants().villager[static_cast<size_t>(type)];
 
 	registry.Assign<Transform>(entity, position, glm::eulerAngleY(glm::radians(180.0f)), glm::vec3(1.0));
+	registry.Assign<Mobile>(entity);
 	const uint32_t health = 100;
 	const uint32_t hunger = 100;
 

--- a/src/ECS/Components/Fixed.h
+++ b/src/ECS/Components/Fixed.h
@@ -9,24 +9,12 @@
 
 #pragma once
 
-#include "Enums.h"
-
 namespace openblack::ecs::components
 {
 
-struct Mobile
+struct Fixed
 {
 	char dummy;
-};
-
-struct MobileStatic
-{
-	MobileStaticInfo type; ///< This is 32 bits but could be 8 bits if stored in uint8_t
-};
-
-struct MobileObject
-{
-	MobileObjectInfo type; ///< This is 32 bits but could be 8 bits if stored in uint8_t
 };
 
 } // namespace openblack::ecs::components

--- a/src/ECS/Components/Transform.h
+++ b/src/ECS/Components/Transform.h
@@ -18,6 +18,7 @@ struct Transform
 {
 	glm::vec3 position;
 	glm::mat3 rotation;
+	// TODO(bwrsandman): Change to float. For all intents and purposes, transform scales uniformly.
 	glm::vec3 scale;
 };
 

--- a/src/ECS/Map.cpp
+++ b/src/ECS/Map.cpp
@@ -1,0 +1,77 @@
+/*****************************************************************************
+ * Copyright (c) 2018-2022 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include "Map.h"
+
+#include <glm/gtx/vec_swizzle.hpp>
+#include <glm/vec3.hpp>
+
+#include "ECS/Components/Fixed.h"
+#include "ECS/Components/Mobile.h"
+#include "ECS/Components/Transform.h"
+#include "ECS/Registry.h"
+#include "Game.h"
+
+using namespace openblack::ecs;
+using namespace openblack::ecs::components;
+
+glm::u16vec2 Map::GetGridCell(const glm::vec3& pos)
+{
+	const glm::u32vec2 coords = glm::xz(pos) * _positionToGridFactor;
+	const glm::u16vec2 result(coords.x >> 0x10, coords.y >> 0x10);
+	assert(glm::all(glm::lessThan(result, _gridSize)));
+	return result;
+}
+
+const std::unordered_set<entt::entity>& Map::GetFixedInGridCell(const glm::vec3& pos) const
+{
+	const auto cellId = GetGridCell(pos);
+	return _fixedGrid[cellId.x + cellId.y * _gridSize.x];
+}
+
+const std::unordered_set<entt::entity>& Map::GetMobileInGridCell(const glm::vec3& pos) const
+{
+	const auto cellId = GetGridCell(pos);
+	return _mobileGrid[cellId.x + cellId.y * _gridSize.x];
+}
+
+void Map::Rebuild()
+{
+	Clear();
+	Build();
+}
+
+void Map::Clear()
+{
+	for (auto& g : _fixedGrid)
+	{
+		g.clear();
+	}
+	for (auto& g : _mobileGrid)
+	{
+		g.clear();
+	}
+}
+
+void Map::Build()
+{
+	auto& registry = Game::instance()->GetEntityRegistry();
+	registry.Each<const Fixed, const Transform>(
+	    [this](entt::entity entity, [[maybe_unused]] const Fixed& fixed, const Transform& transform) {
+		    const auto cellId = GetGridCell(transform.position);
+		    auto& cell = _fixedGrid[cellId.x + cellId.y * _gridSize.x];
+		    cell.insert(entity);
+	    });
+	registry.Each<const Mobile, const Transform>(
+	    [this](entt::entity entity, [[maybe_unused]] const Mobile& mobile, const Transform& transform) {
+		    const auto cellId = GetGridCell(transform.position);
+		    auto& cell = _mobileGrid[cellId.x + cellId.y * _gridSize.x];
+		    cell.insert(entity);
+	    });
+}

--- a/src/ECS/Map.h
+++ b/src/ECS/Map.h
@@ -1,0 +1,44 @@
+/*****************************************************************************
+ * Copyright (c) 2018-2022 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <unordered_set>
+
+#include <entt/fwd.hpp>
+#include <glm/fwd.hpp>
+#include <glm/vec2.hpp>
+
+namespace openblack::ecs
+{
+
+class Map
+{
+public:
+	static constexpr float _positionToGridFactor = static_cast<float>(0x10000) * 0.1f;
+	static constexpr glm::u16vec2 _gridSize = {0x200, 0x200};
+
+	static glm::u16vec2 GetGridCell(const glm::vec3& pos);
+
+	const std::unordered_set<entt::entity>& GetFixedInGridCell(const glm::vec3& pos) const;
+	const std::unordered_set<entt::entity>& GetMobileInGridCell(const glm::vec3& pos) const;
+
+	void Rebuild();
+
+private:
+	void Clear();
+	void Build();
+
+	std::array<std::unordered_set<entt::entity>, _gridSize.x * _gridSize.y> _fixedGrid;
+	std::array<std::unordered_set<entt::entity>, _gridSize.x * _gridSize.y> _mobileGrid;
+};
+
+} // namespace openblack::ecs

--- a/src/ECS/Map.h
+++ b/src/ECS/Map.h
@@ -23,12 +23,18 @@ namespace openblack::ecs
 class Map
 {
 public:
+	using CellId = glm::u16vec2;
+
 	static constexpr float _positionToGridFactor = static_cast<float>(0x10000) * 0.1f;
 	static constexpr glm::u16vec2 _gridSize = {0x200, 0x200};
 
-	static glm::u16vec2 GetGridCell(const glm::vec3& pos);
+	static CellId GetGridCell(const glm::vec2& pos);
+	static CellId GetGridCell(const glm::vec3& pos);
+	static glm::vec2 GetCellCenter(const CellId& cellId);
 
+	const std::unordered_set<entt::entity>& GetFixedInGridCell(const CellId& cellId) const;
 	const std::unordered_set<entt::entity>& GetFixedInGridCell(const glm::vec3& pos) const;
+	const std::unordered_set<entt::entity>& GetMobileInGridCell(const CellId& cellId) const;
 	const std::unordered_set<entt::entity>& GetMobileInGridCell(const glm::vec3& pos) const;
 
 	void Rebuild();

--- a/src/ECS/Systems/RenderingSystem.cpp
+++ b/src/ECS/Systems/RenderingSystem.cpp
@@ -105,7 +105,7 @@ void RenderingSystem::PrepareDrawUploadUniforms(bool drawBoundingBox)
 			    const L3DMesh& l3dMesh = Game::instance()->GetMeshPack().GetMesh(mesh.id);
 			    auto submeshId = (l3dMesh.GetNumSubMeshes() + mesh.bbSubmeshId) % l3dMesh.GetNumSubMeshes();
 			    auto box = l3dMesh.GetSubMeshes()[submeshId]->GetBoundingBox();
-			    auto boxMatrix = modelMatrix * glm::translate(box.center()) * glm::scale(box.size());
+			    auto boxMatrix = modelMatrix * glm::translate(box.Center()) * glm::scale(box.Size());
 			    _renderContext.instanceUniforms[idx + _renderContext.instanceUniforms.size() / 2] = boxMatrix;
 		    }
 		    offset.first->second++;

--- a/src/ECS/Systems/RenderingSystem.cpp
+++ b/src/ECS/Systems/RenderingSystem.cpp
@@ -103,8 +103,7 @@ void RenderingSystem::PrepareDrawUploadUniforms(bool drawBoundingBox)
 		    if (drawBoundingBox)
 		    {
 			    const L3DMesh& l3dMesh = Game::instance()->GetMeshPack().GetMesh(mesh.id);
-			    auto submeshId = (l3dMesh.GetNumSubMeshes() + mesh.bbSubmeshId) % l3dMesh.GetNumSubMeshes();
-			    auto box = l3dMesh.GetSubMeshes()[submeshId]->GetBoundingBox();
+			    auto box = l3dMesh.GetBoundingBox();
 			    auto boxMatrix = modelMatrix * glm::translate(box.Center()) * glm::scale(box.Size());
 			    _renderContext.instanceUniforms[idx + _renderContext.instanceUniforms.size() / 2] = boxMatrix;
 		    }

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -20,7 +20,10 @@
 #include "Common/EventManager.h"
 #include "Common/FileSystem.h"
 #include "ECS/Archetypes/HandArchetype.h"
+#include "ECS/Components/Fixed.h"
+#include "ECS/Components/Mobile.h"
 #include "ECS/Components/Transform.h"
+#include "ECS/Map.h"
 #include "ECS/Registry.h"
 #include "ECS/Systems/DynamicsSystem.h"
 #include "ECS/Systems/RenderingSystem.h"
@@ -64,6 +67,7 @@ Game::Game(Arguments&& args)
     : _eventManager(std::make_unique<EventManager>())
     , _fileSystem(std::make_unique<FileSystem>())
     , _entityRegistry(std::make_unique<ecs::Registry>())
+    , _entityMap(std::make_unique<ecs::Map>())
     , _config()
     , _gameSpeedMultiplier(1.0f)
     , _frameCount(0)
@@ -197,6 +201,8 @@ bool Game::ProcessEvents(const SDL_Event& event)
 
 bool Game::GameLogicLoop()
 {
+	using namespace ecs::components;
+
 	const auto currentTime = std::chrono::steady_clock::now();
 	const auto delta = currentTime - _lastGameLoopTime;
 	if (delta < kTurnDuration * _gameSpeedMultiplier)
@@ -204,8 +210,8 @@ bool Game::GameLogicLoop()
 		return false;
 	}
 
-	// TODO: update entities
-	// const auto& registry = GetEntityRegistry();
+	// Build Map Grid Acceleration Structure
+	_entityMap->Rebuild();
 
 	_lastGameLoopTime = currentTime;
 	_turnDeltaTime = delta;
@@ -406,6 +412,9 @@ bool Game::Run()
 		                    (_fileSystem->GetGamePath() / challengePath).generic_string());
 		return false;
 	}
+
+	// Initialize the Acceleration Structure
+	_entityMap->Rebuild();
 
 	if (_window)
 	{

--- a/src/Game.h
+++ b/src/Game.h
@@ -184,6 +184,7 @@ public:
 	ecs::Registry& GetEntityRegistry() { return *_entityRegistry; }
 	[[nodiscard]] ecs::Registry& GetEntityRegistry() const { return *_entityRegistry; }
 	const InfoConstants& GetInfoConstants() { return _infoConstants; } ///< Access should be only read-only
+	[[nodiscard]] ecs::Map& GetEntityMap() { return *_entityMap; }
 	[[nodiscard]] const ecs::Map& GetEntityMap() const { return *_entityMap; }
 	Config& GetConfig() { return _config; }
 	[[nodiscard]] const Config& GetConfig() const { return _config; }

--- a/src/Game.h
+++ b/src/Game.h
@@ -59,6 +59,7 @@ class LHVM;
 
 namespace ecs
 {
+class Map;
 namespace components
 {
 struct Transform;
@@ -183,6 +184,7 @@ public:
 	ecs::Registry& GetEntityRegistry() { return *_entityRegistry; }
 	[[nodiscard]] ecs::Registry& GetEntityRegistry() const { return *_entityRegistry; }
 	const InfoConstants& GetInfoConstants() { return _infoConstants; } ///< Access should be only read-only
+	[[nodiscard]] const ecs::Map& GetEntityMap() const { return *_entityMap; }
 	Config& GetConfig() { return _config; }
 	[[nodiscard]] const Config& GetConfig() const { return _config; }
 	[[nodiscard]] uint16_t GetTurn() const { return _turnCount; }
@@ -219,6 +221,7 @@ private:
 	std::unique_ptr<lhscriptx::Script> _scriptx;
 	std::unique_ptr<LHVM::LHVM> _lhvm;
 	std::unique_ptr<ecs::Registry> _entityRegistry;
+	std::unique_ptr<ecs::Map> _entityMap;
 
 	InfoConstants _infoConstants;
 	Config _config;

--- a/src/Gui/MeshViewer.cpp
+++ b/src/Gui/MeshViewer.cpp
@@ -131,8 +131,8 @@ void MeshViewer::Draw(Game& game)
 	auto const& submesh = mesh->GetSubMeshes()[_selectedSubMesh];
 
 	auto flags = submesh->GetFlags();
-	ImGui::Text("SubMesh LOD=%u Status=%u%s%s", flags.lod, flags.status, flags.isPhysics ? " [Physics]" : "",
-	            flags.isWindow ? " [Window]" : "");
+	ImGui::Text("SubMesh LOD=%u Status=%u%s%s%s", flags.lod, flags.status, flags.hasBones ? " [Bones]" : "",
+	            flags.isPhysics ? " [Physics]" : "", flags.isWindow ? " [Window]" : "");
 
 	auto const& graphicsMesh = submesh->GetMesh();
 	ImGui::Text("Vertices %u, Indices %u", graphicsMesh.GetVertexBuffer().GetCount(), graphicsMesh.GetIndexBuffer().GetCount());
@@ -271,7 +271,7 @@ void MeshViewer::Update(Game& game, const Renderer& renderer)
 		renderer.DrawMesh(*mesh, meshPack, desc, static_cast<uint8_t>(_selectedSubMesh));
 		if (_viewBoundingBox)
 		{
-			auto box = mesh->GetSubMeshes()[_selectedSubMesh]->GetBoundingBox();
+			auto box = mesh->GetBoundingBox();
 			auto model = glm::translate(box.Center()) * glm::scale(box.Size());
 			bgfx::setTransform(glm::value_ptr(model));
 			_boundingBox->GetMesh().GetVertexBuffer().Bind();

--- a/src/Gui/MeshViewer.cpp
+++ b/src/Gui/MeshViewer.cpp
@@ -272,7 +272,7 @@ void MeshViewer::Update(Game& game, const Renderer& renderer)
 		if (_viewBoundingBox)
 		{
 			auto box = mesh->GetSubMeshes()[_selectedSubMesh]->GetBoundingBox();
-			auto model = glm::translate(box.center()) * glm::scale(box.size());
+			auto model = glm::translate(box.Center()) * glm::scale(box.Size());
 			bgfx::setTransform(glm::value_ptr(model));
 			_boundingBox->GetMesh().GetVertexBuffer().Bind();
 			bgfx::setState(BGFX_STATE_DEFAULT | BGFX_STATE_PT_LINES, 0);


### PR DESCRIPTION
This matches the acceleration structure used in vanilla to look-up locally close fixed and mobile subclasses.
Vanilla used a linked list for this, this implementation uses a set to avoid duplicates, order should not matter either.

An accelerated look-up is needed to find town congregation point. A different AS could be used such as a BVH (used in modern physics and raytracing), quadtree (more dynamic), kd-tree, etc.

Depends on:
- [x] #258 for component clean-up