### PR TITLE
CMakePresets: remove reference to 64-bits in name

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -28,14 +28,14 @@
     },
     {
       "name": "ninja-multi-vcpkg",
-      "displayName": "Ninja Multi-Config (vcpkg, 64 bits)",
+      "displayName": "Ninja Multi-Config (vcpkg)",
       "description": "Configure with vcpkg toolchain and generate Ninja project files for all configurations",
       "generator": "Ninja Multi-Config",
       "inherits": "template-vcpkg"
     },
     {
       "name": "msvc-16-vcpkg",
-      "displayName": "Visual Studio 2019 (vcpkg, 64 bits)",
+      "displayName": "Visual Studio 2019 (vcpkg)",
       "description": "Configure with vcpkg toolchain and generate Visual Studio 2019 project files for all configurations",
       "generator": "Visual Studio 16 2019",
       "inherits": "template-vcpkg"


### PR DESCRIPTION
These were leftover from a previous iteration. Since I didn't supply a 32-bit preset, it doesn't make sense to specify.

The tests set 32-bit with environment variables.

Adding a 32-bit preset is as easy as [including a new configuration with the architecture key](https://docs.microsoft.com/en-us/cpp/build/cmake-presets-vs?view=msvc-170).

Same can be done for compiling for arm