### PR TITLE
Gui: Member size bug in villager debug

### DIFF
--- a/external/imgui/CMakeLists.txt
+++ b/external/imgui/CMakeLists.txt
@@ -18,6 +18,9 @@ add_library(imgui STATIC
 	# imgui_bitfield
 	imgui_bitfield.h
 	imgui_bitfield.cpp
+	# imgui_user
+	imgui_user.h
+	imgui_user.cpp
 	)
 target_include_directories(imgui PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 

--- a/external/imgui/imgui_user.cpp
+++ b/external/imgui/imgui_user.cpp
@@ -17,6 +17,22 @@ static auto vector_getter = [](void* vec, int idx, const char** out_text) {
 	return true;
 };
 
+struct string_view_array_getter_user_data_t
+{
+	const std::string_view* data;
+	int count;
+};
+
+static auto string_view_array_getter = [](void* userData, int idx, const char** out_text) {
+	auto arr = static_cast<string_view_array_getter_user_data_t*>(userData);
+	if (idx < 0 || idx >= arr->count)
+	{
+		return false;
+	}
+	*out_text = arr->data[idx].data();
+	return true;
+};
+
 bool Combo(const char* label, int* currIndex, std::vector<std::string>& values)
 {
 	if (values.empty())
@@ -26,6 +42,19 @@ bool Combo(const char* label, int* currIndex, std::vector<std::string>& values)
 	return Combo(label, currIndex, vector_getter, static_cast<void*>(&values), values.size());
 }
 
+bool Combo(const char* label, int* currIndex, const std::string_view* values, int valueCount)
+{
+	if (valueCount <= 0)
+	{
+		return false;
+	}
+	string_view_array_getter_user_data_t userData = {
+	    values,
+	    valueCount,
+	};
+	return Combo(label, currIndex, string_view_array_getter, static_cast<void*>(&userData), valueCount);
+}
+
 bool ListBox(const char* label, int* currIndex, std::vector<std::string>& values)
 {
 	if (values.empty())
@@ -33,6 +62,19 @@ bool ListBox(const char* label, int* currIndex, std::vector<std::string>& values
 		return false;
 	}
 	return ListBox(label, currIndex, vector_getter, static_cast<void*>(&values), values.size());
+}
+
+bool ListBox(const char* label, int* currIndex, const std::string_view* values, int valueCount)
+{
+	if (valueCount <= 0)
+	{
+		return false;
+	}
+	string_view_array_getter_user_data_t userData = {
+	    values,
+	    valueCount,
+	};
+	return ListBox(label, currIndex, string_view_array_getter, static_cast<void*>(&userData), valueCount);
 }
 
 } // namespace ImGui

--- a/external/imgui/imgui_user.h
+++ b/external/imgui/imgui_user.h
@@ -1,3 +1,4 @@
+#include <array>
 #include <string>
 #include <vector>
 
@@ -5,6 +6,28 @@ namespace ImGui
 {
 
 bool Combo(const char* label, int* currIndex, std::vector<std::string>& values);
+bool Combo(const char* label, int* currIndex, const std::string_view* values, int valueCount);
+template <typename Index_t, std::size_t valueCount>
+inline bool Combo(const char* label, Index_t* currIndex, const std::array<std::string_view, valueCount>& values)
+{
+	int currIndexInt = static_cast<int>(*currIndex);
+	if (Combo(label, &currIndexInt, values.data(), static_cast<int>(valueCount)))
+	{
+		*currIndex = static_cast<Index_t>(currIndexInt);
+	}
+	return false;
+}
 bool ListBox(const char* label, int* currIndex, std::vector<std::string>& values);
+bool ListBox(const char* label, int* currIndex, const std::string_view* values, int valueCount);
+template <typename Index_t, std::size_t valueCount>
+inline bool ListBox(const char* label, Index_t* currIndex, const std::array<std::string_view, valueCount>& values)
+{
+	int currIndexInt = static_cast<int>(*currIndex);
+	if (ListBox(label, &currIndexInt, values.data(), static_cast<int>(valueCount)))
+	{
+		*currIndex = static_cast<Index_t>(currIndexInt);
+	}
+	return false;
+}
 
 } // namespace ImGui

--- a/src/Gui.cpp
+++ b/src/Gui.cpp
@@ -1004,11 +1004,11 @@ void Gui::ShowVillagerNames(const Game& game)
 				ImGui::InputInt("Health", reinterpret_cast<int*>(&entity.health));
 				ImGui::InputInt("Age", reinterpret_cast<int*>(&entity.age));
 				ImGui::InputInt("Hunger", reinterpret_cast<int*>(&entity.hunger));
-				ImGui::InputInt("Life Stage", reinterpret_cast<int*>(&entity.lifeStage));
-				ImGui::InputInt("Sex", reinterpret_cast<int*>(&entity.sex));
-				ImGui::InputInt("Tribe", reinterpret_cast<int*>(&entity.tribe));
-				ImGui::InputInt("Role", reinterpret_cast<int*>(&entity.role));
-				ImGui::InputInt("Task", reinterpret_cast<int*>(&entity.task));
+				ImGui::Combo("Life Stage", &entity.lifeStage, Villager::LifeStageStrs);
+				ImGui::Combo("Sex", &entity.sex, Villager::SexStrs);
+				ImGui::Combo("Tribe", &entity.tribe, TribeStrs);
+				ImGui::Combo("Role", &entity.role, Villager::RoleStrs);
+				ImGui::Combo("Task", &entity.task, Villager::TaskStrs);
 			};
 		}
 


### PR DESCRIPTION
Enums for villager debug attributes were all displayed as 32 bit ints when
most of them were fitting in a 8 bit enum.
Add imgui_user to compilation.
Add Combo and ListBox template to take any size index and arrays of string
views for string representation.
Use this template on life stage, sex, tribe, role and task

## Piror
![Screenshot from 2021-01-09 21-03-22](https://user-images.githubusercontent.com/1013356/104112546-387e5780-52be-11eb-99c5-b285915b0027.png)

## With fix
![Screenshot from 2021-01-09 21-02-15](https://user-images.githubusercontent.com/1013356/104112550-3f0ccf00-52be-11eb-9224-ea5e8aead416.png)
