### PR TITLE
Footpath link

### DIFF
--- a/src/Entities/Components/Footpath.h
+++ b/src/Entities/Components/Footpath.h
@@ -9,12 +9,14 @@
 
 #pragma once
 
-#include <glm/vec3.hpp>
 #include <vector>
+
+#include <glm/vec3.hpp>
 
 namespace openblack::entities::components
 {
 
+/// A list-like structure of positions a Living can travel on to get from the first node to the last, and vice-versa
 struct Footpath
 {
 	using Id = int;
@@ -25,6 +27,17 @@ struct Footpath
 	};
 
 	std::vector<Node> nodes;
+};
+
+/// Links a [Planned]MultiMapFixed entity to a list of footpaths
+/// The position is used to look-up matches. If the MMF is close enough to the link, they are connected.
+/// The relationship of MMF to FPL is one2one and MMF to Footpath is one2many
+struct FootpathLink
+{
+	using Id = int;
+
+	glm::vec3 position;
+	std::vector<Footpath::Id> footpaths;
 };
 
 } // namespace openblack::entities::components

--- a/src/Entities/Registry.h
+++ b/src/Entities/Registry.h
@@ -94,6 +94,11 @@ public:
 	{
 		return Get<Dst>(ToEntity(component));
 	}
+	template <typename... Components>
+	decltype(auto) Size() const
+	{
+		return _registry.view<Components...>().size();
+	}
 
 private:
 	void PrepareDrawDescs(bool drawBoundingBox);

--- a/src/Serializer/Common.h
+++ b/src/Serializer/Common.h
@@ -20,6 +20,9 @@ struct MapCoords
 	uint32_t x;
 	uint32_t z;
 	float altitude;
+
+	bool operator==(const MapCoords& rhs) const { return x == rhs.x && z == rhs.z && altitude == rhs.altitude; }
+	bool operator!=(const MapCoords& rhs) const { return !(*this == rhs); }
 };
 #pragma pack(pop)
 

