### PR TITLE
GUI: Set villager position with window

### DIFF
--- a/src/ECS/Archetypes/VillagerArchetype.cpp
+++ b/src/ECS/Archetypes/VillagerArchetype.cpp
@@ -16,6 +16,7 @@
 #include "ECS/Components/Mobile.h"
 #include "ECS/Components/Transform.h"
 #include "ECS/Components/Villager.h"
+#include "ECS/Components/WallHug.h"
 #include "ECS/Registry.h"
 #include "ECS/Systems/TownSystem.h"
 #include "Game.h"
@@ -53,6 +54,7 @@ entt::entity VillagerArchetype::Create([[maybe_unused]] const glm::vec3& abodePo
 
 	registry.Assign<Villager>(entity, health, static_cast<uint32_t>(age), hunger, lifeStage, sex, info.tribeType,
 	                          info.villagerNumber, task, town, abode);
+	registry.Assign<WallHug>(entity, glm::vec2(), glm::vec2(), GetSpeedStateSpeed(info.speedGroup.speedDefault));
 	const auto resourceId = resources::MeshIdToResourceId(info.highDetail);
 	registry.Assign<Mesh>(entity, resourceId, static_cast<int8_t>(0), static_cast<int8_t>(0));
 

--- a/src/ECS/Components/WallHug.h
+++ b/src/ECS/Components/WallHug.h
@@ -1,0 +1,65 @@
+/*****************************************************************************
+ * Copyright (c) 2018-2022 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include "entt/fwd.hpp"
+#include "glm/vec2.hpp"
+#include "glm/vec3.hpp"
+
+namespace openblack::ecs::components
+{
+
+enum class MoveStateClockwise
+{
+	Undefined,
+	CounterClockwise,
+	Clockwise,
+};
+
+enum class MoveState
+{
+	Linear,
+	Orbit,
+	ExitCircle,
+	StepThrough,
+	FinalStep,
+	Arrived,
+};
+
+template <MoveState S>
+struct MoveStateTagComponent
+{
+	static constexpr MoveState value = S;
+	MoveStateClockwise clockwise;
+	glm::vec2 stepGoal;
+};
+
+typedef MoveStateTagComponent<MoveState::Linear> MoveStateLinearTag;
+typedef MoveStateTagComponent<MoveState::Orbit> MoveStateOrbitTag;
+typedef MoveStateTagComponent<MoveState::ExitCircle> MoveStateExitCircleTag;
+typedef MoveStateTagComponent<MoveState::StepThrough> MoveStateStepThroughTag;
+typedef MoveStateTagComponent<MoveState::FinalStep> MoveStateFinalStepTag;
+typedef MoveStateTagComponent<MoveState::Arrived> MoveStateArrivedTag;
+
+struct WallHugObjectReference
+{
+	uint8_t stepsAway;
+	entt::entity entity;
+};
+
+struct WallHug
+{
+	glm::vec2 goal;
+	glm::vec2 step;
+	float y_angle; // FIXME(bwrsandman): member is a little redundant with transform or atan on step could keep or not
+	float speed;
+};
+
+} // namespace openblack::ecs::components

--- a/src/ECS/Registry.h
+++ b/src/ECS/Registry.h
@@ -61,6 +61,13 @@ public:
 		SetDirty();
 		return _registry.remove<Component, Other...>(entity);
 	}
+	template <typename After, typename Before, typename... Args>
+	decltype(auto) SwapComponents(entt::entity entity, [[maybe_unused]] Before previousComponent,
+	                              [[maybe_unused]] Args&&... args)
+	{
+		Remove<Before>(entity);
+		return Assign<After>(entity, std::forward<Args>(args)...);
+	}
 	void SetDirty();
 	RegistryContext& Context();
 	[[nodiscard]] const RegistryContext& Context() const;

--- a/src/ECS/Systems/PathfindingSystem.cpp
+++ b/src/ECS/Systems/PathfindingSystem.cpp
@@ -1,0 +1,70 @@
+/*****************************************************************************
+ * Copyright (c) 2018-2022 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include "PathfindingSystem.h"
+
+#include <spdlog/spdlog.h>
+
+#include "ECS/Components/Transform.h"
+#include "ECS/Components/WallHug.h"
+#include "ECS/Registry.h"
+#include "Game.h"
+
+using namespace openblack;
+using namespace openblack::ecs::components;
+using namespace openblack::ecs::systems;
+
+PathfindingSystem& PathfindingSystem::instance()
+{
+	static auto instance = new PathfindingSystem();
+	return *instance;
+}
+
+PathfindingSystem::PathfindingSystem() = default;
+
+void PathfindingSystem::Update()
+{
+	auto& registry = Game::instance()->GetEntityRegistry();
+
+	// ARRIVED:
+	registry.Each<const MoveStateArrivedTag, const Transform, const WallHug>(
+	    [](const MoveStateArrivedTag&, const Transform&, const WallHug&) {
+		    SPDLOG_LOGGER_WARN(spdlog::get("pathfinding"), "ARRIVED state not implemented in move To pathfinding");
+	    });
+
+	// LINEAR, LINEAR_CW, LINEAR_CCW
+	registry.Each<const MoveStateLinearTag, const Transform, const WallHug>(
+	    [](const MoveStateLinearTag&, const Transform&, const WallHug&) {
+		    SPDLOG_LOGGER_WARN(spdlog::get("pathfinding"), "LINEAR* states not implemented in move To pathfinding");
+	    });
+
+	// ORBIT_CW, ORBIT_CCW
+	registry.Each<const MoveStateOrbitTag, const Transform, const WallHug>(
+	    [](const MoveStateOrbitTag&, const Transform&, const WallHug&) {
+		    SPDLOG_LOGGER_WARN(spdlog::get("pathfinding"), "ORBIT* states not implemented in move To pathfinding");
+	    });
+
+	// STEP_THROUGH
+	registry.Each<const MoveStateStepThroughTag, const Transform, const WallHug>(
+	    [](const MoveStateStepThroughTag&, const Transform&, const WallHug&) {
+		    SPDLOG_LOGGER_WARN(spdlog::get("pathfinding"), "STEP_THROUGH state not implemented in move To pathfinding");
+	    });
+
+	// FINAL_STEP
+	registry.Each<const MoveStateFinalStepTag, const Transform, const WallHug>(
+	    [](const MoveStateFinalStepTag&, const Transform&, const WallHug&) {
+		    SPDLOG_LOGGER_WARN(spdlog::get("pathfinding"), "FINAL_STEP state not implemented in move To pathfinding");
+	    });
+
+	// EXIT_CIRCLE_CW, EXIT_CIRCLE_CCW:
+	registry.Each<const MoveStateExitCircleTag, const Transform, const WallHug>(
+	    [](const MoveStateExitCircleTag&, const Transform&, const WallHug&) {
+		    SPDLOG_LOGGER_WARN(spdlog::get("pathfinding"), "EXIT_CIRCLE* states not implemented in move To pathfinding");
+	    });
+}

--- a/src/ECS/Systems/PathfindingSystem.cpp
+++ b/src/ECS/Systems/PathfindingSystem.cpp
@@ -35,36 +35,36 @@ void PathfindingSystem::Update()
 	// ARRIVED:
 	registry.Each<const MoveStateArrivedTag, const Transform, const WallHug>(
 	    [](const MoveStateArrivedTag&, const Transform&, const WallHug&) {
-		    SPDLOG_LOGGER_WARN(spdlog::get("pathfinding"), "ARRIVED state not implemented in move To pathfinding");
+		    SPDLOG_LOGGER_WARN(spdlog::get("pathfinding"), "ARRIVED state not implemented in move to pathfinding");
 	    });
 
 	// LINEAR, LINEAR_CW, LINEAR_CCW
 	registry.Each<const MoveStateLinearTag, const Transform, const WallHug>(
 	    [](const MoveStateLinearTag&, const Transform&, const WallHug&) {
-		    SPDLOG_LOGGER_WARN(spdlog::get("pathfinding"), "LINEAR* states not implemented in move To pathfinding");
+		    SPDLOG_LOGGER_WARN(spdlog::get("pathfinding"), "LINEAR* states not implemented in move to pathfinding");
 	    });
 
 	// ORBIT_CW, ORBIT_CCW
 	registry.Each<const MoveStateOrbitTag, const Transform, const WallHug>(
 	    [](const MoveStateOrbitTag&, const Transform&, const WallHug&) {
-		    SPDLOG_LOGGER_WARN(spdlog::get("pathfinding"), "ORBIT* states not implemented in move To pathfinding");
+		    SPDLOG_LOGGER_WARN(spdlog::get("pathfinding"), "ORBIT* states not implemented in move to pathfinding");
 	    });
 
 	// STEP_THROUGH
 	registry.Each<const MoveStateStepThroughTag, const Transform, const WallHug>(
 	    [](const MoveStateStepThroughTag&, const Transform&, const WallHug&) {
-		    SPDLOG_LOGGER_WARN(spdlog::get("pathfinding"), "STEP_THROUGH state not implemented in move To pathfinding");
+		    SPDLOG_LOGGER_WARN(spdlog::get("pathfinding"), "STEP_THROUGH state not implemented in move to pathfinding");
 	    });
 
 	// FINAL_STEP
 	registry.Each<const MoveStateFinalStepTag, const Transform, const WallHug>(
 	    [](const MoveStateFinalStepTag&, const Transform&, const WallHug&) {
-		    SPDLOG_LOGGER_WARN(spdlog::get("pathfinding"), "FINAL_STEP state not implemented in move To pathfinding");
+		    SPDLOG_LOGGER_WARN(spdlog::get("pathfinding"), "FINAL_STEP state not implemented in move to pathfinding");
 	    });
 
 	// EXIT_CIRCLE_CW, EXIT_CIRCLE_CCW:
 	registry.Each<const MoveStateExitCircleTag, const Transform, const WallHug>(
 	    [](const MoveStateExitCircleTag&, const Transform&, const WallHug&) {
-		    SPDLOG_LOGGER_WARN(spdlog::get("pathfinding"), "EXIT_CIRCLE* states not implemented in move To pathfinding");
+		    SPDLOG_LOGGER_WARN(spdlog::get("pathfinding"), "EXIT_CIRCLE* states not implemented in move to pathfinding");
 	    });
 }

--- a/src/ECS/Systems/PathfindingSystem.h
+++ b/src/ECS/Systems/PathfindingSystem.h
@@ -1,0 +1,24 @@
+/*****************************************************************************
+ * Copyright (c) 2018-2022 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+namespace openblack::ecs::systems
+{
+class PathfindingSystem
+{
+public:
+	static PathfindingSystem& instance();
+
+	void Update();
+
+private:
+	PathfindingSystem();
+};
+} // namespace openblack::ecs::systems

--- a/src/Enums.h
+++ b/src/Enums.h
@@ -3025,6 +3025,14 @@ enum class SpeedState : uint32_t
 	MetresSec_100 = MakeSpeedState(100.0f),
 };
 
+constexpr float GetSpeedStateSpeed(SpeedState state)
+{
+	constexpr uint32_t ms100 = 0x10000;
+	constexpr float ms1 = static_cast<float>(ms100) * 0.01f;
+	float scaled = static_cast<uint32_t>(state) - 0.5f;
+	return scaled / ms1;
+}
+
 constexpr uint32_t MakeTurnAngleState(float degrees)
 {
 	constexpr uint32_t a360 = 0x800;

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -78,6 +78,7 @@ Game::Game(Arguments&& args)
     , _gameSpeedMultiplier(1.0f)
     , _frameCount(0)
     , _turnCount(0)
+    , _paused(true)
     , _handPose()
 {
 	std::function<std::shared_ptr<spdlog::logger>(const std::string&)> CreateLogger;
@@ -186,6 +187,9 @@ bool Game::ProcessEvents(const SDL_Event& event)
 		case SDLK_f:
 			_window->SetFullscreen(true);
 			break;
+		case SDLK_p:
+			_paused = !_paused;
+			break;
 		case SDLK_F1:
 			_config.bgfxDebug = !_config.bgfxDebug;
 			break;
@@ -238,7 +242,7 @@ bool Game::GameLogicLoop()
 
 	const auto currentTime = std::chrono::steady_clock::now();
 	const auto delta = currentTime - _lastGameLoopTime;
-	if (delta < kTurnDuration * _gameSpeedMultiplier)
+	if (_paused || delta < kTurnDuration * _gameSpeedMultiplier)
 	{
 		return false;
 	}
@@ -588,6 +592,7 @@ void Game::LoadMap(const std::filesystem::path& path)
 	_turnDeltaTime = 0ns;
 	SetGameSpeed(Game::kTurnDurationMultiplierNormal);
 	_turnCount = 0;
+	_paused = true;
 }
 
 void Game::LoadLandscape(const std::filesystem::path& path)

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -26,6 +26,7 @@
 #include "ECS/Registry.h"
 #include "ECS/Systems/CameraBookmarkSystem.h"
 #include "ECS/Systems/DynamicsSystem.h"
+#include "ECS/Systems/PathfindingSystem.h"
 #include "ECS/Systems/RenderingSystem.h"
 #include "GameWindow.h"
 #include "Graphics/FrameBuffer.h"
@@ -239,6 +240,7 @@ bool Game::ProcessEvents(const SDL_Event& event)
 bool Game::GameLogicLoop()
 {
 	using namespace ecs::components;
+	using namespace ecs::systems;
 
 	const auto currentTime = std::chrono::steady_clock::now();
 	const auto delta = currentTime - _lastGameLoopTime;
@@ -249,6 +251,11 @@ bool Game::GameLogicLoop()
 
 	// Build Map Grid Acceleration Structure
 	_entityMap->Rebuild();
+
+	{
+		auto pathfinding = _profiler->BeginScoped(Profiler::Stage::PathfindingUpdate);
+		PathfindingSystem::instance().Update();
+	}
 
 	_lastGameLoopTime = currentTime;
 	_turnDeltaTime = delta;
@@ -271,7 +278,7 @@ bool Game::Update()
 
 	// Physics
 	{
-		auto sdlInput = _profiler->BeginScoped(Profiler::Stage::PhysicsUpdate);
+		auto physics = _profiler->BeginScoped(Profiler::Stage::PhysicsUpdate);
 		if (_frameCount > 0)
 		{
 			_dynamicsSystem->Update(deltaTime);

--- a/src/Game.h
+++ b/src/Game.h
@@ -185,6 +185,7 @@ public:
 	Config& GetConfig() { return _config; }
 	[[nodiscard]] const Config& GetConfig() const { return _config; }
 	[[nodiscard]] uint16_t GetTurn() const { return _turnCount; }
+	[[nodiscard]] bool IsPaused() const { return _paused; }
 	[[nodiscard]] std::chrono::duration<float, std::milli> GetDeltaTime() const { return _turnDeltaTime; }
 	[[nodiscard]] const glm::ivec2& GetMousePosition() const { return _mousePosition; }
 
@@ -228,6 +229,7 @@ private:
 	float _gameSpeedMultiplier;
 	uint32_t _frameCount;
 	uint16_t _turnCount;
+	bool _paused;
 
 	glm::ivec2 _mousePosition;
 	glm::mat4 _handPose;

--- a/src/Game.h
+++ b/src/Game.h
@@ -79,6 +79,7 @@ enum class LoggingSubsystem : uint8_t
 	game,
 	graphics,
 	scripting,
+	pathfinding,
 
 	_count
 };
@@ -87,6 +88,7 @@ static std::array<std::string_view, static_cast<size_t>(LoggingSubsystem::_count
     "game",
     "graphics",
     "scripting",
+    "pathfinding",
 };
 
 struct Arguments

--- a/src/Gui/Gui.cpp
+++ b/src/Gui/Gui.cpp
@@ -1086,7 +1086,8 @@ void Gui::ShowCameraPositionOverlay(const Game& game)
 		const auto& handPosition = game.GetEntityRegistry().Get<ecs::components::Transform>(game.GetHand()).position;
 		ImGui::Text("Hand Position: (%.1f,%.1f,%.1f)", handPosition.x, handPosition.y, handPosition.z);
 
-		ImGui::Text("Game Turn: %u (%.3f ms)", game.GetTurn(), game.GetDeltaTime().count());
+		ImGui::Text("Game Turn: %u (%.3f ms)%s", game.GetTurn(), game.GetDeltaTime().count(),
+		            game.IsPaused() ? " - paused" : "");
 	}
 	ImGui::End();
 }

--- a/src/Gui/Gui.cpp
+++ b/src/Gui/Gui.cpp
@@ -46,6 +46,7 @@
 #include "LHVMViewer.h"
 #include "LandIsland.h"
 #include "MeshViewer.h"
+#include "PathFinding.h"
 #include "Profiler.h"
 
 // Turn off formatting because it adds spaces which break the stringifying
@@ -101,6 +102,7 @@ std::unique_ptr<Gui> Gui::create(const GameWindow* window, graphics::RenderPass 
 	debugWindows.emplace_back(new Console);
 	debugWindows.emplace_back(new LandIsland);
 	debugWindows.emplace_back(new LHVMViewer);
+	debugWindows.emplace_back(new PathFinding);
 
 	auto gui = std::unique_ptr<Gui>(new Gui(imgui, static_cast<bgfx::ViewId>(viewId), std::move(debugWindows)));
 

--- a/src/Gui/PathFinding.cpp
+++ b/src/Gui/PathFinding.cpp
@@ -1,0 +1,176 @@
+/*****************************************************************************
+ * Copyright (c) 2018-2022 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include "PathFinding.h"
+
+#include <SDL.h>
+#include <glm/gtc/type_ptr.hpp>
+#include <glm/gtx/vec_swizzle.hpp>
+#include <imgui_internal.h>
+
+#include "3D/L3DMesh.h"
+#include "3D/LandIsland.h"
+#include "ECS/Components/Mesh.h"
+#include "ECS/Components/Transform.h"
+#include "ECS/Components/Villager.h"
+#include "ECS/Map.h"
+#include "ECS/Registry.h"
+#include "Game.h"
+#include "Locator.h"
+
+using namespace openblack::gui;
+
+PathFinding::PathFinding()
+    : DebugWindow("Path Finding", ImVec2(400, 400))
+    , _handTo(HandTo::None)
+    , _handPosition(glm::zero<glm::vec3>())
+    , _destination(glm::zero<glm::vec3>())
+    , _selectedVillager()
+{
+}
+
+void PathFinding::Draw(Game& game)
+{
+	ImGui::TextWrapped(
+	    "Select Villager by left clicking on it, then select a pathfinding action and right click the destination");
+
+	const uint8_t numChildren = 2;
+	const float rounding = 5.0f;
+	const auto size = ImGui::GetWindowSize();
+	const auto pos = ImGui::GetCursorPos();
+	const float halfHeight = (size.y - pos.y) / numChildren - 2 * rounding;
+
+	ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, rounding);
+	ImGui::BeginChild("Selected Villager", ImVec2(0, halfHeight), true);
+	if (_selectedVillager.has_value())
+	{
+		using namespace ecs::components;
+		auto& registry = game.GetEntityRegistry();
+
+		ImGui::Columns(2);
+
+		ImGui::Text("Villager %u", static_cast<uint32_t>(*_selectedVillager));
+		ImGui::NextColumn();
+
+		if (ImGui::Button("Clear Selection"))
+		{
+			_selectedVillager.reset();
+		}
+		ImGui::NextColumn();
+
+		ImGui::Columns(1);
+
+		auto& transform = registry.Get<Transform>(_selectedVillager.value());
+		ImGui::DragFloat3("Position", glm::value_ptr(transform.position));
+	}
+	else
+	{
+		ImGui::Text("No villager selected");
+	}
+	ImGui::EndChild();
+
+	ImGui::BeginChild("Actions", ImVec2(0, halfHeight), true);
+	if (_selectedVillager.has_value())
+	{
+		if (ImGui::BeginTabBar("Actions"))
+		{
+			using namespace ecs::components;
+			auto& registry = game.GetEntityRegistry();
+			if (ImGui::BeginTabItem("Teleport"))
+			{
+				ImGui::DragFloat3("Destination", glm::value_ptr(_destination));
+
+				ImGui::PushStyleVar(ImGuiStyleVar_Alpha,
+				                    ImGui::GetStyle().Alpha * (_selectedVillager.has_value() ? 1.0f : 0.5f));
+				ImGui::PushItemFlag(ImGuiItemFlags_Disabled, !_selectedVillager.has_value());
+				if (ImGui::Button("Execute"))
+				{
+					registry.Get<Transform>(*_selectedVillager).position = _destination;
+				}
+				ImGui::PopItemFlag();
+				ImGui::PopStyleVar();
+
+				ImGui::EndTabItem();
+			}
+			ImGui::EndTabBar();
+		}
+	}
+	else
+	{
+		ImGui::Text("No action available");
+	}
+	ImGui::EndChild();
+
+	ImGui::PopStyleVar();
+}
+
+void PathFinding::Update(Game& game, [[maybe_unused]] const openblack::Renderer& renderer)
+{
+	using namespace ecs::components;
+	auto& registry = game.GetEntityRegistry();
+	const auto& handTransform = registry.Get<Transform>(game.GetHand());
+	auto const& meshes = Locator::resources::ref().GetMeshes();
+	if (glm::any(glm::isnan(handTransform.position) || glm::isinf(handTransform.position)))
+	{
+		return;
+	}
+	_handPosition = handTransform.position;
+	_handPosition.y = game.GetLandIsland().GetHeightAt(glm::xz(_handPosition));
+
+	if (_handTo == HandTo::Villager)
+	{
+		auto& map = game.GetEntityMap();
+		for (const auto& entity : map.GetMobileInGridCell(_handPosition))
+		{
+			if (registry.AllOf<Villager>(entity))
+			{
+				const auto& mesh = meshes.Handle(registry.Get<Mesh>(entity).id);
+				const auto& transform = registry.Get<Transform>(entity);
+				auto vectorTo = transform.position - _handPosition;
+				const auto& bb = mesh->GetBoundingBox();
+				auto point = glm::transpose(transform.rotation) * vectorTo;
+				point.y = bb.Center().y; // Fix to ignore altitude
+				if (bb.Contains(point))
+				{
+					_selectedVillager = entity;
+				}
+			}
+		}
+	}
+	else if (_handTo == HandTo::Destination)
+	{
+		_destination = handTransform.position;
+	}
+	_handTo = HandTo::None;
+}
+
+void PathFinding::ProcessEventOpen(const SDL_Event& event)
+{
+	ImGuiIO& io = ImGui::GetIO();
+	switch (event.type)
+	{
+	case SDL_MOUSEBUTTONDOWN:
+	{
+		if (!io.WantCaptureMouse)
+		{
+			if (event.button.button == SDL_BUTTON_LEFT)
+			{
+				_handTo = HandTo::Villager;
+			}
+			else if (event.button.button == SDL_BUTTON_RIGHT)
+			{
+				_handTo = HandTo::Destination;
+			}
+		}
+	}
+	break;
+	}
+}
+
+void PathFinding::ProcessEventAlways([[maybe_unused]] const SDL_Event& event) {}

--- a/src/Gui/PathFinding.h
+++ b/src/Gui/PathFinding.h
@@ -34,7 +34,7 @@ private:
 	enum class HandTo
 	{
 		None,
-		Villager,
+		Entity,
 		Destination,
 	};
 
@@ -42,6 +42,7 @@ private:
 	glm::vec3 _handPosition;
 	glm::vec3 _destination;
 	std::optional<entt::entity> _selectedVillager;
+	std::optional<entt::entity> _selectedFootpath;
 };
 
 } // namespace openblack::gui

--- a/src/Gui/PathFinding.h
+++ b/src/Gui/PathFinding.h
@@ -1,0 +1,47 @@
+/*****************************************************************************
+ * Copyright (c) 2018-2022 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include "DebugWindow.h"
+
+#include <optional>
+
+#include <entt/fwd.hpp>
+#include <glm/vec3.hpp>
+
+namespace openblack::gui
+{
+
+class PathFinding: public DebugWindow
+{
+public:
+	PathFinding();
+
+protected:
+	void Draw(Game& game) override;
+	void Update(Game& game, const Renderer& renderer) override;
+	void ProcessEventOpen(const SDL_Event& event) override;
+	void ProcessEventAlways(const SDL_Event& event) override;
+
+private:
+	enum class HandTo
+	{
+		None,
+		Villager,
+		Destination,
+	};
+
+	HandTo _handTo;
+	glm::vec3 _handPosition;
+	glm::vec3 _destination;
+	std::optional<entt::entity> _selectedVillager;
+};
+
+} // namespace openblack::gui

--- a/src/Profiler.h
+++ b/src/Profiler.h
@@ -24,6 +24,7 @@ public:
 	enum class Stage : uint8_t
 	{
 		PhysicsUpdate,
+		PathfindingUpdate,
 		SdlInput,
 		UpdateUniforms,
 		UpdateEntities,
@@ -51,29 +52,30 @@ public:
 	};
 
 	static constexpr std::array<std::string_view, static_cast<uint8_t>(Stage::_count)> stageNames = {
-	    "Physics Update",    //
-	    "SDL Input",         //
-	    "Update Uniforms",   //
-	    "Entities",          //
-	    "GUI Loop",          //
-	    "Game Logic",        //
-	    "Encode Draw Scene", //
-	    "Reflection Pass",   //
-	    "Draw Sky",          //
-	    "Draw Water",        //
-	    "Draw Island",       //
-	    "Draw Models",       //
-	    "Draw Sprites",      //
-	    "Draw Debug Cross",  //
-	    "Main Pass",         //
-	    "Draw Sky",          //
-	    "Draw Water",        //
-	    "Draw Island",       //
-	    "Draw Models",       //
-	    "Draw Sprites",      //
-	    "Draw Debug Cross",  //
-	    "Encode GUI Draw",   //
-	    "Renderer Frame",    //
+	    "Physics Update",     //
+	    "Pathfinding Update", //
+	    "SDL Input",          //
+	    "Update Uniforms",    //
+	    "Entities",           //
+	    "GUI Loop",           //
+	    "Game Logic",         //
+	    "Encode Draw Scene",  //
+	    "Reflection Pass",    //
+	    "Draw Sky",           //
+	    "Draw Water",         //
+	    "Draw Island",        //
+	    "Draw Models",        //
+	    "Draw Sprites",       //
+	    "Draw Debug Cross",   //
+	    "Main Pass",          //
+	    "Draw Sky",           //
+	    "Draw Water",         //
+	    "Draw Island",        //
+	    "Draw Models",        //
+	    "Draw Sprites",       //
+	    "Draw Debug Cross",   //
+	    "Encode GUI Draw",    //
+	    "Renderer Frame",     //
 	};
 
 private:


### PR DESCRIPTION
This PR adds a debug window which lets you select a villager (make sure the green bar intersects them) and a destination and either teleport them, move them using pathfinding or using footpaths.

The actual implementations are not done and will result in warnings in the log. The actual implementation of move to pathfinding is in #338 and walking on footpath is to be done after states (#285) the for it are implemented.

![Screenshot from 2022-03-12 15-07-58](https://user-images.githubusercontent.com/1013356/158033330-a7c40fbe-7711-4ed5-977c-4c5e32326d2f.png)

https://user-images.githubusercontent.com/1013356/158035188-cab3714e-53b0-4609-b00f-8f001b6d0b57.mp4

Also adds pause functionality with game paused by default and visible in the bottom right ui.

- [x] Add Debug window
- [x] Select Villager from map
- [x] Add Mobile Wall Hug component
    - WallHug component is in #338
- [x] Add goal to mobile wall hug
    - WallHug component is in #338
- [x] Link to MWH goal in GUI

Depends on:
- [x] #265 Map lookup
- [x] #284 Gui Debug Window structure