### PR TITLE
Add copyright checker

### DIFF
--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -1,0 +1,14 @@
+name: Copyright Check
+on: [ push, pull_request ]
+jobs:
+  copyright-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Check License Lines
+      uses: kt3k/license_checker@v1.0.6
+  
+#  - name: Create Pull Request
+#    uses: peter-evans/create-pull-request@v2
+#    with:
+#      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.licenserc.json
+++ b/.licenserc.json
@@ -1,0 +1,17 @@
+{
+    "**/*.{h,cpp}": [
+        "/*****************************************************************************",
+        " * Copyright (c) 2018-2022 openblack developers",
+        " *",
+        " * For a complete list of all authors, please refer to contributors.md",
+        " * Interested in contributing? Visit https://github.com/openblack/openblack",
+        " *",
+        " * openblack is licensed under the GNU General Public License version 3.",
+        " *****************************************************************************"
+    ],
+    "ignore": [
+        "externals/",
+        "stb_image_write.h",
+        "tiny_gltf.h"
+    ]
+}

--- a/src/Graphics/ShaderIncluder.h
+++ b/src/Graphics/ShaderIncluder.h
@@ -1,3 +1,12 @@
+/*****************************************************************************
+ * Copyright (c) 2018-2022 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
 // https://stackoverflow.com/questions/40062883/how-to-use-a-macro-in-an-include-directive
 
 // Turn off formatting because it adds spaces which break the stringifying

--- a/src/LHScriptX/ScriptingBindingUtils.cpp
+++ b/src/LHScriptX/ScriptingBindingUtils.cpp
@@ -1,3 +1,12 @@
+/*****************************************************************************
+ * Copyright (c) 2018-2022 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
 #include "ScriptingBindingUtils.h"
 
 #include "3D/LandIsland.h"

--- a/src/Serializer/FotFile.cpp
+++ b/src/Serializer/FotFile.cpp
@@ -1,3 +1,12 @@
+/*****************************************************************************
+ * Copyright (c) 2018-2022 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
 #include "FotFile.h"
 
 #include <spdlog/spdlog.h>


### PR DESCRIPTION
Add an action that checks for our license / copyright comment at the top of each of our project files.
There is a configuration file `.licenserc.json` with the glob path and which is configured to ignore external 3rd party files.

example failed test: https://github.com/openblack/openblack/runs/4755262264?check_suite_focus=true#step:4:150

https://github.com/marketplace/actions/license-checker