### PR TITLE
Add categories to logs

### DIFF
--- a/src/3D/AnimationPack.cpp
+++ b/src/3D/AnimationPack.cpp
@@ -24,7 +24,7 @@ AnimationPack::~AnimationPack() = default;
 
 bool AnimationPack::LoadFromFile(const fs::path& path)
 {
-	spdlog::debug("Loading Mesh Pack from file: {}", path.generic_string());
+	spdlog::get("game")->debug("Loading Mesh Pack from file: {}", path.generic_string());
 	pack::PackFile pack;
 
 	try
@@ -33,7 +33,7 @@ bool AnimationPack::LoadFromFile(const fs::path& path)
 	}
 	catch (std::runtime_error& err)
 	{
-		spdlog::error("Failed to open {}: {}", path.generic_string(), err.what());
+		spdlog::get("game")->error("Failed to open {}: {}", path.generic_string(), err.what());
 		return false;
 	}
 
@@ -43,11 +43,11 @@ bool AnimationPack::LoadFromFile(const fs::path& path)
 	{
 		_animations[i] = std::make_unique<L3DAnim>();
 		_animations[i]->LoadFromBuffer(animation[i]);
-		spdlog::debug("{} animation with {} frames with duration {}", _animations[i]->GetName(),
-		              _animations[i]->GetFrames().size(), _animations[i]->GetDuration());
+		spdlog::get("game")->debug("{} animation with {} frames with duration {}", _animations[i]->GetName(),
+		                           _animations[i]->GetFrames().size(), _animations[i]->GetDuration());
 	}
 
-	spdlog::debug("AnimationPack loaded {0} animations", _animations.size());
+	spdlog::get("game")->debug("AnimationPack loaded {0} animations", _animations.size());
 
 	return true;
 }

--- a/src/3D/AnimationPack.cpp
+++ b/src/3D/AnimationPack.cpp
@@ -24,7 +24,7 @@ AnimationPack::~AnimationPack() = default;
 
 bool AnimationPack::LoadFromFile(const fs::path& path)
 {
-	spdlog::get("game")->debug("Loading Mesh Pack from file: {}", path.generic_string());
+	SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "Loading Mesh Pack from file: {}", path.generic_string());
 	pack::PackFile pack;
 
 	try
@@ -33,7 +33,7 @@ bool AnimationPack::LoadFromFile(const fs::path& path)
 	}
 	catch (std::runtime_error& err)
 	{
-		spdlog::get("game")->error("Failed to open {}: {}", path.generic_string(), err.what());
+		SPDLOG_LOGGER_ERROR(spdlog::get("game"), "Failed to open {}: {}", path.generic_string(), err.what());
 		return false;
 	}
 
@@ -43,11 +43,11 @@ bool AnimationPack::LoadFromFile(const fs::path& path)
 	{
 		_animations[i] = std::make_unique<L3DAnim>();
 		_animations[i]->LoadFromBuffer(animation[i]);
-		spdlog::get("game")->debug("{} animation with {} frames with duration {}", _animations[i]->GetName(),
-		                           _animations[i]->GetFrames().size(), _animations[i]->GetDuration());
+		SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "{} animation with {} frames with duration {}", _animations[i]->GetName(),
+		                    _animations[i]->GetFrames().size(), _animations[i]->GetDuration());
 	}
 
-	spdlog::get("game")->debug("AnimationPack loaded {0} animations", _animations.size());
+	SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "AnimationPack loaded {0} animations", _animations.size());
 
 	return true;
 }

--- a/src/3D/L3DAnim.cpp
+++ b/src/3D/L3DAnim.cpp
@@ -55,7 +55,7 @@ void L3DAnim::Load(const anm::ANMFile& anm)
 
 bool L3DAnim::LoadFromFile(const fs::path& path)
 {
-	spdlog::debug("Loading L3DAnim from file: {}", path.generic_string());
+	spdlog::get("game")->debug("Loading L3DAnim from file: {}", path.generic_string());
 	anm::ANMFile anm;
 
 	try
@@ -64,7 +64,7 @@ bool L3DAnim::LoadFromFile(const fs::path& path)
 	}
 	catch (std::runtime_error& err)
 	{
-		spdlog::error("Failed to open l3d mesh from filesystem {}: {}", path.generic_string(), err.what());
+		spdlog::get("game")->error("Failed to open l3d mesh from filesystem {}: {}", path.generic_string(), err.what());
 		return false;
 	}
 
@@ -83,7 +83,7 @@ void L3DAnim::LoadFromBuffer(const std::vector<uint8_t>& data)
 	}
 	catch (std::runtime_error& err)
 	{
-		spdlog::error("Failed to open l3d animation from buffer: {}", err.what());
+		spdlog::get("game")->error("Failed to open l3d animation from buffer: {}", err.what());
 		return;
 	}
 

--- a/src/3D/L3DAnim.cpp
+++ b/src/3D/L3DAnim.cpp
@@ -55,7 +55,7 @@ void L3DAnim::Load(const anm::ANMFile& anm)
 
 bool L3DAnim::LoadFromFile(const fs::path& path)
 {
-	spdlog::get("game")->debug("Loading L3DAnim from file: {}", path.generic_string());
+	SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "Loading L3DAnim from file: {}", path.generic_string());
 	anm::ANMFile anm;
 
 	try
@@ -64,7 +64,8 @@ bool L3DAnim::LoadFromFile(const fs::path& path)
 	}
 	catch (std::runtime_error& err)
 	{
-		spdlog::get("game")->error("Failed to open l3d mesh from filesystem {}: {}", path.generic_string(), err.what());
+		SPDLOG_LOGGER_ERROR(spdlog::get("game"), "Failed to open l3d mesh from filesystem {}: {}", path.generic_string(),
+		                    err.what());
 		return false;
 	}
 
@@ -83,7 +84,7 @@ void L3DAnim::LoadFromBuffer(const std::vector<uint8_t>& data)
 	}
 	catch (std::runtime_error& err)
 	{
-		spdlog::get("game")->error("Failed to open l3d animation from buffer: {}", err.what());
+		SPDLOG_LOGGER_ERROR(spdlog::get("game"), "Failed to open l3d animation from buffer: {}", err.what());
 		return;
 	}
 

--- a/src/3D/L3DMesh.cpp
+++ b/src/3D/L3DMesh.cpp
@@ -79,7 +79,7 @@ void L3DMesh::Load(const l3d::L3DFile& l3d)
 
 bool L3DMesh::LoadFromFile(const fs::path& path)
 {
-	spdlog::get("game")->debug("Loading L3DMesh from file: {}", path.generic_string());
+	SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "Loading L3DMesh from file: {}", path.generic_string());
 	l3d::L3DFile l3d;
 
 	try
@@ -88,7 +88,8 @@ bool L3DMesh::LoadFromFile(const fs::path& path)
 	}
 	catch (std::runtime_error& err)
 	{
-		spdlog::get("game")->error("Failed to open l3d mesh from filesystem {}: {}", path.generic_string(), err.what());
+		SPDLOG_LOGGER_ERROR(spdlog::get("game"), "Failed to open l3d mesh from filesystem {}: {}", path.generic_string(),
+		                    err.what());
 		return false;
 	}
 
@@ -107,7 +108,7 @@ void L3DMesh::LoadFromBuffer(const std::vector<uint8_t>& data)
 	}
 	catch (std::runtime_error& err)
 	{
-		spdlog::get("game")->error("Failed to open l3d mesh from buffer: {}", err.what());
+		SPDLOG_LOGGER_ERROR(spdlog::get("game"), "Failed to open l3d mesh from buffer: {}", err.what());
 		return;
 	}
 

--- a/src/3D/L3DMesh.cpp
+++ b/src/3D/L3DMesh.cpp
@@ -79,7 +79,7 @@ void L3DMesh::Load(const l3d::L3DFile& l3d)
 
 bool L3DMesh::LoadFromFile(const fs::path& path)
 {
-	spdlog::debug("Loading L3DMesh from file: {}", path.generic_string());
+	spdlog::get("game")->debug("Loading L3DMesh from file: {}", path.generic_string());
 	l3d::L3DFile l3d;
 
 	try
@@ -88,7 +88,7 @@ bool L3DMesh::LoadFromFile(const fs::path& path)
 	}
 	catch (std::runtime_error& err)
 	{
-		spdlog::error("Failed to open l3d mesh from filesystem {}: {}", path.generic_string(), err.what());
+		spdlog::get("game")->error("Failed to open l3d mesh from filesystem {}: {}", path.generic_string(), err.what());
 		return false;
 	}
 
@@ -107,7 +107,7 @@ void L3DMesh::LoadFromBuffer(const std::vector<uint8_t>& data)
 	}
 	catch (std::runtime_error& err)
 	{
-		spdlog::error("Failed to open l3d mesh from buffer: {}", err.what());
+		spdlog::get("game")->error("Failed to open l3d mesh from buffer: {}", err.what());
 		return;
 	}
 

--- a/src/3D/L3DSubMesh.cpp
+++ b/src/3D/L3DSubMesh.cpp
@@ -130,8 +130,8 @@ void L3DSubMesh::Load(const l3d::L3DFile& l3d, uint32_t meshIndex)
 	auto indexBuffer = new IndexBuffer(_l3dMesh.GetDebugName(), indicesMem, IndexBuffer::Type::Uint16);
 	_mesh = std::make_unique<graphics::Mesh>(vertexBuffer, indexBuffer);
 
-	spdlog::get("game")->debug("{} submesh {} with {} verts and {} indices", _l3dMesh.GetDebugName(), meshIndex, nVertices,
-	                           nIndices);
+	SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "{} submesh {} with {} verts and {} indices", _l3dMesh.GetDebugName(), meshIndex,
+	                    nVertices, nIndices);
 }
 
 Mesh& L3DSubMesh::GetMesh() const

--- a/src/3D/L3DSubMesh.cpp
+++ b/src/3D/L3DSubMesh.cpp
@@ -130,7 +130,8 @@ void L3DSubMesh::Load(const l3d::L3DFile& l3d, uint32_t meshIndex)
 	auto indexBuffer = new IndexBuffer(_l3dMesh.GetDebugName(), indicesMem, IndexBuffer::Type::Uint16);
 	_mesh = std::make_unique<graphics::Mesh>(vertexBuffer, indexBuffer);
 