--- a/src/Serializer/FotFile.cpp
+++ b/src/Serializer/FotFile.cpp
@@ -19,16 +19,19 @@ void FotFile::Load(const fs::path& path)
 {
 	auto stream = _game.GetFileSystem().Open(path, FileMode::Read);
 	serializer::GameThingSerializer serializer(*stream);
-	auto footpath_link_saves = serializer.DeserializeList<serializer::GameThingSerializer::FootpathLinkSave>();
+	auto footpathLinkSaves = serializer.DeserializeList<serializer::GameThingSerializer::FootpathLinkSave>();
 	auto footpaths = serializer.DeserializeList<serializer::GameThingSerializer::Footpath>();
 	auto& registry = _game.GetEntityRegistry();
 	const auto& island = _game.GetLandIsland();
 
+	// Keep track of footpath entities in order to associate them to the footpath link saves later
+	std::vector<entities::components::Footpath::Id> footpathEntities;
+
 	for (const auto& footpath : footpaths)
 	{
 		const auto entity = registry.Create();
-		auto& footpath_entt = registry.Assign<entities::components::Footpath>(entity);
-		footpath_entt.nodes.reserve(footpath._nodes.size());
+		auto& footpathEntt = registry.Assign<entities::components::Footpath>(entity);
+		footpathEntt.nodes.reserve(footpath._nodes.size());
 		for (const auto& node : footpath._nodes)
 		{
 			glm::vec3 position = glm::vec3 {
@@ -41,7 +44,28 @@ void FotFile::Load(const fs::path& path)
 			// if that is the case, this bit should be moved to rendering code
 			position.y += island.GetHeightAt({position.x, position.z});
 
-			footpath_entt.nodes.push_back({position});
+			footpathEntt.nodes.push_back({position});
 		}
+		footpathEntities.push_back(static_cast<entities::components::Footpath::Id>(entity));
+	}
+
+	for (const auto& save : footpathLinkSaves)
+	{
+		std::vector<entities::components::Footpath::Id> linkFootpathEntities;
+		for (const auto& footpath : save._link._footpaths)
+		{
+			// Save links have duplicates to entries in footpaths
+			const auto footpathListItr = std::find(footpaths.cbegin(), footpaths.cend(), footpath);
+			assert(footpathListItr != footpaths.cend());
+			const auto footpathIndex = std::distance(footpaths.cbegin(), footpathListItr);
+			linkFootpathEntities.push_back(footpathEntities[footpathIndex]);
+		}
+		glm::vec3 position = glm::vec3 {
+		    10.0f * save._coords.x / static_cast<float>(0xFFFF),
+		    save._coords.altitude,
+		    10.0f * save._coords.z / static_cast<float>(0xFFFF),
+		};
+		const auto entity = registry.Create();
+		auto& linkEntt = registry.Assign<entities::components::FootpathLink>(entity, position, std::move(linkFootpathEntities));
 	}
 }

--- a/src/Serializer/GameThingSerializer.cpp
+++ b/src/Serializer/GameThingSerializer.cpp
@@ -148,12 +148,33 @@ bool GameThingSerializer::GameThing::Deserialize(GameThingSerializer& deserializ
 	return true;
 }
 
+bool GameThingSerializer::GameThing::operator==(const GameThingSerializer::GameThing& rhs) const
+{
+	return _unknown1 == rhs._unknown1 && _unknown2 == rhs._unknown2;
+}
+
+bool GameThingSerializer::GameThing::operator!=(const GameThingSerializer::GameThing& rhs) const
+{
+	return !(*this == rhs);
+}
+
 bool GameThingSerializer::Footpath::Deserialize(GameThingSerializer& deserializer)
 {
 	GameThing::Deserialize(deserializer);
 	_nodes = deserializer.DeserializeList<FootpathNode>();
 	_unknown = deserializer.ReadValue<uint32_t>();
 	return true;
+}
+
+bool GameThingSerializer::Footpath::operator==(const GameThingSerializer::Footpath& rhs) const
+{
+	return static_cast<const GameThing&>(*this) == static_cast<const GameThing&>(rhs) && _nodes == rhs._nodes &&
+	       _unknown == rhs._unknown;
+}
+
+bool GameThingSerializer::Footpath::operator!=(const GameThingSerializer::Footpath& rhs) const
+{
+	return !(*this == rhs);
 }
 
 bool GameThingSerializer::FootpathLink::Deserialize(GameThingSerializer& deserializer)
@@ -169,6 +190,17 @@ bool GameThingSerializer::FootpathNode::Deserialize(GameThingSerializer& deseria
 	_coords = deserializer.ReadValue<MapCoords>();
 	_unknown = deserializer.ReadValue<uint8_t>();
 	return true;
+}
+
+bool GameThingSerializer::FootpathNode::operator==(const GameThingSerializer::FootpathNode& rhs) const
+{
+	return static_cast<const GameThing&>(*this) == static_cast<const GameThing&>(rhs) && _coords == rhs._coords &&
+	       _unknown == rhs._unknown;
+}
+
+bool GameThingSerializer::FootpathNode::operator!=(const GameThingSerializer::FootpathNode& rhs) const
+{
+	return !(*this == rhs);
 }
 
 bool GameThingSerializer::FootpathLinkSave::Deserialize(GameThingSerializer& deserializer)

--- a/src/Serializer/GameThingSerializer.h
+++ b/src/Serializer/GameThingSerializer.h
@@ -47,6 +47,8 @@ public:
 		virtual ~GameThing() = default;
 
 		virtual bool Deserialize(GameThingSerializer& deserializer);
+		bool operator==(const GameThing& rhs) const;
+		bool operator!=(const GameThing& rhs) const;
 	};
 
 	struct FootpathNode final: GameThing
@@ -55,6 +57,8 @@ public:
 		uint8_t _unknown;
 
 		bool Deserialize(GameThingSerializer& deserializer) override;
+		bool operator==(const FootpathNode& rhs) const;
+		bool operator!=(const FootpathNode& rhs) const;
 	};
 
 	struct Footpath final: GameThing
@@ -63,6 +67,8 @@ public:
 		uint32_t _unknown;
 
 		bool Deserialize(GameThingSerializer& deserializer) override;
+		bool operator==(const Footpath& rhs) const;
+		bool operator!=(const Footpath& rhs) const;
 	};
 
 	struct FootpathLink final: GameThing


### PR DESCRIPTION
This is part of the villager state machine work that I am doing.

The footpath link is a look-up entry for associating buildings (`MultiMapFixed` and `PlannedMuliMapFixed`) to one or more footpaths.
This is used when a living wants to navigate to a building using a footpath.

The `FotFile` stores `FootpathLinkSave` which has a list of footpaths and position.
The footpaths in the list are duplicates of those found in the footpath list.
Eventually, the footpath links are traversed to associate themselves with loaded buildings (this is not done yet as MultiMapFixed is not yet added).

The solution here was to add equality operators to the `GameThingSerializer` structs and use `std::find` to get the references to the original footpaths.