### PR TITLE
Readme improvements

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,8 +34,8 @@ for you. To do so, you will be selecting the `"ninja-multi-vcpkg"   - Ninja Mult
 
 ### Visual Studio Code
  * Install [Visual Studio Code](https://code.visualstudio.com/Download)
- * Install [C++ Extension](https://code.visualstudio.com/docs/languages/cpp)
- * Install the [CMake Tools Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools)
+ * Install the [C++ Extension](vscode:extension/ms-vscode.cpptools)
+ * Install the [CMake Tools Extension](vscode:extension/ms-vscode.cmake-tools)
  * You can simply [open the `openblack` folder directly in Visual Studio Code and select a preset](https://devblogs.microsoft.com/cppblog/cmake-presets-integration-in-visual-studio-and-visual-studio-code/).
 
 ### Visual Studio 2019 / 2022

--- a/readme.md
+++ b/readme.md
@@ -48,8 +48,8 @@ for you. To do so, you will be selecting the `"ninja-multi-vcpkg"   - Ninja Mult
 
 ### Commandline
 * Your usual build tool-chain.
-    * Ubuntu / Debian: `# apt install build-essential cmake`
-    * Arch Linux / Manjaro: `# pacman -S base-devel cmake`
+    * Ubuntu / Debian: `# apt install build-essential cmake ninja-build`
+    * Arch Linux / Manjaro: `# pacman -S base-devel cmake ninja`
 * You can generate the cmake build preset using `cmake --preset` and you can list the presets using `cmake --list-presets`
 
 ## Configuration for using System Dependencies (Recommended for packagers)

--- a/readme.md
+++ b/readme.md
@@ -30,16 +30,23 @@ The simplest way to obtain all the required dependencies is through [vcpkg](http
 The easiest way to get started on any platform is to allow CMake and vcpkg to handle all dependencies and configuration
 for you. To do so, you will be selecting the `"ninja-multi-vcpkg"   - Ninja Multi-Config (vcpkg)` preset. Other presets are available for more advanced users.
 
-* Install [CMake version 3.20+](https://cmake.org/download/)
-
 ### Visual Studio Code
  * Install [Visual Studio Code](https://code.visualstudio.com/Download)
  * Install the [C++ Extension](vscode:extension/ms-vscode.cpptools)
+    * The extension might not be required on Linux
+    * Install a compiler depending on your platform
+        * GNU or Clang compilers on Linux
+        * Visual Studio's MSVC on Windows (See Visual Studio)
+        * Clang compiler on Mac
  * Install the [CMake Tools Extension](vscode:extension/ms-vscode.cmake-tools)
+     * Install [CMake version 3.20+](https://cmake.org/download/)
  * You can simply [open the `openblack` folder directly in Visual Studio Code and select a preset](https://devblogs.microsoft.com/cppblog/cmake-presets-integration-in-visual-studio-and-visual-studio-code/).
 
 ### Visual Studio 2019 / 2022
 * Install [Visual Studio](https://visualstudio.microsoft.com/downloads/)
+    * Select an appropriate MSVC C++ Component for your version
+    * Select an appropriate Windows SDK Component for your version
+    * Select the C++ CMake tools for Windows Component
 * You can simply [open the `openblack` folder directly in Visual Studio and select a preset](https://devblogs.microsoft.com/cppblog/cmake-presets-integration-in-visual-studio-and-visual-studio-code/).
 
 ### Clion


### PR DESCRIPTION
Improved the the readme for first time configuration:
* On linux using the ninja multibuild config (which I would consider being the default preset) fails if you don't have ninja installed
* If you're use vscode and reading the readme from there, it makes more sense for the links to open vscode marketplace instead of the browser.

Note to reviewers:
* The link to the c++ extension should be right according to the [page](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) but it wasn't showing up on linux. It does on windows.