-	spdlog::debug("{} submesh {} with {} verts and {} indices", _l3dMesh.GetDebugName(), meshIndex, nVertices, nIndices);
+	spdlog::get("game")->debug("{} submesh {} with {} verts and {} indices", _l3dMesh.GetDebugName(), meshIndex, nVertices,
+	                           nIndices);
 }
 
 Mesh& L3DSubMesh::GetMesh() const

--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -43,7 +43,7 @@ LandIsland::~LandIsland() = default;
 
 void LandIsland::LoadFromFile(const std::string& filename)
 {
-	spdlog::debug("Loading Land from file: {}", filename);
+	spdlog::get("game")->debug("Loading Land from file: {}", filename);
 	lnd::LNDFile lnd;
 
 	try
@@ -52,25 +52,25 @@ void LandIsland::LoadFromFile(const std::string& filename)
 	}
 	catch (std::runtime_error& err)
 	{
-		spdlog::error("Failed to open lnd file from filesystem {}: {}", filename, err.what());
+		spdlog::get("game")->error("Failed to open lnd file from filesystem {}: {}", filename, err.what());
 		return;
 	}
 
 	std::memcpy(_blockIndexLookup.data(), lnd.GetHeader().lookUpTable, _blockIndexLookup.size() * sizeof(_blockIndexLookup[0]));
 
 	auto& lndBlocks = lnd.GetBlocks();
-	spdlog::debug("[LandIsland] loading {} blocks", lndBlocks.size());
+	spdlog::get("game")->debug("[LandIsland] loading {} blocks", lndBlocks.size());
 	_landBlocks.resize(lndBlocks.size());
 	for (size_t i = 0; i < _landBlocks.size(); i++)
 	{
 		_landBlocks[i]._block = std::make_unique<lnd::LNDBlock>(lndBlocks[i]);
 	}
 
-	spdlog::debug("[LandIsland] loading {} countries", lnd.GetCountries().size());
+	spdlog::get("game")->debug("[LandIsland] loading {} countries", lnd.GetCountries().size());
 	_countries = lnd.GetCountries();
 
 	auto materialCount = lnd.GetMaterials().size();
-	spdlog::debug("[LandIsland] loading {} textures", materialCount);
+	spdlog::get("game")->debug("[LandIsland] loading {} textures", materialCount);
 	std::vector<uint16_t> rgba5TextureData;
 	rgba5TextureData.resize(lnd::LNDMaterial::width * lnd::LNDMaterial::height * lnd.GetMaterials().size());
 	for (size_t i = 0; i < lnd.GetMaterials().size(); i++)

--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -43,7 +43,7 @@ LandIsland::~LandIsland() = default;
 
 void LandIsland::LoadFromFile(const std::string& filename)
 {
-	spdlog::get("game")->debug("Loading Land from file: {}", filename);
+	SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "Loading Land from file: {}", filename);
 	lnd::LNDFile lnd;
 
 	try
@@ -52,25 +52,25 @@ void LandIsland::LoadFromFile(const std::string& filename)
 	}
 	catch (std::runtime_error& err)
 	{
-		spdlog::get("game")->error("Failed to open lnd file from filesystem {}: {}", filename, err.what());
+		SPDLOG_LOGGER_ERROR(spdlog::get("game"), "Failed to open lnd file from filesystem {}: {}", filename, err.what());
 		return;
 	}
 
 	std::memcpy(_blockIndexLookup.data(), lnd.GetHeader().lookUpTable, _blockIndexLookup.size() * sizeof(_blockIndexLookup[0]));
 
 	auto& lndBlocks = lnd.GetBlocks();
-	spdlog::get("game")->debug("[LandIsland] loading {} blocks", lndBlocks.size());
+	SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "[LandIsland] loading {} blocks", lndBlocks.size());
 	_landBlocks.resize(lndBlocks.size());
 	for (size_t i = 0; i < _landBlocks.size(); i++)
 	{
 		_landBlocks[i]._block = std::make_unique<lnd::LNDBlock>(lndBlocks[i]);
 	}
 
-	spdlog::get("game")->debug("[LandIsland] loading {} countries", lnd.GetCountries().size());
+	SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "[LandIsland] loading {} countries", lnd.GetCountries().size());
 	_countries = lnd.GetCountries();
 
 	auto materialCount = lnd.GetMaterials().size();
-	spdlog::get("game")->debug("[LandIsland] loading {} textures", materialCount);
+	SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "[LandIsland] loading {} textures", materialCount);
 	std::vector<uint16_t> rgba5TextureData;
 	rgba5TextureData.resize(lnd::LNDMaterial::width * lnd::LNDMaterial::height * lnd.GetMaterials().size());
 	for (size_t i = 0; i < lnd.GetMaterials().size(); i++)

--- a/src/3D/MeshPack.cpp
+++ b/src/3D/MeshPack.cpp
@@ -28,7 +28,7 @@ namespace openblack
 
 bool MeshPack::LoadFromFile(const fs::path& path)
 {
-	spdlog::debug("Loading Mesh Pack from file: {}", path.generic_string());
+	spdlog::get("game")->debug("Loading Mesh Pack from file: {}", path.generic_string());
 	pack::PackFile pack;
 
 	try
@@ -37,7 +37,7 @@ bool MeshPack::LoadFromFile(const fs::path& path)
 	}
 	catch (std::runtime_error& err)
 	{
-		spdlog::error("Failed to open {}: {}", path.generic_string(), err.what());
+		spdlog::get("game")->error("Failed to open {}: {}", path.generic_string(), err.what());
 		return false;
 	}
 
@@ -88,7 +88,7 @@ void MeshPack::loadTextures(const std::map<std::string, pack::G3DTexture>& textu
 		                                        g3dTexture.ddsData.size());
 	}
 
-	spdlog::debug("MeshPack loaded {0} textures", textures.size());
+	spdlog::get("game")->debug("MeshPack loaded {0} textures", textures.size());
 }
 
 void MeshPack::loadMeshes(const std::vector<std::vector<uint8_t>>& meshes)
@@ -96,12 +96,12 @@ void MeshPack::loadMeshes(const std::vector<std::vector<uint8_t>>& meshes)
 	_meshes.resize(meshes.size());
 	for (uint32_t i = 0; i < _meshes.size(); i++)
 	{
-		// spdlog::debug("L3DMesh {} {}", i, MeshNames[i].data());
+		// spdlog::get("game")->debug("L3DMesh {} {}", i, MeshNames[i].data());
 		_meshes[i] = std::make_unique<L3DMesh>(MeshNames[i].data());
 		_meshes[i]->LoadFromBuffer(meshes[i]);
 	}
 
-	spdlog::debug("MeshPack loaded {0} meshes", meshes.size());
+	spdlog::get("game")->debug("MeshPack loaded {0} meshes", meshes.size());
 }
 
 } // namespace openblack

--- a/src/3D/MeshPack.cpp
+++ b/src/3D/MeshPack.cpp
@@ -28,7 +28,7 @@ namespace openblack
 
 bool MeshPack::LoadFromFile(const fs::path& path)
 {
-	spdlog::get("game")->debug("Loading Mesh Pack from file: {}", path.generic_string());
+	SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "Loading Mesh Pack from file: {}", path.generic_string());
 	pack::PackFile pack;
 
 	try
@@ -37,7 +37,7 @@ bool MeshPack::LoadFromFile(const fs::path& path)
 	}
 	catch (std::runtime_error& err)
 	{
-		spdlog::get("game")->error("Failed to open {}: {}", path.generic_string(), err.what());
+		SPDLOG_LOGGER_ERROR(spdlog::get("game"), "Failed to open {}: {}", path.generic_string(), err.what());
 		return false;
 	}
 
@@ -88,7 +88,7 @@ void MeshPack::loadTextures(const std::map<std::string, pack::G3DTexture>& textu
 		                                        g3dTexture.ddsData.size());
 	}
 
-	spdlog::get("game")->debug("MeshPack loaded {0} textures", textures.size());
+	SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "MeshPack loaded {0} textures", textures.size());
 }
 
 void MeshPack::loadMeshes(const std::vector<std::vector<uint8_t>>& meshes)
@@ -96,12 +96,12 @@ void MeshPack::loadMeshes(const std::vector<std::vector<uint8_t>>& meshes)
 	_meshes.resize(meshes.size());
 	for (uint32_t i = 0; i < _meshes.size(); i++)
 	{
-		// spdlog::get("game")->debug("L3DMesh {} {}", i, MeshNames[i].data());
+		// SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "L3DMesh {} {}", i, MeshNames[i].data());
 		_meshes[i] = std::make_unique<L3DMesh>(MeshNames[i].data());
 		_meshes[i]->LoadFromBuffer(meshes[i]);
 	}
 
-	spdlog::get("game")->debug("MeshPack loaded {0} meshes", meshes.size());
+	SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "MeshPack loaded {0} meshes", meshes.size());
 }
 
 } // namespace openblack

--- a/src/3D/Sky.cpp
+++ b/src/3D/Sky.cpp
@@ -50,7 +50,7 @@ Sky::Sky()
 				filename[0] = std::toupper(filename[0]);
 			}
 			auto path = filesystem.WeatherSystemPath() / filename;
-			spdlog::get("game")->debug("Loading sky texture: {}", path.generic_string());
+			SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "Loading sky texture: {}", path.generic_string());
 
 			Bitmap16B* bitmap = Bitmap16B::LoadFromFile(path);
 			memcpy(_bitmaps[i * 3 + j].data(), bitmap->Data(), bitmap->Size());

--- a/src/3D/Sky.cpp
+++ b/src/3D/Sky.cpp
@@ -50,7 +50,7 @@ Sky::Sky()
 				filename[0] = std::toupper(filename[0]);
 			}
 			auto path = filesystem.WeatherSystemPath() / filename;
-			spdlog::debug("Loading sky texture: {}", path.generic_string());
+			spdlog::get("game")->debug("Loading sky texture: {}", path.generic_string());
 
 			Bitmap16B* bitmap = Bitmap16B::LoadFromFile(path);
 			memcpy(_bitmaps[i * 3 + j].data(), bitmap->Data(), bitmap->Size());

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -123,7 +123,12 @@ else()
   endif()
 endif()
 
