### PR TITLE
Add vcpkg manifest and submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vcpkg"]
+	path = vcpkg
+	url = https://github.com/Microsoft/vcpkg.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   set(CMAKE_TOOLCHAIN_FILE
       "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
       CACHE STRING "")
+else()
+  # set default toolchain to vcpkg submodule
+  set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake
+    CACHE STRING "Vcpkg toolchain file")
 endif()
 
 project(openblack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,16 +7,18 @@ else()
   include(FetchContent)
 endif()
 
-# automatically use vcpkg if VCPKG_ROOT is defined
-if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
-  message(STATUS "Using VCPKG_ROOT $ENV{VCPKG_ROOT}")
-  set(CMAKE_TOOLCHAIN_FILE
-      "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
-      CACHE STRING "")
+# On Visual Studio generators default to using vcpkg as the most newbie friendly option
+if (CMAKE_GENERATOR MATCHES "^Visual Studio")
+  message(STATUS "Defaulting to using vcpkg in a Windows build environment. You can disable with OPENBLACK_USE_VCPKG")
+  option(OPENBLACK_USE_VCPKG "Resolve dependencies using the vcpkg submodule toolchain" ON)
 else()
-  # set default toolchain to vcpkg submodule
+  option(OPENBLACK_USE_VCPKG "Resolve dependencies using the vcpkg submodule toolchain" OFF)
+endif()
+
+# If using vcpkg and not manually specified the toolchain then set it for them
+if (OPENBLACK_USE_VCPKG AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake
-    CACHE STRING "Vcpkg toolchain file")
+    CACHE STRING "Default to vcpkg toolchain file")
 endif()
 
 project(openblack)

--- a/readme.md
+++ b/readme.md
@@ -5,9 +5,9 @@
 [![Discord chat](https://img.shields.io/discord/608729286513262622?logo=discord&logoColor=white)](https://discord.gg/5QTexBU)
 [![License](https://img.shields.io/github/license/openblack/openblack)](LICENSE.md)
 
-openblack is an open source reimplementation of [Black & White (2001)](https://en.wikipedia.org/wiki/Black_&_White_(video_game)) written in modern C++ and modern OpenGL.
+openblack is an open source reimplementation of [Black & White (2001)](https://en.wikipedia.org/wiki/Black_&_White_(video_game)) written in modern C++ and modern rendering engines (OpenGL, Vulkan).
 
-You still need to have the original game assets in order to use this.
+You still need to have the original game assets in order to use this, don't ask where to get these.
 
 ---
 
@@ -45,10 +45,10 @@ You can either:
 
 ```bash
 cd openblack
-cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=C:/Users/Matt/Development/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -Dbgfx_DIR=C:/Users/Matt/Development/bgfx-windows-x64/lib/cmake/bgfx
+cmake -S . -B build -Dbgfx_DIR=C:/Users/Matt/Development/bgfx-windows-x64/lib/cmake/bgfx
 ```
 
-_Replace `C:/Users/Matt/Development/vcpkg` with your vcpkg root and `C:/Users/Matt/Development/bgfx-windows-x64` with the folder you extracted bgfx to._
+_Replace `C:/Users/Matt/Development/bgfx-windows-x64` with the folder you extracted bgfx to._
 
 ## Linux
 
@@ -62,7 +62,7 @@ Ensure you have dependencies first
 ```bash
 sudo apt install cmake
 cd openblack
-cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-linux
+cmake -S . -B build -DOPENBLACK_USE_VCPKG=true -DVCPKG_TARGET_TRIPLET=x64-linux
 cmake --build build -j 5
 ```
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,12 @@
+{
+    "name": "openblack",
+    "version-string": "0.0.1-dev",
+    "dependencies": [
+        "sdl2",
+        "spdlog",
+        "glm",
+        "entt",
+        "cxxopts",
+        "openal-soft"
+    ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,6 +7,11 @@
         "glm",
         "entt",
         "cxxopts",
-        "openal-soft"
+        "openal-soft",
+        {
+            "name": "ffmpeg",
+            "default-features": false,
+            "features": [ "avcodev", "avformat", "libavutil", "swresample" ]
+        }
     ]
 }


### PR DESCRIPTION
Adds a vcpkg manifest and vcpkg as a submodule, also makes CMake default the CMAKE_TOOLCHAIN_FILE to vcpkg in the submodule.

* Creates a way to easily maintain a list of dependencies.
* Creates consistent versioning across developers and CI/release environments.
* Easier for people to begin developing, they don't need to install vcpkg, CMake runs all the necessary install commands.

Resolves #271 