### PR TITLE
components: Add Mesh Component and use for drawing

### DIFF
--- a/src/Common/MeshLookup.h
+++ b/src/Common/MeshLookup.h
@@ -28,13 +28,13 @@ namespace openblack
 class MeshId
 {
 public:
-	using IdType = int;
+	using IdType = int16_t;
 	constexpr MeshId(MeshPackId id)
 	    : _id(static_cast<IdType>(id)) {};
 	constexpr MeshId(IdType id)
 	    : _id(static_cast<IdType>(id)) {};
-	constexpr operator int() const { return _id; }
-	constexpr bool operator==(const int& other) const { return _id == other; }
+	constexpr operator IdType() const { return _id; }
+	constexpr bool operator==(const IdType& other) const { return _id == other; }
 
 private:
 	IdType _id;

--- a/src/Entities/Components/Mesh.h
+++ b/src/Entities/Components/Mesh.h
@@ -1,0 +1,24 @@
+/*****************************************************************************
+ * Copyright (c) 2018-2021 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include "Common/MeshLookup.h"
+
+namespace openblack::entities::components
+{
+
+struct Mesh
+{
+	MeshId id;
+	int8_t submeshId;
+	int8_t bbSubmeshId;
+};
+
+} // namespace openblack::entities::components

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -20,6 +20,7 @@
 #include "Common/EventManager.h"
 #include "Common/FileSystem.h"
 #include "Entities/Components/Hand.h"
+#include "Entities/Components/Mesh.h"
 #include "Entities/Components/Transform.h"
 #include "Entities/Registry.h"
 #include "GameWindow.h"
@@ -441,6 +442,8 @@ void Game::LoadMap(const fs::path& path)
 	_entityRegistry->Assign<entities::components::Hand>(_handEntity);
 	const auto rotation = glm::mat3(glm::eulerAngleXZ(glm::half_pi<float>(), glm::half_pi<float>()));
 	_entityRegistry->Assign<entities::components::Transform>(_handEntity, glm::vec3(0), rotation, glm::vec3(0.02));
+	_entityRegistry->Assign<entities::components::Mesh>(_handEntity, entities::components::Hand::meshId, static_cast<int8_t>(0),
+	                                                    static_cast<int8_t>(0));
 
 	Script script(this);
 	script.Load(source);

--- a/src/LHScriptX/FeatureScriptCommands.cpp
+++ b/src/LHScriptX/FeatureScriptCommands.cpp
@@ -23,6 +23,7 @@
 #include "Entities/Components/Field.h"
 #include "Entities/Components/Footpath.h"
 #include "Entities/Components/Forest.h"
+#include "Entities/Components/Mesh.h"
 #include "Entities/Components/Stream.h"
 #include "Entities/Components/Town.h"
 #include "Entities/Components/Transform.h"
@@ -370,8 +371,9 @@ void FeatureScriptCommands::CreateAbode(int32_t townId, glm::vec3 position, cons
 	const auto entity = registry.Create();
 
 	registry.Assign<Transform>(entity, position, GetRotation(rotation), GetSize(size));
-	registry.Assign<Abode>(entity, GetAbodeInfo(abodeInfo), static_cast<uint32_t>(townId), static_cast<uint32_t>(foodAmount),
-	                       static_cast<uint32_t>(woodAmount));
+	const auto& abode = registry.Assign<Abode>(entity, GetAbodeInfo(abodeInfo), static_cast<uint32_t>(townId),
+	                                           static_cast<uint32_t>(foodAmount), static_cast<uint32_t>(woodAmount));
+	registry.Assign<Mesh>(entity, abodeMeshLookup[abode.type], static_cast<int8_t>(0), static_cast<int8_t>(0));
 }
 
 void FeatureScriptCommands::CreatePlannedAbode(int32_t townId, glm::vec3 position, const std::string& abodeInfo,
@@ -388,8 +390,9 @@ void FeatureScriptCommands::CreateTownCentre(int32_t townId, glm::vec3 position,
 	auto submeshIds = std::vector {3};
 
 	registry.Assign<Transform>(entity, position, GetRotation(rotation), GetSize(size));
-	registry.Assign<Abode>(entity, GetAbodeInfo(abodeInfo), static_cast<uint32_t>(townId), static_cast<uint32_t>(0),
-	                       static_cast<uint32_t>(0));
+	const auto& abode = registry.Assign<Abode>(entity, GetAbodeInfo(abodeInfo), static_cast<uint32_t>(townId),
+	                                           static_cast<uint32_t>(0), static_cast<uint32_t>(0));
+	registry.Assign<Mesh>(entity, abodeMeshLookup[abode.type], static_cast<int8_t>(0), static_cast<int8_t>(0));
 }
 
 void FeatureScriptCommands::CreateTownSpell(int32_t townId, const std::string& spellName)
@@ -447,7 +450,10 @@ void FeatureScriptCommands::CreateVillagerPos(glm::vec3 position, [[maybe_unused
 	auto lifeStage = age >= 18 ? Villager::LifeStage::Adult : Villager::LifeStage::Child;
 	auto sex = (role == Villager::Role::HOUSEWIFE) ? Villager::Sex::FEMALE : Villager::Sex::MALE;
 	auto task = Villager::Task::IDLE;
-	registry.Assign<Villager>(entity, health, static_cast<uint32_t>(age), hunger, lifeStage, sex, tribe, role, task);
+	const auto& villager =
+	    registry.Assign<Villager>(entity, health, static_cast<uint32_t>(age), hunger, lifeStage, sex, tribe, role, task);
+	registry.Assign<Mesh>(entity, villagerMeshLookup[villager.GetVillagerType()], static_cast<int8_t>(0),
+	                      static_cast<int8_t>(0));
 }
 
 void FeatureScriptCommands::CreateCitadel(glm::vec3 position, int32_t, const std::string&, int32_t, int32_t)
@@ -504,7 +510,8 @@ void FeatureScriptCommands::CreateNewTree(int32_t forestId, glm::vec3 position, 
 	const auto entity = registry.Create();
 
 	registry.Assign<Transform>(entity, position, glm::eulerAngleY(-rotation), glm::vec3(currentSize));
-	registry.Assign<Tree>(entity, Tree::Info(treeType));
+	const auto& tree = registry.Assign<Tree>(entity, Tree::Info(treeType));
+	registry.Assign<Mesh>(entity, treeMeshLookup[tree.type], static_cast<int8_t>(0), static_cast<int8_t>(-1));
 }
 
 void FeatureScriptCommands::CreateField(glm::vec3 position, int32_t)
@@ -567,8 +574,9 @@ void FeatureScriptCommands::CreateMobileObject(glm::vec3 position, int32_t type,
 	auto& registry = Game::instance()->GetEntityRegistry();
 	const auto entity = registry.Create();
 
-	registry.Assign<MobileObject>(entity, static_cast<MobileObject::Info>(type));
 	registry.Assign<Transform>(entity, position, GetRotation(rotation), GetSize(scale));
+	const auto& object = registry.Assign<MobileObject>(entity, static_cast<MobileObject::Info>(type));
+	registry.Assign<Mesh>(entity, mobileObjectMeshLookup[object.type], static_cast<int8_t>(0), static_cast<int8_t>(1));
 }
 
 void FeatureScriptCommands::CreateMobileStatic(glm::vec3 position, int32_t, float, float)
@@ -584,8 +592,9 @@ void FeatureScriptCommands::CreateMobileUStatic(glm::vec3 position, int32_t type
 
 	glm::vec3 offset(0.0f, verticalOffset, 0.0f);
 
-	registry.Assign<MobileStatic>(entity, MobileStatic::Info(type));
 	registry.Assign<Transform>(entity, position + offset, glm::eulerAngleXYZ(-pitch, -rotation, -lean), glm::vec3(scale));
+	const auto& mobile = registry.Assign<MobileStatic>(entity, MobileStatic::Info(type));
+	registry.Assign<Mesh>(entity, mobileStaticMeshLookup[mobile.type], static_cast<int8_t>(0), static_cast<int8_t>(1));
 }
 
 void FeatureScriptCommands::CreateDeadTree(glm::vec3 position, const std::string&, int32_t, float, float, float, float)
@@ -671,8 +680,9 @@ void FeatureScriptCommands::CreateNewBigForest(glm::vec3 position, int32_t type,
 	auto& registry = Game::instance()->GetEntityRegistry();
 	const auto entity = registry.Create();
 
-	registry.Assign<Forest>(entity);
 	registry.Assign<Transform>(entity, position, glm::eulerAngleY(-rotation), glm::vec3(scale));
+	registry.Assign<Forest>(entity);
+	registry.Assign<Mesh>(entity, MeshPackId::FeatureForest, static_cast<int8_t>(0), static_cast<int8_t>(1));
 }
 
 void FeatureScriptCommands::CreateInfluenceRing(glm::vec3 position, int32_t, float, int32_t)
@@ -769,8 +779,9 @@ void FeatureScriptCommands::CreateBonfire(glm::vec3 position, float rotation, fl
 	auto& registry = Game::instance()->GetEntityRegistry();
 	const auto entity = registry.Create();
 
-	registry.Assign<MobileStatic>(entity, MobileStatic::Info::Bonfire);
 	registry.Assign<Transform>(entity, position, glm::eulerAngleY(-rotation), glm::vec3(scale));
+	const auto& mobile = registry.Assign<MobileStatic>(entity, MobileStatic::Info::Bonfire);
+	registry.Assign<Mesh>(entity, mobileStaticMeshLookup[mobile.type], static_cast<int8_t>(0), static_cast<int8_t>(1));
 }
 
 void FeatureScriptCommands::CreateBase(glm::vec3 position, int32_t)
@@ -784,8 +795,9 @@ void FeatureScriptCommands::CreateNewFeature(glm::vec3 position, const std::stri
 	auto& registry = Game::instance()->GetEntityRegistry();
 	const auto entity = registry.Create();
 
-	registry.Assign<Feature>(entity, GetFeatureInfo(type));
 	registry.Assign<Transform>(entity, position, GetRotation(rotation), GetSize(scale));
+	const auto& feature = registry.Assign<Feature>(entity, GetFeatureInfo(type));
+	registry.Assign<Mesh>(entity, featureMeshLookup[feature.type], static_cast<int8_t>(0), static_cast<int8_t>(1));
 }
 
 void FeatureScriptCommands::SetInteractDesire(float)
@@ -848,8 +860,22 @@ void FeatureScriptCommands::CreateAnimatedStatic(glm::vec3 position, const std::
 	auto& registry = Game::instance()->GetEntityRegistry();
 	const auto entity = registry.Create();
 
-	registry.Assign<AnimatedStatic>(entity, type);
 	registry.Assign<Transform>(entity, position, GetRotation(rotation), GetSize(scale));
+	const auto& animated = registry.Assign<AnimatedStatic>(entity, type);
+	MeshPackId meshPackId = MeshPackId::Dummy;
+	if (animated.type == "Norse Gate")
+	{
+		meshPackId = MeshPackId::BuildingNorseGate;
+	}
+	else if (animated.type == "Gate Stone Plinth")
+	{
+		meshPackId = MeshPackId::ObjectGateTotemPlinthe;
+	}
+	else if (animated.type == "Piper Cave Entrance")
+	{
+		meshPackId = MeshPackId::BuildingMineEntrance;
+	}
+	registry.Assign<Mesh>(entity, static_cast<MeshId>(meshPackId), static_cast<int8_t>(0), static_cast<int8_t>(0));
 }
 
 void FeatureScriptCommands::FireFlySpellRewardProb(const std::string& spell, float probability)
@@ -862,8 +888,9 @@ void FeatureScriptCommands::CreateNewTownField(int32_t townId, glm::vec3 positio
 	auto& registry = Game::instance()->GetEntityRegistry();
 	const auto entity = registry.Create();
 
-	registry.Assign<Field>(entity, townId);
 	registry.Assign<Transform>(entity, position, GetRotation(rotation), GetSize(1000));
+	registry.Assign<Field>(entity, townId);
+	registry.Assign<Mesh>(entity, MeshPackId::TreeWheat, static_cast<int8_t>(0), static_cast<int8_t>(0));
 }
 
 void FeatureScriptCommands::CreateSpellDispenser(int32_t, glm::vec3 position, const std::string&, const std::string&, float,


### PR DESCRIPTION
By adding a mesh component, access to mesh id and sub mesh id are much quicker (struct is aligned on 8 bytes) and easier to do with EnTT.

Getting mesh Ids is now done at entity creation time.

Rendering is done with one `Each` call. No more need to use look-up tables. This greatly simplifies the amount of code needed.

Changing villager roles will have to be accompanied by changes to the mesh component.

The debug bounding boxes are now properly oriented after a fix.

![Screenshot from 2020-12-31 00-31-34](https://user-images.githubusercontent.com/1013356/103396170-9ad99a00-4aff-11eb-8832-ef4e5844ecf6.png)

Open question: for some reason some of the bounding boxes use different submesh ids. Why is this?

Depends on:
- [x] #258 for component clean-up