-target_compile_definitions(openblack PRIVATE "$<$<CONFIG:DEBUG>:OPENBLACK_DEBUG>")
+target_compile_definitions(openblack
+  PRIVATE
+  "$<$<CONFIG:DEBUG>:OPENBLACK_DEBUG>"
+  # Compile-time optimize out log messages (debug level if debug, else info)
+  "SPDLOG_ACTIVE_LEVEL=$<IF:$<CONFIG:DEBUG>,SPDLOG_LEVEL_DEBUG,SPDLOG_LEVEL_INFO>"
+)
 
 if(MSVC)
   set(CMAKE_CONFIGURATION_TYPES

--- a/src/Common/MeshLookup.h
+++ b/src/Common/MeshLookup.h
@@ -56,7 +56,7 @@ public:
 
 		if (item == lookup.end())
 		{
-			spdlog::get("game")->error("Unknown item. Using Dummy mesh.");
+			SPDLOG_LOGGER_ERROR(spdlog::get("game"), "Unknown item. Using Dummy mesh.");
 			return static_cast<MeshId>(meshId);
 		}
 

--- a/src/Common/MeshLookup.h
+++ b/src/Common/MeshLookup.h
@@ -56,7 +56,7 @@ public:
 
 		if (item == lookup.end())
 		{
-			spdlog::error("Unknown item. Using Dummy mesh.");
+			spdlog::get("game")->error("Unknown item. Using Dummy mesh.");
 			return static_cast<MeshId>(meshId);
 		}
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -38,6 +38,7 @@
 #include <glm/gtx/euler_angles.hpp>
 #include <glm/gtx/intersect.hpp>
 #include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
 
 #include <Serializer/FotFile.h>
@@ -67,12 +68,18 @@ Game::Game(Arguments&& args)
     , _turnCount(0)
     , _intersection()
 {
+	std::function<std::shared_ptr<spdlog::logger>(const std::string&)> CreateLogger;
 	if (!args.logFile.empty() && args.logFile != "stdout")
 	{
-		auto logger = spdlog::basic_logger_mt("default_logger", args.logFile);
-		spdlog::set_default_logger(logger);
+		CreateLogger = [&args](const std::string& name) { return spdlog::basic_logger_mt(name, args.logFile); };
 	}
-	spdlog::set_level(args.logLevel);
+	else
+	{
+		CreateLogger = [](const std::string& name) { return spdlog::stdout_color_mt(name); };
+	}
+	auto logger = CreateLogger("default_logger");
+	logger->set_level(args.logLevel);
+	spdlog::set_default_logger(logger);
 	sInstance = this;
 
 	std::string binaryPath = fs::path {args.executablePath}.parent_path().generic_string();

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -77,14 +77,17 @@ Game::Game(Arguments&& args)
 	{
 		CreateLogger = [](const std::string& name) { return spdlog::stdout_color_mt(name); };
 	}
-	auto logger = CreateLogger("default_logger");
-	logger->set_level(args.logLevel);
-	spdlog::set_default_logger(logger);
+	auto gameLogger = CreateLogger("game");
+	auto graphicsLogger = CreateLogger("graphics");
+	auto scriptingLogger = CreateLogger("scripting");
+	gameLogger->set_level(args.logLevel);
+	graphicsLogger->set_level(args.logLevel);
+	scriptingLogger->set_level(args.logLevel);
 	sInstance = this;
 
 	std::string binaryPath = fs::path {args.executablePath}.parent_path().generic_string();
 	_config.numFramesToSimulate = args.numFramesToSimulate;
-	spdlog::info("current binary path: {}", binaryPath);
+	spdlog::get("game")->info("current binary path: {}", binaryPath);
 	SetGamePath(args.gamePath);
 	if (args.rendererType != bgfx::RendererType::Noop)
 	{
@@ -95,7 +98,7 @@ Game::Game(Arguments&& args)
 	_fileSystem->SetGamePath(GetGamePath());
 	_handModel = std::make_unique<L3DMesh>();
 	_handModel->LoadFromFile(_fileSystem->CreatureMeshPath() / "Hand_Boned_Base2.l3d");
-	spdlog::debug("The GamePath is \"{}\".", _fileSystem->GetGamePath().generic_string());
+	spdlog::get("game")->debug("The GamePath is \"{}\".", _fileSystem->GetGamePath().generic_string());
 
 	_gui = Gui::create(_window.get(), graphics::RenderPass::ImGui, args.scale);
 
@@ -467,8 +470,8 @@ void Game::LoadMap(const fs::path& path)
 	}
 	else
 	{
-		spdlog::warn("The map at {} does not come with a footpath file. Expected {}", path.generic_string(),
-		             fot_path.generic_string());
+		spdlog::get("game")->warn("The map at {} does not come with a footpath file. Expected {}", path.generic_string(),
+		                          fot_path.generic_string());
 	}
 
 	_lastGameLoopTime = std::chrono::steady_clock::now();
@@ -502,7 +505,7 @@ bool Game::LoadVariables()
 
 	for (const auto& m : _infoConstants.magic)
 	{
-		spdlog::debug("MAGIC_TYPE {}, PerceivedPower={}", m.typeEnum, m.perceivedPower);
+		spdlog::get("game")->debug("MAGIC_TYPE {}, PerceivedPower={}", m.typeEnum, m.perceivedPower);
 	}
 
 	// GMagicInfo: 0x48 bytes // DETAIL_MAGIC_GENERAL_INFO
@@ -535,7 +538,7 @@ void Game::SetGamePath(const fs::path& gamePath)
 	}
 	if (!fs::exists(gamePath))
 	{
-		spdlog::error("GamePath does not exist: '{}'", gamePath.generic_string());
+		spdlog::get("game")->error("GamePath does not exist: '{}'", gamePath.generic_string());
 		return;
 	}
 	_gamePath = gamePath;
@@ -559,7 +562,7 @@ const fs::path& Game::GetGamePath()
 			return _gamePath;
 		}
 
-		spdlog::error("Failed to find the GameDir registry value, game not installed.");
+		spdlog::get("game")->error("Failed to find the GameDir registry value, game not installed.");
 #endif // _WIN32
 
 		// no key, don't guess, let the user know to set the command param
@@ -567,7 +570,7 @@ const fs::path& Game::GetGamePath()
 		                         "Game path was not supplied, use the -g "
 		                         "command parameter to set it.",
 		                         nullptr);
-		spdlog::error("Failed to find the GameDir.");
+		spdlog::get("game")->error("Failed to find the GameDir.");
 		exit(1);
 	}
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -77,12 +77,11 @@ Game::Game(Arguments&& args)
 	{
 		CreateLogger = [](const std::string& name) { return spdlog::stdout_color_mt(name); };
 	}
-	auto gameLogger = CreateLogger("game");
-	auto graphicsLogger = CreateLogger("graphics");
-	auto scriptingLogger = CreateLogger("scripting");
-	gameLogger->set_level(args.logLevel);
-	graphicsLogger->set_level(args.logLevel);
-	scriptingLogger->set_level(args.logLevel);
+	for (size_t i = 0; i < LoggingSubsystemStrs.size(); ++i)
+	{
+		auto logger = CreateLogger(LoggingSubsystemStrs[i].data());
+		logger->set_level(args.logLevels[i]);
+	}
 	sInstance = this;
 
 	std::string binaryPath = fs::path {args.executablePath}.parent_path().generic_string();

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -86,7 +86,7 @@ Game::Game(Arguments&& args)
 
 	std::string binaryPath = fs::path {args.executablePath}.parent_path().generic_string();
 	_config.numFramesToSimulate = args.numFramesToSimulate;
-	spdlog::get("game")->info("current binary path: {}", binaryPath);
+	SPDLOG_LOGGER_INFO(spdlog::get("game"), "current binary path: {}", binaryPath);
 	SetGamePath(args.gamePath);
 	if (args.rendererType != bgfx::RendererType::Noop)
 	{
@@ -97,7 +97,7 @@ Game::Game(Arguments&& args)
 	_fileSystem->SetGamePath(GetGamePath());
 	_handModel = std::make_unique<L3DMesh>();
 	_handModel->LoadFromFile(_fileSystem->CreatureMeshPath() / "Hand_Boned_Base2.l3d");
-	spdlog::get("game")->debug("The GamePath is \"{}\".", _fileSystem->GetGamePath().generic_string());
+	SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "The GamePath is \"{}\".", _fileSystem->GetGamePath().generic_string());
 
 	_gui = Gui::create(_window.get(), graphics::RenderPass::ImGui, args.scale);
 
@@ -469,8 +469,8 @@ void Game::LoadMap(const fs::path& path)
 	}
 	else
 	{
-		spdlog::get("game")->warn("The map at {} does not come with a footpath file. Expected {}", path.generic_string(),
-		                          fot_path.generic_string());
+		SPDLOG_LOGGER_WARN(spdlog::get("game"), "The map at {} does not come with a footpath file. Expected {}",
+		                   path.generic_string(), fot_path.generic_string());
 	}
 
 	_lastGameLoopTime = std::chrono::steady_clock::now();
@@ -504,7 +504,7 @@ bool Game::LoadVariables()
 
 	for (const auto& m : _infoConstants.magic)
 	{
-		spdlog::get("game")->debug("MAGIC_TYPE {}, PerceivedPower={}", m.typeEnum, m.perceivedPower);
+		SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "MAGIC_TYPE {}, PerceivedPower={}", m.typeEnum, m.perceivedPower);
 	}
 
 	// GMagicInfo: 0x48 bytes // DETAIL_MAGIC_GENERAL_INFO
@@ -537,7 +537,7 @@ void Game::SetGamePath(const fs::path& gamePath)
 	}
 	if (!fs::exists(gamePath))
 	{
-		spdlog::get("game")->error("GamePath does not exist: '{}'", gamePath.generic_string());
+		SPDLOG_LOGGER_ERROR(spdlog::get("game"), "GamePath does not exist: '{}'", gamePath.generic_string());
 		return;
 	}
 	_gamePath = gamePath;
