### PR TITLE
Add clang-format action

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,2 +1,5 @@
-tiny_gltf.h
-stb_image_write.h
+apps/anmtool/tiny_gltf.h
+apps/anmtool/json.hpp
+apps/l3dtool/tiny_gltf.h
+apps/l3dtool/json.hpp
+src/Common/stb_image_write.h

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,5 +1,5 @@
 name: Formatting Check
-on: [push, pull_request]
+on: [ push, pull_request ]
 jobs:
   formatting-check:
     name: clang-format
@@ -10,3 +10,21 @@ jobs:
         with:
           source: 'src apps components'
           clangFormatVersion: 12
+          inplace: False
+
+  # Run only if a PR and clang-format has failed
+  formatting-action-suggester:
+    name: clang-format fix suggester
+    needs: formatting-check
+    if: always() && github.event_name == 'pull_request' && needs.formatting-check.result == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: DoozyX/clang-format-lint-action@v0.13
+        with:
+          source: 'src apps components'
+          clangFormatVersion: 12
+          inplace: True
+      - uses: reviewdog/action-suggester@v1
+        with:
+          tool_name: clang-format

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,12 @@
+name: Formatting Check
+on: [push, pull_request]
+jobs:
+  formatting-check:
+    name: clang-format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: DoozyX/clang-format-lint-action@v0.13
+        with:
+          source: 'src apps components'
+          clangFormatVersion: 12

--- a/src/Gui.cpp
+++ b/src/Gui.cpp
@@ -18,8 +18,8 @@
 #include <bx/timer.h>
 #include <glm/gtx/compatibility.hpp>
 #include <imgui.h>
-#include <imgui_user.h>
 #include <imgui_internal.h>
+#include <imgui_user.h>
 #include <imgui_widget_flamegraph.h>
 #ifdef _WIN32
 #include <SDL2/SDL_syswm.h>


### PR DESCRIPTION
https://github.com/marketplace/actions/clang-format-lint

This doesn't use the cmake clang-format, so it requires slightly different formatting (especially in the ignore file).
It is possible to have it automatically commit formatting fixes with https://github.com/marketplace/actions/add-commit
It does run much faster (~15s) than using the cmake clang-format because it doesn't need to install or configure anything .