@@ -561,7 +561,7 @@ const fs::path& Game::GetGamePath()
 			return _gamePath;
 		}
 
-		spdlog::get("game")->error("Failed to find the GameDir registry value, game not installed.");
+		SPDLOG_LOGGER_ERROR(spdlog::get("game"), "Failed to find the GameDir registry value, game not installed.");
 #endif // _WIN32
 
 		// no key, don't guess, let the user know to set the command param
@@ -569,7 +569,7 @@ const fs::path& Game::GetGamePath()
 		                         "Game path was not supplied, use the -g "
 		                         "command parameter to set it.",
 		                         nullptr);
-		spdlog::get("game")->error("Failed to find the GameDir.");
+		SPDLOG_LOGGER_ERROR(spdlog::get("game"), "Failed to find the GameDir.");
 		exit(1);
 	}
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -72,7 +72,7 @@ Game::Game(Arguments&& args)
 		auto logger = spdlog::basic_logger_mt("default_logger", args.logFile);
 		spdlog::set_default_logger(logger);
 	}
-	spdlog::set_level(static_cast<spdlog::level::level_enum>(spdlog::level::debug + args.logLevel));
+	spdlog::set_level(args.logLevel);
 	sInstance = this;
 
 	std::string binaryPath = fs::path {args.executablePath}.parent_path().generic_string();

--- a/src/Game.h
+++ b/src/Game.h
@@ -24,6 +24,7 @@ namespace fs = std::experimental::filesystem;
 #include <bgfx/bgfx.h>
 #include <entt/entity/fwd.hpp>
 #include <glm/glm.hpp>
+#include <spdlog/common.h>
 
 #include <LHVM/LHVM.h>
 
@@ -73,7 +74,7 @@ struct Arguments
 	float scale;
 	uint32_t numFramesToSimulate;
 	std::string logFile;
-	uint32_t logLevel;
+	spdlog::level::level_enum logLevel;
 };
 
 class Game

--- a/src/Game.h
+++ b/src/Game.h
@@ -16,6 +16,7 @@ namespace fs = std::filesystem;
 #include <experimental/filesystem>
 namespace fs = std::experimental::filesystem;
 #endif // HAS_FILESYSTEM
+#include <array>
 #include <memory>
 #include <string>
 #include <vector>
@@ -62,6 +63,21 @@ namespace entities
 class Registry;
 }
 
+enum class LoggingSubsystem : uint8_t
+{
+	game,
+	graphics,
+	scripting,
+
+	_count
+};
+
+static std::array<std::string_view, static_cast<size_t>(LoggingSubsystem::_count)> LoggingSubsystemStrs {
+    "game",
+    "graphics",
+    "scripting",
+};
+
 struct Arguments
 {
 	std::string executablePath;
@@ -74,7 +90,7 @@ struct Arguments
 	float scale;
 	uint32_t numFramesToSimulate;
 	std::string logFile;
-	spdlog::level::level_enum logLevel;
+	std::array<spdlog::level::level_enum, LoggingSubsystemStrs.size()> logLevels;
 };
 
 class Game

--- a/src/GameWindow.cpp
+++ b/src/GameWindow.cpp
@@ -32,10 +32,11 @@ GameWindow::GameWindow(const std::string& title, int width, int height, DisplayM
 	SDL_VERSION(&compiledVersion);
 	SDL_GetVersion(&linkedVersion);
 
-	spdlog::get("graphics")->info("Initializing SDL...");
-	spdlog::get("graphics")
-	    ->info("SDL Version/Compiled {}.{}.{}", compiledVersion.major, compiledVersion.minor, compiledVersion.patch);
-	spdlog::get("graphics")->info("SDL Version/Linked {}.{}.{}", linkedVersion.major, linkedVersion.minor, linkedVersion.patch);
+	SPDLOG_LOGGER_INFO(spdlog::get("graphics"), "Initializing SDL...");
+	SPDLOG_LOGGER_INFO(spdlog::get("graphics"), "SDL Version/Compiled {}.{}.{}", //
+	                   compiledVersion.major, compiledVersion.minor, compiledVersion.patch);
+	SPDLOG_LOGGER_INFO(spdlog::get("graphics"), "SDL Version/Linked {}.{}.{}", //
+	                   linkedVersion.major, linkedVersion.minor, linkedVersion.patch);
 
 	// Initialize SDL
 	if (SDL_WasInit(0) == 0)
@@ -67,7 +68,7 @@ GameWindow::GameWindow(const std::string& title, int width, int height, DisplayM
 
 	if (window == nullptr)
 	{
-		spdlog::get("graphics")->error("Failed to create SDL2 window: '{}'", SDL_GetError());
+		SPDLOG_LOGGER_ERROR(spdlog::get("graphics"), "Failed to create SDL2 window: '{}'", SDL_GetError());
 		throw std::runtime_error("Failed creating SDL2 window: " + std::string(SDL_GetError()));
 	}
 

--- a/src/GameWindow.cpp
+++ b/src/GameWindow.cpp
@@ -32,9 +32,10 @@ GameWindow::GameWindow(const std::string& title, int width, int height, DisplayM
 	SDL_VERSION(&compiledVersion);
 	SDL_GetVersion(&linkedVersion);
 
-	spdlog::info("Initializing SDL...");
-	spdlog::info("SDL Version/Compiled {}.{}.{}", compiledVersion.major, compiledVersion.minor, compiledVersion.patch);
-	spdlog::info("SDL Version/Linked {}.{}.{}", linkedVersion.major, linkedVersion.minor, linkedVersion.patch);
+	spdlog::get("graphics")->info("Initializing SDL...");
+	spdlog::get("graphics")
+	    ->info("SDL Version/Compiled {}.{}.{}", compiledVersion.major, compiledVersion.minor, compiledVersion.patch);
+	spdlog::get("graphics")->info("SDL Version/Linked {}.{}.{}", linkedVersion.major, linkedVersion.minor, linkedVersion.patch);
 
 	// Initialize SDL
 	if (SDL_WasInit(0) == 0)
@@ -66,7 +67,7 @@ GameWindow::GameWindow(const std::string& title, int width, int height, DisplayM
 
 	if (window == nullptr)
 	{
-		spdlog::error("Failed to create SDL2 window: '{}'", SDL_GetError());
+		spdlog::get("graphics")->error("Failed to create SDL2 window: '{}'", SDL_GetError());
 		throw std::runtime_error("Failed creating SDL2 window: " + std::string(SDL_GetError()));
 	}
 

--- a/src/Graphics/ShaderProgram.cpp
+++ b/src/Graphics/ShaderProgram.cpp
@@ -62,7 +62,7 @@ void ShaderProgram::SetTextureSampler(const char* samplerName, uint8_t bindPoint
 	}
 	else
 	{
-		spdlog::warn("Could not find texture sampler {}", samplerName);
+		spdlog::get("graphics")->warn("Could not find texture sampler {}", samplerName);
 	}
 }
 
@@ -75,7 +75,7 @@ void ShaderProgram::SetUniformValue(const char* uniformName, const void* value) 
 	}
 	else
 	{
-		spdlog::warn("Could not find uniform {}", uniformName);
+		spdlog::get("graphics")->warn("Could not find uniform {}", uniformName);
 	}
 }
 

--- a/src/Graphics/ShaderProgram.cpp
+++ b/src/Graphics/ShaderProgram.cpp
@@ -62,7 +62,7 @@ void ShaderProgram::SetTextureSampler(const char* samplerName, uint8_t bindPoint
 	}
 	else
 	{
-		spdlog::get("graphics")->warn("Could not find texture sampler {}", samplerName);
+		SPDLOG_LOGGER_WARN(spdlog::get("graphics"), "Could not find texture sampler {}", samplerName);
 	}
 }
 
@@ -75,7 +75,7 @@ void ShaderProgram::SetUniformValue(const char* uniformName, const void* value) 
 	}
 	else
 	{
-		spdlog::get("graphics")->warn("Could not find uniform {}", uniformName);
+		SPDLOG_LOGGER_WARN(spdlog::get("graphics"), "Could not find uniform {}", uniformName);
 	}
 }
 

--- a/src/Graphics/Texture2D.cpp
+++ b/src/Graphics/Texture2D.cpp
@@ -117,12 +117,12 @@ void Texture2D::DumpTexture() const
 	for (uint16_t i = 0; i < _info.numLayers; ++i)
 	{
 		auto filename = "dump/" + _name + "_" + std::to_string(i) + ".png";
-		spdlog::info("Writing texture layer {} to {}.", i, filename.c_str());
+		spdlog::get("graphics")->info("Writing texture layer {} to {}.", i, filename.c_str());
 		auto current_pixels = &pixels[i * stride * _info.height];
 		auto writeResult = stbi_write_png(filename.c_str(), _info.width, _info.height, numComponents, current_pixels, stride);
 		if (writeResult == 0)
 		{
-			spdlog::error("Writing texture to {} failed!", filename.c_str());
+			spdlog::get("graphics")->error("Writing texture to {} failed!", filename.c_str());
 			break;
 		}
 	}

--- a/src/Graphics/Texture2D.cpp
+++ b/src/Graphics/Texture2D.cpp
@@ -117,12 +117,12 @@ void Texture2D::DumpTexture() const
 	for (uint16_t i = 0; i < _info.numLayers; ++i)
 	{
 		auto filename = "dump/" + _name + "_" + std::to_string(i) + ".png";
-		spdlog::get("graphics")->info("Writing texture layer {} to {}.", i, filename.c_str());
+		SPDLOG_LOGGER_INFO(spdlog::get("graphics"), "Writing texture layer {} to {}.", i, filename.c_str());
 		auto current_pixels = &pixels[i * stride * _info.height];
 		auto writeResult = stbi_write_png(filename.c_str(), _info.width, _info.height, numComponents, current_pixels, stride);
 		if (writeResult == 0)
 		{
-			spdlog::get("graphics")->error("Writing texture to {} failed!", filename.c_str());
+			SPDLOG_LOGGER_ERROR(spdlog::get("graphics"), "Writing texture to {} failed!", filename.c_str());
 			break;
 		}
 	}

--- a/src/LHScriptX/FeatureScriptCommands.cpp
+++ b/src/LHScriptX/FeatureScriptCommands.cpp
@@ -287,7 +287,7 @@ Abode::Info GetAbodeInfo(const std::string& abodeType)
 
 	if (item == abodeIdLookup.end())
 	{
-		spdlog::get("scripting")->error("Missing abode mesh lookup for \"{}\".", abodeType);
+		SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "Missing abode mesh lookup for \"{}\".", abodeType);
 		return Abode::Info::TibetanWonder;
 	}
 
@@ -300,7 +300,7 @@ Feature::Info GetFeatureInfo(const std::string& featureType)
 
 	if (item == featureInfoLookup.end())
 	{
-		spdlog::get("scripting")->error("Missing abode mesh lookup for \"{}\".", featureType);
+		SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "Missing abode mesh lookup for \"{}\".", featureType);
 		return Feature::Info::Ark;
 	}
 
@@ -319,12 +319,14 @@ inline glm::vec3 GetSize(int size)
 
 void FeatureScriptCommands::CreateMist(glm::vec3 position, float param_2, int32_t param_3, float param_4, float param_5)
 {
-	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	                    __func__);
 }
 
 void FeatureScriptCommands::CreatePath(int32_t param_1, int32_t param_2, int32_t param_3, int32_t param_4)
 {
-	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	                    __func__);
 }
 
 void FeatureScriptCommands::CreateTown(int32_t townId, glm::vec3 position, const std::string& playerOwner,
@@ -352,17 +354,20 @@ void FeatureScriptCommands::SetTownBelief(int32_t townId, const std::string& pla
 
 void FeatureScriptCommands::SetTownBeliefCap(int32_t townId, const std::string& playerOwner, float belief)
 {
-	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	                    __func__);
 }
 
 void FeatureScriptCommands::SetTownUninhabitable(int32_t townId)
 {
-	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	                    __func__);
 }
 
 void FeatureScriptCommands::SetTownCongregationPos(int32_t townId, glm::vec3 position)
 {
-	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	                    __func__);
 }
 
 void FeatureScriptCommands::CreateAbode(int32_t townId, glm::vec3 position, const std::string& abodeInfo, int32_t rotation,
@@ -380,7 +385,8 @@ void FeatureScriptCommands::CreateAbode(int32_t townId, glm::vec3 position, cons
 void FeatureScriptCommands::CreatePlannedAbode(int32_t townId, glm::vec3 position, const std::string& abodeInfo,
                                                int32_t rotation, int32_t size, int32_t foodAmount, int32_t woodAmount)
 {
-	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	                    __func__);
 }
 
 void FeatureScriptCommands::CreateTownCentre(int32_t townId, glm::vec3 position, const std::string& abodeInfo, int32_t rotation,
@@ -398,44 +404,52 @@ void FeatureScriptCommands::CreateTownCentre(int32_t townId, glm::vec3 position,
 
 void FeatureScriptCommands::CreateTownSpell(int32_t townId, const std::string& spellName)
 {
-	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	                    __func__);
 }
 
 void FeatureScriptCommands::CreateNewTownSpell(int32_t townId, const std::string& spellName)
 {
-	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	                    __func__);
 }
 
 void FeatureScriptCommands::CreateTownCentreSpellIcon(int32_t param_1, const std::string& param_2)
 {
-	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	                    __func__);
 }
 
 void FeatureScriptCommands::CreateSpellIcon(glm::vec3 position, const std::string& param_2, int32_t param_3, int32_t param_4,
                                             int32_t param_5)
 {
-	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	                    __func__);
 }
 
 void FeatureScriptCommands::CreatePlannedSpellIcon(int32_t param_1, glm::vec3 position, const std::string& param_3,
                                                    int32_t param_4, int32_t param_5, int32_t param_6)
 {
-	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	                    __func__);
 }
 
 void FeatureScriptCommands::CreateVillager(glm::vec3, glm::vec3, const std::string&)
 {
-	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	                    __func__);
 }
 
 void FeatureScriptCommands::CreateTownVillager(int32_t townId, glm::vec3 position, const std::string& villagerType, int32_t age)
 {
-	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	                    __func__);
 }
 
 void FeatureScriptCommands::CreateSpecialTownVillager(int32_t, glm::vec3, int32_t, int32_t)
 {
-	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	                    __func__);
 }
 
 void FeatureScriptCommands::CreateVillagerPos(glm::vec3 position, [[maybe_unused]] glm::vec3 param_2,
@@ -459,49 +473,58 @@ void FeatureScriptCommands::CreateVillagerPos(glm::vec3 position, [[maybe_unused
 
 void FeatureScriptCommands::CreateCitadel(glm::vec3 position, int32_t, const std::string&, int32_t, int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreatePlannedCitadel(int32_t, glm::vec3 position, int32_t, const std::string&, int32_t, int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateCreaturePen(glm::vec3 position, int32_t, int32_t, int32_t, int32_t, int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateWorshipSite(glm::vec3 position, int32_t, const std::string&, const std::string&, int32_t,
                                               int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreatePlannedWorshipSite(glm::vec3 position, int32_t, const std::string&, const std::string&,
                                                      int32_t, int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateAnimal(glm::vec3 position, int32_t, int32_t, int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateNewAnimal(glm::vec3 position, int32_t, int32_t, int32_t, int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateForest(int32_t forestId, glm::vec3 position)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateTree(int32_t forestId, glm::vec3 position, int32_t, int32_t, int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateNewTree(int32_t forestId, glm::vec3 position, int32_t treeType, int32_t isNonScenic,
@@ -517,57 +540,68 @@ void FeatureScriptCommands::CreateNewTree(int32_t forestId, glm::vec3 position, 
 
 void FeatureScriptCommands::CreateField(glm::vec3 position, int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateTownField(int32_t townId, glm::vec3 position, int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateFishFarm(glm::vec3 position, int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateTownFishFarm(int32_t townId, glm::vec3 position, int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateFeature(glm::vec3 position, int32_t, int32_t, int32_t, int32_t)
 {
-	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	                    __func__);
 }
 
 void FeatureScriptCommands::CreateFlowers(glm::vec3 position, int32_t, float, float)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateWallSection(glm::vec3 position, int32_t, int32_t, int32_t, int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreatePlannedWallSection(glm::vec3 position, int32_t, int32_t, int32_t, int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreatePitch(glm::vec3 position, int32_t, int32_t, int32_t, int32_t, int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreatePot(glm::vec3 position, int32_t, int32_t, int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateTownTemporaryPots(int32_t, int32_t, int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateMobileObject(glm::vec3 position, int32_t type, int32_t rotation, int32_t scale)
@@ -582,7 +616,8 @@ void FeatureScriptCommands::CreateMobileObject(glm::vec3 position, int32_t type,
 
 void FeatureScriptCommands::CreateMobileStatic(glm::vec3 position, int32_t, float, float)
 {
-	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	                    __func__);
 }
 
 void FeatureScriptCommands::CreateMobileUStatic(glm::vec3 position, int32_t type, float verticalOffset, float pitch,
@@ -600,38 +635,45 @@ void FeatureScriptCommands::CreateMobileUStatic(glm::vec3 position, int32_t type
 
 void FeatureScriptCommands::CreateDeadTree(glm::vec3 position, const std::string&, int32_t, float, float, float, float)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateScaffold(int32_t, glm::vec3 position, int32_t, int32_t, int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CountryChange(glm::vec3 position, int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::HeightChange(glm::vec3 position, int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateCreature(glm::vec3 position, int32_t, int32_t)
 {
-	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	                    __func__);
 }
 
 void FeatureScriptCommands::CreateCreatureFromFile(const std::string& playerName, int32_t creatureType,
                                                    const std::string& creatureMind, glm::vec3 position)
 {
-	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	                    __func__);
 }
 
 void FeatureScriptCommands::CreateFlock(int32_t, glm::vec3, glm::vec3, int32_t, int32_t, int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::LoadLandscape(const std::string& path)
@@ -641,12 +683,13 @@ void FeatureScriptCommands::LoadLandscape(const std::string& path)
 
 void FeatureScriptCommands::Version(float version)
 {
-	spdlog::get("scripting")->debug("LHScriptX: Land version set to: {}", version);
+	SPDLOG_LOGGER_DEBUG(spdlog::get("scripting"), "LHScriptX: Land version set to: {}", version);
 }
 
 void FeatureScriptCommands::CreateArea(glm::vec3 position, float)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::StartCameraPos(glm::vec3 position)
@@ -658,22 +701,26 @@ void FeatureScriptCommands::StartCameraPos(glm::vec3 position)
 
 void FeatureScriptCommands::FlyByFile(const std::string& path)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::TownNeedsPos(int32_t townId, glm::vec3 position)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateFurniture(glm::vec3 position, int32_t, float)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateBigForest(glm::vec3 position, int32_t, float, float)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateNewBigForest(glm::vec3 position, int32_t type, int32_t param_3, float rotation, float scale)
@@ -688,38 +735,45 @@ void FeatureScriptCommands::CreateNewBigForest(glm::vec3 position, int32_t type,
 
 void FeatureScriptCommands::CreateInfluenceRing(glm::vec3 position, int32_t, float, int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateWeatherClimate(int32_t, int32_t, glm::vec3, float, float)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateWeatherClimateRain(int32_t, float, int32_t, int32_t, int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateWeatherClimateTemp(int32_t, float, float)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateWeatherClimateWind(int32_t, float, float, float)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateWeatherStorm(int32_t, glm::vec3, float, int32_t, glm::vec3, glm::vec3, glm::vec3, float,
                                                glm::vec3)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::BrushSize(float, float)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateStream(int32_t streamId)
@@ -743,12 +797,14 @@ void FeatureScriptCommands::CreateStreamPoint(int32_t streamId, glm::vec3 positi
 
 void FeatureScriptCommands::CreateWaterfall(glm::vec3 position)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateArena(glm::vec3 position, float)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateFootpath(int32_t footpathId)
@@ -772,7 +828,8 @@ void FeatureScriptCommands::LinkFootpath(int32_t footpathId)
 {
 	// TODO: The last MultiMapFixed created in this script is an implicit param
 	//       This Command adds the footpath to a list in a FootpathLink on the MultiMapFixed
-	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	                    __func__);
 }
 
 void FeatureScriptCommands::CreateBonfire(glm::vec3 position, float rotation, float param_3, float scale)
@@ -787,7 +844,8 @@ void FeatureScriptCommands::CreateBonfire(glm::vec3 position, float rotation, fl
 
 void FeatureScriptCommands::CreateBase(glm::vec3 position, int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateNewFeature(glm::vec3 position, const std::string& type, int32_t rotation, int32_t scale,
@@ -803,57 +861,68 @@ void FeatureScriptCommands::CreateNewFeature(glm::vec3 position, const std::stri
 
 void FeatureScriptCommands::SetInteractDesire(float)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::ToggleComputerPlayer(const std::string&, int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::SetComputerPlayerCreatureLike(const std::string&, const std::string&)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::MultiplayerDebug(int32_t, int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateStreetLantern(glm::vec3 position, int32_t)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateStreetLight(glm::vec3 position)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::SetLandNumber(int32_t number)
 {
-	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	                    __func__);
 }
 
 void FeatureScriptCommands::CreateOneShotSpell(glm::vec3 position, const std::string&)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateOneShotSpellPu(glm::vec3 position, const std::string&)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateFireFly(glm::vec3 position)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::TownDesireBoost(int32_t townId, const std::string&, float)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateAnimatedStatic(glm::vec3 position, const std::string& type, int32_t rotation, int32_t scale)
@@ -881,7 +950,8 @@ void FeatureScriptCommands::CreateAnimatedStatic(glm::vec3 position, const std::
 
 void FeatureScriptCommands::FireFlySpellRewardProb(const std::string& spell, float probability)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateNewTownField(int32_t townId, glm::vec3 position, int32_t param_3, float rotation)
@@ -897,75 +967,90 @@ void FeatureScriptCommands::CreateNewTownField(int32_t townId, glm::vec3 positio
 void FeatureScriptCommands::CreateSpellDispenser(int32_t, glm::vec3 position, const std::string&, const std::string&, float,
                                                  float, float)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::LoadComputerPlayerPersonality(int32_t, glm::vec3)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::SetComputerPlayerPersonality(const std::string&, glm::vec3, float)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::SetGlobalLandBalance(int32_t, float)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::SetLandBalance(const std::string&, int32_t, float)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::CreateDrinkWaypoint(glm::vec3 position)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::SetTownInfluenceMultiplier(float multiplier)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::SetPlayerInfluenceMultiplier(float multiplier)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::SetTownBalanceBeliefScale(int32_t townId, float scale)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::StartGameMessage(const std::string& message, int32_t landNumber)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::AddGameMessageLine(const std::string& message, int32_t landNumber)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::EditLevel()
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::SetNighttime(float, float, float)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::MakeLastObjectArtifact(int32_t, const std::string&, float)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }
 
 void FeatureScriptCommands::SetLostTownScale(float scale)
 {
-	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__,
+	// __func__);
 }

--- a/src/LHScriptX/FeatureScriptCommands.cpp
+++ b/src/LHScriptX/FeatureScriptCommands.cpp
@@ -287,7 +287,7 @@ Abode::Info GetAbodeInfo(const std::string& abodeType)
 
 	if (item == abodeIdLookup.end())
 	{
-		spdlog::error("Missing abode mesh lookup for \"{}\".", abodeType);
+		spdlog::get("scripting")->error("Missing abode mesh lookup for \"{}\".", abodeType);
 		return Abode::Info::TibetanWonder;
 	}
 
@@ -300,7 +300,7 @@ Feature::Info GetFeatureInfo(const std::string& featureType)
 
 	if (item == featureInfoLookup.end())
 	{
-		spdlog::error("Missing abode mesh lookup for \"{}\".", featureType);
+		spdlog::get("scripting")->error("Missing abode mesh lookup for \"{}\".", featureType);
 		return Feature::Info::Ark;
 	}
 
@@ -319,18 +319,19 @@ inline glm::vec3 GetSize(int size)
 
 void FeatureScriptCommands::CreateMist(glm::vec3 position, float param_2, int32_t param_3, float param_4, float param_5)
 {
-	spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreatePath(int32_t param_1, int32_t param_2, int32_t param_3, int32_t param_4)
 {
-	spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateTown(int32_t townId, glm::vec3 position, const std::string& playerOwner,
                                        [[maybe_unused]] int32_t, const std::string& civilisation)
 {
-	spdlog::debug(R"(LHScriptX: Creating town {} for "{}" with civilisation "{}".)", townId, playerOwner, civilisation);
+	spdlog::get("scripting")
+	    ->debug(R"(LHScriptX: Creating town {} for "{}" with civilisation "{}".)", townId, playerOwner, civilisation);
 
 	auto& registry = Game::instance()->GetEntityRegistry();
 	const auto entity = registry.Create();
@@ -351,17 +352,17 @@ void FeatureScriptCommands::SetTownBelief(int32_t townId, const std::string& pla
 
 void FeatureScriptCommands::SetTownBeliefCap(int32_t townId, const std::string& playerOwner, float belief)
 {
-	spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::SetTownUninhabitable(int32_t townId)
 {
-	spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::SetTownCongregationPos(int32_t townId, glm::vec3 position)
 {
-	spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateAbode(int32_t townId, glm::vec3 position, const std::string& abodeInfo, int32_t rotation,
@@ -379,7 +380,7 @@ void FeatureScriptCommands::CreateAbode(int32_t townId, glm::vec3 position, cons
 void FeatureScriptCommands::CreatePlannedAbode(int32_t townId, glm::vec3 position, const std::string& abodeInfo,
                                                int32_t rotation, int32_t size, int32_t foodAmount, int32_t woodAmount)
 {
-	spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateTownCentre(int32_t townId, glm::vec3 position, const std::string& abodeInfo, int32_t rotation,
@@ -397,44 +398,44 @@ void FeatureScriptCommands::CreateTownCentre(int32_t townId, glm::vec3 position,
 
 void FeatureScriptCommands::CreateTownSpell(int32_t townId, const std::string& spellName)
 {
-	spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateNewTownSpell(int32_t townId, const std::string& spellName)
 {
-	spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateTownCentreSpellIcon(int32_t param_1, const std::string& param_2)
 {
-	spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateSpellIcon(glm::vec3 position, const std::string& param_2, int32_t param_3, int32_t param_4,
                                             int32_t param_5)
 {
-	spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreatePlannedSpellIcon(int32_t param_1, glm::vec3 position, const std::string& param_3,
                                                    int32_t param_4, int32_t param_5, int32_t param_6)
 {
-	spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateVillager(glm::vec3, glm::vec3, const std::string&)
 {
-	spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateTownVillager(int32_t townId, glm::vec3 position, const std::string& villagerType, int32_t age)
 {
-	spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateSpecialTownVillager(int32_t, glm::vec3, int32_t, int32_t)
 {
-	spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateVillagerPos(glm::vec3 position, [[maybe_unused]] glm::vec3 param_2,
@@ -458,49 +459,49 @@ void FeatureScriptCommands::CreateVillagerPos(glm::vec3 position, [[maybe_unused
 
 void FeatureScriptCommands::CreateCitadel(glm::vec3 position, int32_t, const std::string&, int32_t, int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreatePlannedCitadel(int32_t, glm::vec3 position, int32_t, const std::string&, int32_t, int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateCreaturePen(glm::vec3 position, int32_t, int32_t, int32_t, int32_t, int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateWorshipSite(glm::vec3 position, int32_t, const std::string&, const std::string&, int32_t,
                                               int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreatePlannedWorshipSite(glm::vec3 position, int32_t, const std::string&, const std::string&,
                                                      int32_t, int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateAnimal(glm::vec3 position, int32_t, int32_t, int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateNewAnimal(glm::vec3 position, int32_t, int32_t, int32_t, int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateForest(int32_t forestId, glm::vec3 position)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateTree(int32_t forestId, glm::vec3 position, int32_t, int32_t, int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateNewTree(int32_t forestId, glm::vec3 position, int32_t treeType, int32_t isNonScenic,
@@ -516,57 +517,57 @@ void FeatureScriptCommands::CreateNewTree(int32_t forestId, glm::vec3 position, 
 
 void FeatureScriptCommands::CreateField(glm::vec3 position, int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateTownField(int32_t townId, glm::vec3 position, int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateFishFarm(glm::vec3 position, int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateTownFishFarm(int32_t townId, glm::vec3 position, int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateFeature(glm::vec3 position, int32_t, int32_t, int32_t, int32_t)
 {
-	spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateFlowers(glm::vec3 position, int32_t, float, float)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateWallSection(glm::vec3 position, int32_t, int32_t, int32_t, int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreatePlannedWallSection(glm::vec3 position, int32_t, int32_t, int32_t, int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreatePitch(glm::vec3 position, int32_t, int32_t, int32_t, int32_t, int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreatePot(glm::vec3 position, int32_t, int32_t, int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateTownTemporaryPots(int32_t, int32_t, int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateMobileObject(glm::vec3 position, int32_t type, int32_t rotation, int32_t scale)
@@ -581,7 +582,7 @@ void FeatureScriptCommands::CreateMobileObject(glm::vec3 position, int32_t type,
 
 void FeatureScriptCommands::CreateMobileStatic(glm::vec3 position, int32_t, float, float)
 {
-	spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateMobileUStatic(glm::vec3 position, int32_t type, float verticalOffset, float pitch,
@@ -599,38 +600,38 @@ void FeatureScriptCommands::CreateMobileUStatic(glm::vec3 position, int32_t type
 
 void FeatureScriptCommands::CreateDeadTree(glm::vec3 position, const std::string&, int32_t, float, float, float, float)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateScaffold(int32_t, glm::vec3 position, int32_t, int32_t, int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CountryChange(glm::vec3 position, int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::HeightChange(glm::vec3 position, int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateCreature(glm::vec3 position, int32_t, int32_t)
 {
-	spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateCreatureFromFile(const std::string& playerName, int32_t creatureType,
                                                    const std::string& creatureMind, glm::vec3 position)
 {
-	spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateFlock(int32_t, glm::vec3, glm::vec3, int32_t, int32_t, int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::LoadLandscape(const std::string& path)
@@ -640,12 +641,12 @@ void FeatureScriptCommands::LoadLandscape(const std::string& path)
 
 void FeatureScriptCommands::Version(float version)
 {
-	spdlog::debug("LHScriptX: Land version set to: {}", version);
+	spdlog::get("scripting")->debug("LHScriptX: Land version set to: {}", version);
 }
 
 void FeatureScriptCommands::CreateArea(glm::vec3 position, float)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::StartCameraPos(glm::vec3 position)
@@ -657,22 +658,22 @@ void FeatureScriptCommands::StartCameraPos(glm::vec3 position)
 
 void FeatureScriptCommands::FlyByFile(const std::string& path)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::TownNeedsPos(int32_t townId, glm::vec3 position)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateFurniture(glm::vec3 position, int32_t, float)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateBigForest(glm::vec3 position, int32_t, float, float)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateNewBigForest(glm::vec3 position, int32_t type, int32_t param_3, float rotation, float scale)
@@ -687,38 +688,38 @@ void FeatureScriptCommands::CreateNewBigForest(glm::vec3 position, int32_t type,
 
 void FeatureScriptCommands::CreateInfluenceRing(glm::vec3 position, int32_t, float, int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateWeatherClimate(int32_t, int32_t, glm::vec3, float, float)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateWeatherClimateRain(int32_t, float, int32_t, int32_t, int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateWeatherClimateTemp(int32_t, float, float)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateWeatherClimateWind(int32_t, float, float, float)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateWeatherStorm(int32_t, glm::vec3, float, int32_t, glm::vec3, glm::vec3, glm::vec3, float,
                                                glm::vec3)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::BrushSize(float, float)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateStream(int32_t streamId)
@@ -742,12 +743,12 @@ void FeatureScriptCommands::CreateStreamPoint(int32_t streamId, glm::vec3 positi
 
 void FeatureScriptCommands::CreateWaterfall(glm::vec3 position)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateArena(glm::vec3 position, float)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateFootpath(int32_t footpathId)
@@ -771,7 +772,7 @@ void FeatureScriptCommands::LinkFootpath(int32_t footpathId)
 {
 	// TODO: The last MultiMapFixed created in this script is an implicit param
 	//       This Command adds the footpath to a list in a FootpathLink on the MultiMapFixed
-	spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateBonfire(glm::vec3 position, float rotation, float param_3, float scale)
@@ -786,7 +787,7 @@ void FeatureScriptCommands::CreateBonfire(glm::vec3 position, float rotation, fl
 
 void FeatureScriptCommands::CreateBase(glm::vec3 position, int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateNewFeature(glm::vec3 position, const std::string& type, int32_t rotation, int32_t scale,
@@ -802,57 +803,57 @@ void FeatureScriptCommands::CreateNewFeature(glm::vec3 position, const std::stri
 
 void FeatureScriptCommands::SetInteractDesire(float)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::ToggleComputerPlayer(const std::string&, int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::SetComputerPlayerCreatureLike(const std::string&, const std::string&)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::MultiplayerDebug(int32_t, int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateStreetLantern(glm::vec3 position, int32_t)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateStreetLight(glm::vec3 position)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::SetLandNumber(int32_t number)
 {
-	spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateOneShotSpell(glm::vec3 position, const std::string&)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateOneShotSpellPu(glm::vec3 position, const std::string&)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateFireFly(glm::vec3 position)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::TownDesireBoost(int32_t townId, const std::string&, float)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateAnimatedStatic(glm::vec3 position, const std::string& type, int32_t rotation, int32_t scale)
@@ -880,7 +881,7 @@ void FeatureScriptCommands::CreateAnimatedStatic(glm::vec3 position, const std::
 
 void FeatureScriptCommands::FireFlySpellRewardProb(const std::string& spell, float probability)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateNewTownField(int32_t townId, glm::vec3 position, int32_t param_3, float rotation)
@@ -896,75 +897,75 @@ void FeatureScriptCommands::CreateNewTownField(int32_t townId, glm::vec3 positio
 void FeatureScriptCommands::CreateSpellDispenser(int32_t, glm::vec3 position, const std::string&, const std::string&, float,
                                                  float, float)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::LoadComputerPlayerPersonality(int32_t, glm::vec3)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::SetComputerPlayerPersonality(const std::string&, glm::vec3, float)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::SetGlobalLandBalance(int32_t, float)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::SetLandBalance(const std::string&, int32_t, float)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::CreateDrinkWaypoint(glm::vec3 position)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::SetTownInfluenceMultiplier(float multiplier)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::SetPlayerInfluenceMultiplier(float multiplier)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::SetTownBalanceBeliefScale(int32_t townId, float scale)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::StartGameMessage(const std::string& message, int32_t landNumber)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::AddGameMessageLine(const std::string& message, int32_t landNumber)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::EditLevel()
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::SetNighttime(float, float, float)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::MakeLastObjectArtifact(int32_t, const std::string&, float)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }
 
 void FeatureScriptCommands::SetLostTownScale(float scale)
 {
-	// spdlog::error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
+	// spdlog::get("scripting")->error("LHScriptX: {}:{}: Function {} not implemented.", __FILE__, __LINE__, __func__);
 }

--- a/src/Parsers/InfoFile.cpp
+++ b/src/Parsers/InfoFile.cpp
@@ -21,7 +21,7 @@ namespace openblack
 
 bool InfoFile::LoadFromFile(const fs::path& path, InfoConstants& infos)
 {
-	spdlog::get("game")->debug("Loading Info Pack from file: {}", path.generic_string());
+	SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "Loading Info Pack from file: {}", path.generic_string());
 
 	std::vector<uint8_t> data;
 	try
@@ -38,7 +38,7 @@ bool InfoFile::LoadFromFile(const fs::path& path, InfoConstants& infos)
 	}
 	catch (std::runtime_error& err)
 	{
-		spdlog::get("game")->error("Failed to open {}: {}", path.generic_string(), err.what());
+		SPDLOG_LOGGER_ERROR(spdlog::get("game"), "Failed to open {}: {}", path.generic_string(), err.what());
 		return false;
 	}
 

--- a/src/Parsers/InfoFile.cpp
+++ b/src/Parsers/InfoFile.cpp
@@ -21,7 +21,7 @@ namespace openblack
 
 bool InfoFile::LoadFromFile(const fs::path& path, InfoConstants& infos)
 {
-	spdlog::debug("Loading Info Pack from file: {}", path.generic_string());
+	spdlog::get("game")->debug("Loading Info Pack from file: {}", path.generic_string());
 
 	std::vector<uint8_t> data;
 	try
@@ -38,7 +38,7 @@ bool InfoFile::LoadFromFile(const fs::path& path, InfoConstants& infos)
 	}
 	catch (std::runtime_error& err)
 	{
-		spdlog::error("Failed to open {}: {}", path.generic_string(), err.what());
+		spdlog::get("game")->error("Failed to open {}: {}", path.generic_string(), err.what());
 		return false;
 	}
 

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -46,7 +46,7 @@ struct BgfxCallback: public bgfx::CallbackI
 		const static std::array CodeLookup = {
 		    "DebugCheck", "InvalidShader", "UnableToInitialize", "UnableToCreateTexture", "DeviceLost",
 		};
-		spdlog::critical("bgfx: {}:{}: FATAL ({}): {}", filePath, line, CodeLookup[code], str);
+		spdlog::get("graphics")->critical("bgfx: {}:{}: FATAL ({}): {}", filePath, line, CodeLookup[code], str);
 
 		// Must terminate, continuing will cause crash anyway.
 		throw std::runtime_error(std::string("bgfx: ") + filePath + ":" + std::to_string(line) + ": FATAL (" +
@@ -68,7 +68,7 @@ struct BgfxCallback: public bgfx::CallbackI
 		{
 			out[len - 1] = '\0';
 		}
-		spdlog::debug("bgfx: {}:{}: {}", filePath, line, out);
+		spdlog::get("graphics")->debug("bgfx: {}:{}: {}", filePath, line, out);
 	}
 	void profilerBegin(const char* name, uint32_t abgr, const char* filePath, uint16_t line) override {}
 	void profilerBeginLiteral(const char* name, uint32_t abgr, const char* filePath, uint16_t line) override {}
@@ -250,7 +250,7 @@ void Renderer::DrawMesh(const L3DMesh& mesh, const MeshPack& meshPack, const L3D
 {
 	if (mesh.GetNumSubMeshes() == 0)
 	{
-		spdlog::warn("Mesh {} has no submeshes to draw", mesh.GetDebugName());
+		spdlog::get("graphics")->warn("Mesh {} has no submeshes to draw", mesh.GetDebugName());
 		return;
 	}
 
@@ -260,7 +260,7 @@ void Renderer::DrawMesh(const L3DMesh& mesh, const MeshPack& meshPack, const L3D
 	{
 		if (subMeshIndex >= mesh.GetNumSubMeshes())
 		{
-			spdlog::warn("tried to draw submesh out of range ({}/{})", subMeshIndex, mesh.GetNumSubMeshes());
+			spdlog::get("graphics")->warn("tried to draw submesh out of range ({}/{})", subMeshIndex, mesh.GetNumSubMeshes());
 		}
 
 		DrawSubMesh(mesh, *subMeshes[subMeshIndex], meshPack, desc, desc.viewId, *desc.program, desc.state, desc.rgba, false);

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -46,7 +46,7 @@ struct BgfxCallback: public bgfx::CallbackI
 		const static std::array CodeLookup = {
 		    "DebugCheck", "InvalidShader", "UnableToInitialize", "UnableToCreateTexture", "DeviceLost",
 		};
-		spdlog::get("graphics")->critical("bgfx: {}:{}: FATAL ({}): {}", filePath, line, CodeLookup[code], str);
+		SPDLOG_LOGGER_CRITICAL(spdlog::get("graphics"), "bgfx: {}:{}: FATAL ({}): {}", filePath, line, CodeLookup[code], str);
 
 		// Must terminate, continuing will cause crash anyway.
 		throw std::runtime_error(std::string("bgfx: ") + filePath + ":" + std::to_string(line) + ": FATAL (" +
@@ -68,7 +68,7 @@ struct BgfxCallback: public bgfx::CallbackI
 		{
 			out[len - 1] = '\0';
 		}
-		spdlog::get("graphics")->debug("bgfx: {}:{}: {}", filePath, line, out);
+		SPDLOG_LOGGER_DEBUG(spdlog::get("graphics"), "bgfx: {}:{}: {}", filePath, line, out);
 	}
 	void profilerBegin(const char* name, uint32_t abgr, const char* filePath, uint16_t line) override {}
 	void profilerBeginLiteral(const char* name, uint32_t abgr, const char* filePath, uint16_t line) override {}
@@ -250,7 +250,7 @@ void Renderer::DrawMesh(const L3DMesh& mesh, const MeshPack& meshPack, const L3D
 {
 	if (mesh.GetNumSubMeshes() == 0)
 	{
-		spdlog::get("graphics")->warn("Mesh {} has no submeshes to draw", mesh.GetDebugName());
+		SPDLOG_LOGGER_WARN(spdlog::get("graphics"), "Mesh {} has no submeshes to draw", mesh.GetDebugName());
 		return;
 	}
 
@@ -260,7 +260,8 @@ void Renderer::DrawMesh(const L3DMesh& mesh, const MeshPack& meshPack, const L3D
 	{
 		if (subMeshIndex >= mesh.GetNumSubMeshes())
 		{
-			spdlog::get("graphics")->warn("tried to draw submesh out of range ({}/{})", subMeshIndex, mesh.GetNumSubMeshes());
+			SPDLOG_LOGGER_WARN(spdlog::get("graphics"), "tried to draw submesh out of range ({}/{})", subMeshIndex,
+			                   mesh.GetNumSubMeshes());
 		}
 
 		DrawSubMesh(mesh, *subMeshes[subMeshIndex], meshPack, desc, desc.viewId, *desc.program, desc.state, desc.rgba, false);

--- a/src/Serializer/GameThingSerializer.cpp
+++ b/src/Serializer/GameThingSerializer.cpp
@@ -50,7 +50,8 @@ void GameThingSerializer::ReadChecksum()
 	auto readSum = ReadValue<uint32_t>();
 	if (expectedSum != readSum)
 	{
-		spdlog::error("Failed checksum (expected={:08X}, read={:08X}) at {:08X}", expectedSum, readSum, _stream.Position());
+		spdlog::get("game")->error("Failed checksum (expected={:08X}, read={:08X}) at {:08X}", expectedSum, readSum,
+		                           _stream.Position());
 		assert(false);
 	}
 }
@@ -58,9 +59,9 @@ void GameThingSerializer::ReadChecksum()
 std::shared_ptr<GameThingSerializer::GameThing> GameThingSerializer::DeserializeOne(std::optional<GameThingType> required_type)
 {
 	auto offset = _stream.Position();
-	spdlog::debug("offset={}", offset);
+	spdlog::get("game")->debug("offset={}", offset);
 	auto index = ReadValue<uint32_t>();
-	spdlog::debug("index={}, len={}", index, _cache.size());
+	spdlog::get("game")->debug("index={}, len={}", index, _cache.size());
 
 	if (index == 0)
 	{
@@ -131,7 +132,7 @@ std::vector<T> GameThingSerializer::DeserializeList()
 	list.reserve(count);
 	for (uint32_t i = 0; i < count; ++i)
 	{
-		spdlog::debug("i={}", i);
+		spdlog::get("game")->debug("i={}", i);
 		auto ptr = std::dynamic_pointer_cast<T>(DeserializeOne(GameThingTypeEnum<T>));
 		if (ptr)
 		{

--- a/src/Serializer/GameThingSerializer.cpp
+++ b/src/Serializer/GameThingSerializer.cpp
@@ -50,8 +50,8 @@ void GameThingSerializer::ReadChecksum()
 	auto readSum = ReadValue<uint32_t>();
 	if (expectedSum != readSum)
 	{
-		spdlog::get("game")->error("Failed checksum (expected={:08X}, read={:08X}) at {:08X}", expectedSum, readSum,
-		                           _stream.Position());
+		SPDLOG_LOGGER_ERROR(spdlog::get("game"), "Failed checksum (expected={:08X}, read={:08X}) at {:08X}", expectedSum,
+		                    readSum, _stream.Position());
 		assert(false);
 	}
 }
@@ -59,9 +59,9 @@ void GameThingSerializer::ReadChecksum()
 std::shared_ptr<GameThingSerializer::GameThing> GameThingSerializer::DeserializeOne(std::optional<GameThingType> required_type)
 {
 	auto offset = _stream.Position();
-	spdlog::get("game")->debug("offset={}", offset);
+	SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "offset={}", offset);
 	auto index = ReadValue<uint32_t>();
-	spdlog::get("game")->debug("index={}, len={}", index, _cache.size());
+	SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "index={}, len={}", index, _cache.size());
 
 	if (index == 0)
 	{
@@ -132,7 +132,7 @@ std::vector<T> GameThingSerializer::DeserializeList()
 	list.reserve(count);
 	for (uint32_t i = 0; i < count; ++i)
 	{
-		spdlog::get("game")->debug("i={}", i);
+		SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "i={}", i);
 		auto ptr = std::dynamic_pointer_cast<T>(DeserializeOne(GameThingTypeEnum<T>));
 		if (ptr)
 		{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,7 @@ bool parseOptions(int argc, char** argv, openblack::Arguments& args, int& return
 		("b,backend-type", "Which backend to use for rendering.", cxxopts::value<std::string>()->default_value("OpenGL"))
 		("n,num-frames-to-simulate", "Number of frames to simulate before quitting.", cxxopts::value<uint32_t>()->default_value("0"))
 		("l,log-file", "Output file for logs, 'stdout' for terminal output.", cxxopts::value<std::string>()->default_value(defaultLogFile))
-		("L,log-level", "Level of logging.", cxxopts::value<uint32_t>()->default_value("0"))
+		("L,log-level", "Level (trace, debug, info, warning, error, critical, off) of logging.", cxxopts::value<std::string>()->default_value("debug"))
 	;
 	// clang-format on
 
@@ -94,6 +94,8 @@ bool parseOptions(int argc, char** argv, openblack::Arguments& args, int& return
 			throw cxxopts::option_not_exists_exception(result["window-mode"].as<std::string>());
 		}
 
+		spdlog::level::level_enum logLevel = spdlog::level::from_str(result["log-level"].as<std::string>());
+
 		args.executablePath = argv[0];
 		if (result.count("game-path") == 0)
 		{
@@ -128,7 +130,7 @@ bool parseOptions(int argc, char** argv, openblack::Arguments& args, int& return
 		args.rendererType = rendererType;
 		args.numFramesToSimulate = result["num-frames-to-simulate"].as<uint32_t>();
 		args.logFile = result["log-file"].as<std::string>();
-		args.logLevel = result["log-level"].as<uint32_t>();
+		args.logLevel = logLevel;
 	}
 	catch (cxxopts::OptionParseException& err)
 	{


### PR DESCRIPTION
This PR adds granularity to logs. This frees us up to the possibility of adding more log messages without worrying about spamming everyone's logs.

We make use of different loggers which can be set to each have different levels in the command line.
We also use the `SPDLOG_LOGGER` macro which lets the log show the line and file name associated with a log message.
Additionally, this allows us to compile away log messages of low severity by setting the `SPDLOG_ACTIVE_LEVEL` define.

Adding a category (audio for example) is as simple as adding it to `LoggingSubsystem` and `LoggingSubsystemStrs` in `Game.h`. The loggers will be created automatically and the commandline arguments and help text will be added also. Simply use `spdlog::get("new logger's name")`

The purpose of this PR is to allow game logic to add messages each frame in the villager states PR.

Sample running in debug compilation mode with the args ` -L error -L graphics=info -L game=debug`, which means use Error level by default, Info for graphics and Debug for game
```
[2021-01-16 01:55:42.841] [game] [info] [Game.cpp:88] current binary path: /home/sandy/code/openblack/cmake-build-debug-gcc/bin
[2021-01-16 01:55:42.841] [graphics] [info] [GameWindow.cpp:35] Initializing SDL...
[2021-01-16 01:55:42.841] [graphics] [info] [GameWindow.cpp:36] SDL Version/Compiled 2.0.14
[2021-01-16 01:55:42.841] [graphics] [info] [GameWindow.cpp:38] SDL Version/Linked 2.0.14
[2021-01-16 01:55:43.285] [game] [debug] [L3DMesh.cpp:82] Loading L3DMesh from file: Data/CreatureMesh/Hand_Boned_Base2.l3d
[2021-01-16 01:55:43.286] [game] [debug] [L3DSubMesh.cpp:133]  submesh 0 with 141 verts and 507 indices
[2021-01-16 01:55:43.286] [game] [debug] [Game.cpp:99] The GamePath is "/home/sandy/code/bw_reversing/bw".
[2021-01-16 01:55:43.295] [game] [debug] [MeshPack.cpp:31] Loading Mesh Pack from file: Data/AllMeshes.g3d
[2021-01-16 01:55:43.362] [game] [debug] [MeshPack.cpp:91] MeshPack loaded 110 textures
[2021-01-16 01:55:43.362] [game] [debug] [L3DSubMesh.cpp:133] Dummy submesh 0 with 20 verts and 36 indices
[2021-01-16 01:55:43.362] [game] [debug] [L3DSubMesh.cpp:133] AnimalBat1 submesh 0 with 37 verts and 144 indices
[2021-01-16 01:55:43.362] [game] [debug] [L3DSubMesh.cpp:133] AnimalBat2 submesh 0 with 14 verts and 36 indices
[2021-01-16 01:55:43.362] [game] [debug] [L3DSubMesh.cpp:133] AnimalCrow1 submesh 0 with 33 verts and 132 indices
```