### PR TITLE
Sky shader

### DIFF
--- a/assets/shaders/fs_object.sc
+++ b/assets/shaders/fs_object.sc
@@ -4,21 +4,28 @@ $input v_position, v_texcoord0, v_normal
 
 SAMPLER2D(s_diffuse, 0);
 
+uniform vec4 u_sky;
+
 void main()
 {
 	// constants
 	const vec3 lightColor = vec3(1.0f, 1.0f, 1.0f);
 	const vec4 lightPos = vec4(-4000.0f, 1300.0f, -1435.0f, 1.0f);
-	const float ambientStrength = 0.5f;
+	const float ambientStrength = 0.25f;
 	const float alphaThreshold = 1.0f / 255.0f;
+
+	// unpack uniforms
+	float skyType = u_sky.x;
+
+	float skyBightness = skyType / 2.0f;
 	// ambient
-	vec3 ambient = ambientStrength * lightColor;
+	vec3 ambient = (skyBightness * 0.25f + ambientStrength) * lightColor;
 
 	// diffuse
 	vec3 norm = normalize(v_normal);
 	vec4 lightDir = normalize(lightPos - v_position);
 	float diff = max(dot(v_normal, lightDir.xyz), 0.0);
-	vec3 diffuse = diff * lightColor * 0.5;
+	vec3 diffuse = skyBightness * diff * lightColor * ( 1.0f - ambientStrength);
 
 	vec4 diffuseTex = texture2D(s_diffuse, v_texcoord0.xy);
 	diffuseTex.rgb = diffuseTex.rgb * (ambient + diffuse);

--- a/assets/shaders/fs_sky.sc
+++ b/assets/shaders/fs_sky.sc
@@ -1,0 +1,45 @@
+$input v_position, v_texcoord0, v_normal
+
+#include <bgfx_shader.sh>
+
+SAMPLER2DARRAY(s_diffuse, 0);
+uniform vec4 u_typeAlignment;
+
+void main()
+{
+	// constants
+	const float nightIndex = 0.0f;
+	const float duskIndex = 1.0f;
+	const float dayIndex = 2.0f;
+	const float evilIndex = 0.0f;
+	const float neutralIndex = 1.0f;
+	const float goodIndex = 2.0f;
+
+	// unpack uniform
+	float textureType = clamp(u_typeAlignment.x, nightIndex, dayIndex);
+	float alignment = clamp(u_typeAlignment.y, evilIndex, goodIndex);
+
+	float alignT = mod(alignment, 1.0f);
+	float alignA = alignment - alignT;
+	float alignB = min(alignA + 1, goodIndex);
+
+	float typeT = mod(textureType, 1.0f);
+	float typeA = textureType - typeT;
+	float typeB = min(typeA + 1, dayIndex);
+
+	float indexAA = 3 * alignA + typeA;
+	float indexAB = 3 * alignA + typeB;
+	float indexBA = 3 * alignB + typeA;
+	float indexBB = 3 * alignB + typeB;
+
+	vec4 colorAA = texture2DArray(s_diffuse, vec3(v_texcoord0.xy, indexAA));
+	vec4 colorAB = texture2DArray(s_diffuse, vec3(v_texcoord0.xy, indexAB));
+	vec4 colorBA = texture2DArray(s_diffuse, vec3(v_texcoord0.xy, indexBA));
+	vec4 colorBB = texture2DArray(s_diffuse, vec3(v_texcoord0.xy, indexBB));
+
+	vec4 colorAlignA = mix(colorAA, colorBA, alignT);
+	vec4 colorAlignB = mix(colorAB, colorBB, alignT);
+
+	gl_FragColor = mix(colorAlignA, colorAlignB, typeT);
+
+}

--- a/assets/shaders/fs_terrain.sc
+++ b/assets/shaders/fs_terrain.sc
@@ -8,14 +8,14 @@ SAMPLER2DARRAY(s0_materials, 0);
 SAMPLER2D(s1_bump, 1);
 SAMPLER2D(s2_smallBump, 2);
 
-uniform vec4 u_timeOfDayBump;
+uniform vec4 u_skyAndBump;
 
 void main()
 {
 	// unpack uniforms
-	float timeOfDay = u_timeOfDayBump.x;
-	float bumpMapStrength = u_timeOfDayBump.y;
-	float smallBumpMapStrength = u_timeOfDayBump.z;
+	float skyType = u_skyAndBump.x;
+	float bumpMapStrength = u_skyAndBump.y;
+	float smallBumpMapStrength = u_skyAndBump.z;
 
 	// do each vert with both materials
 	vec4 colOne = mix(
@@ -50,8 +50,8 @@ void main()
 	}
 
 	// apply light map
-	float dayBrightness = cos(timeOfDay* 2.0f * M_PI) * 0.5f + 0.5f;
-	col = col * mix(.25f, clamp(v_lightLevel * 2, 0.5, 1), dayBrightness);
+	float skyBightness = skyType / 2.0f;
+	col = col * mix(.25f, clamp(v_lightLevel * 2, 0.5, 1), skyBightness);
 
 	gl_FragColor = vec4(col.rgb, v_waterAlpha);
 

--- a/assets/shaders/fs_water.sc
+++ b/assets/shaders/fs_water.sc
@@ -5,9 +5,15 @@ $input v_texcoord0, v_texcoord1
 SAMPLER2D(s_diffuse, 0);
 SAMPLER2D(s_reflection, 1);
 
+uniform vec4 u_sky;
+
 void main()
-{
-	vec3 diffuse_colour = texture2D(s_diffuse, vec2(v_texcoord0.x, v_texcoord0.y)).rgb;
+{	// unpack uniforms
+	float skyType = u_sky.x;
+
+	float skyBightness = skyType / 2.0f;
+
+	vec3 diffuse_colour = mix(0.25f, 1.0f, skyBightness) * texture2D(s_diffuse, vec2(v_texcoord0.x, v_texcoord0.y)).rgb;
 	vec3 reflect_colour = texture2DProj(s_reflection, v_texcoord1).rgb;
 
 	gl_FragColor = vec4(mix(reflect_colour, diffuse_colour, 0.8), 1.0);

--- a/src/3D/Sky.cpp
+++ b/src/3D/Sky.cpp
@@ -19,9 +19,6 @@
 #include "Game.h"
 #include "Graphics/Texture2D.h"
 
-constexpr std::array<std::string_view, 3> alignments = {"Ntrl", "good", "evil"};
-constexpr std::array<std::string_view, 3> times = {"day", "dusk", "night"};
-
 using namespace openblack::graphics;
 
 namespace openblack
@@ -36,16 +33,16 @@ Sky::Sky()
 	_model = std::make_unique<L3DMesh>("Sky");
 	_model->LoadFromFile(filesystem.WeatherSystemPath() / "sky.l3d");
 
-	for (uint32_t i = 0; i < alignments.size(); i++)
+	for (uint32_t i = 0; i < _alignments.size(); i++)
 	{
-		for (uint32_t j = 0; j < times.size(); j++)
+		for (uint32_t j = 0; j < _times.size(); j++)
 		{
-			auto time = std::string(times[j]);
+			auto time = std::string(_times[j]);
 			if (i == 0)
 			{
 				time[0] = static_cast<char>(std::toupper(static_cast<unsigned char>(time[0])));
 			}
-			std::string filename = fmt::format("sky_{}_{}.555", alignments[i], time);
+			std::string filename = fmt::format("sky_{}_{}.555", _alignments[i], time);
 			if (i == 0)
 			{
 				filename[0] = static_cast<char>(std::toupper(static_cast<unsigned char>(filename[0])));
@@ -54,7 +51,7 @@ Sky::Sky()
 			SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "Loading sky texture: {}", path.generic_string());
 
 			Bitmap16B* bitmap = Bitmap16B::LoadFromFile(path);
-			memcpy(_bitmaps[i * 3 + j].data(), bitmap->Data(), bitmap->Size());
+			memcpy(&_bitmaps[(i * 3 + j) * _textureResolution[0] * _textureResolution[1]], bitmap->Data(), bitmap->Size());
 			delete bitmap;
 		}
 	}
@@ -80,7 +77,7 @@ void Sky::SetTime(float time)
 
 void Sky::Interpolate555Texture(uint16_t* bitmap, uint16_t* bitmap1, uint16_t* bitmap2, float interpolate)
 {
-	for (int i = 0; i < 256 * 256; i++)
+	for (uint32_t i = 0; i < static_cast<uint32_t>(_textureResolution[0]) * static_cast<uint32_t>(_textureResolution[1]); i++)
 	{
 		const auto color1 = glm::u16vec3((bitmap1[i] & 0x7C00) >> 10, (bitmap1[i] & 0x3E0) >> 5, (bitmap1[i] & 0x1F));
 		const auto color2 = glm::u16vec3((bitmap2[i] & 0x7C00) >> 10, (bitmap2[i] & 0x3E0) >> 5, (bitmap2[i] & 0x1F));
@@ -91,11 +88,11 @@ void Sky::Interpolate555Texture(uint16_t* bitmap, uint16_t* bitmap1, uint16_t* b
 
 void Sky::CalculateTextures()
 {
-	std::array<uint16_t, 256 * 256> bitmap;
+	std::array<uint16_t, static_cast<size_t>(_textureResolution[0]) * static_cast<size_t>(_textureResolution[1])> bitmap;
 
-	uint16_t* day = _bitmaps[0].data();
-	uint16_t* dusk = _bitmaps[1].data();
-	uint16_t* night = _bitmaps[2].data();
+	uint16_t* day = &_bitmaps[0 * _textureResolution[0] * _textureResolution[1]];
+	uint16_t* dusk = &_bitmaps[1 * _textureResolution[0] * _textureResolution[1]];
+	uint16_t* night = &_bitmaps[2 * _textureResolution[0] * _textureResolution[1]];
 
 	// 0.00: day
 	// 0.25: dusk
@@ -112,9 +109,12 @@ void Sky::CalculateTextures()
 		Interpolate555Texture(bitmap.data(), dusk, day, (_timeOfDay - 0.75f) * 4.0f);
 
 	// set alpha=1
-	for (unsigned int i = 0; i < 256 * 256; i++) bitmap[i] = bitmap[i] | 0x8000;
+	for (uint32_t i = 0; i < static_cast<uint32_t>(_textureResolution[0]) * static_cast<uint32_t>(_textureResolution[1]); i++)
+	{
+		bitmap[i] = bitmap[i] | 0x8000;
+	}
 
-	_texture->Create(256, 256, 1, Format::RGB5A1, Wrapping::ClampEdge, bitmap.data(),
+	_texture->Create(_textureResolution[0], _textureResolution[1], 1, Format::RGB5A1, Wrapping::ClampEdge, bitmap.data(),
 	                 static_cast<uint32_t>(bitmap.size() * sizeof(bitmap[0])));
 }
 

--- a/src/3D/Sky.cpp
+++ b/src/3D/Sky.cpp
@@ -58,7 +58,9 @@ Sky::Sky()
 
 	_texture = std::make_unique<Texture2D>("Sky");
 	_timeOfDay = 1.0f;
-	CalculateTextures();
+
+	_texture->Create(_textureResolution[0], _textureResolution[1], _textureResolution[2], Format::RGB5A1, Wrapping::ClampEdge,
+	                 _bitmaps.data(), static_cast<uint32_t>(_bitmaps.size() * sizeof(_bitmaps[0])));
 }
 
 void Sky::SetDayNightTimes(float nightFull, float duskStart, float duskEnd, float dayFull)
@@ -71,51 +73,37 @@ void Sky::SetDayNightTimes(float nightFull, float duskStart, float duskEnd, floa
 
 void Sky::SetTime(float time)
 {
+	assert(time <= 24.0f);
 	_timeOfDay = time;
-	CalculateTextures();
 }
 
-void Sky::Interpolate555Texture(uint16_t* bitmap, uint16_t* bitmap1, uint16_t* bitmap2, float interpolate)
+float Sky::GetCurrentSkyType() const
 {
-	for (uint32_t i = 0; i < static_cast<uint32_t>(_textureResolution[0]) * static_cast<uint32_t>(_textureResolution[1]); i++)
+	assert(_timeOfDay <= 24.0f);
+
+	// Reflect time at 12
+	float time = _timeOfDay > 12.0f ? 24.0f - _timeOfDay : _timeOfDay;
+
+	if (time <= _nightFullTime) // In full night
 	{
-		const auto color1 = glm::u16vec3((bitmap1[i] & 0x7C00) >> 10, (bitmap1[i] & 0x3E0) >> 5, (bitmap1[i] & 0x1F));
-		const auto color2 = glm::u16vec3((bitmap2[i] & 0x7C00) >> 10, (bitmap2[i] & 0x3E0) >> 5, (bitmap2[i] & 0x1F));
-		const auto color = glm::mix(color1, color2, interpolate);
-		bitmap[i] = (color.r << 10) | (color.g << 5) | color.b;
+		return 0.0f; // Index for night texture
 	}
-}
-
-void Sky::CalculateTextures()
-{
-	std::array<uint16_t, static_cast<size_t>(_textureResolution[0]) * static_cast<size_t>(_textureResolution[1])> bitmap;
-
-	uint16_t* day = &_bitmaps[0 * _textureResolution[0] * _textureResolution[1]];
-	uint16_t* dusk = &_bitmaps[1 * _textureResolution[0] * _textureResolution[1]];
-	uint16_t* night = &_bitmaps[2 * _textureResolution[0] * _textureResolution[1]];
-
-	// 0.00: day
-	// 0.25: dusk
-	// 0.50: night
-	// 0.75: dusk
-	// 1.00: day
-	if (_timeOfDay < 0.25f)
-		Interpolate555Texture(bitmap.data(), day, dusk, _timeOfDay * 4.0f);
-	else if (_timeOfDay < 0.5f)
-		Interpolate555Texture(bitmap.data(), dusk, night, (_timeOfDay - 0.25f) * 4.0f);
-	else if (_timeOfDay < 0.75f)
-		Interpolate555Texture(bitmap.data(), night, dusk, (_timeOfDay - 0.5f) * 4.0f);
-	else
-		Interpolate555Texture(bitmap.data(), dusk, day, (_timeOfDay - 0.75f) * 4.0f);
-
-	// set alpha=1
-	for (uint32_t i = 0; i < static_cast<uint32_t>(_textureResolution[0]) * static_cast<uint32_t>(_textureResolution[1]); i++)
+	else if (time < _duskStartTime) // Between night and dusk
 	{
-		bitmap[i] = bitmap[i] | 0x8000;
+		return (time - _nightFullTime) / (_duskStartTime - _nightFullTime); // 0 - 1 lerp between night and dusk
 	}
-
-	_texture->Create(_textureResolution[0], _textureResolution[1], 1, Format::RGB5A1, Wrapping::ClampEdge, bitmap.data(),
-	                 static_cast<uint32_t>(bitmap.size() * sizeof(bitmap[0])));
+	else if (time <= _duskEndTime) // In full dusk
+	{
+		return 1.0f; // Index for dusk texture
+	}
+	else if (time < _dayFullTime) // Between dusk and day
+	{
+		return 1.0f + (time - _duskEndTime) / (_dayFullTime - _duskEndTime); // 1 - 2 lerp between dusk and day
+	}
+	else // In full day
+	{
+		return 2.0f; // Index for day texture
+	}
 }
 
 } // namespace openblack

--- a/src/3D/Sky.h
+++ b/src/3D/Sky.h
@@ -34,26 +34,27 @@ public:
 	~Sky() = default;
 
 	void SetDayNightTimes(float nightFull, float duskStart, float duskEnd, float dayFull);
-
-	void Interpolate555Texture(uint16_t* bitmap, uint16_t*, uint16_t*, float);
-
-	void CalculateTextures();
+	/// Time between 0 and 24 in hours
 	void SetTime(float time);
-
-	float TimeOfDay;
+	/// Return index in times as a float for interpolation between adjacent times
+	/// Will use _nightFullTime, _duskStartTime, _duskEndTime and _dayFullTime to determine value
+	/// 0 -> Night (min value)
+	/// 1 -> Dawn/Dusk
+	/// 2 -> Day (max value)
+	float GetCurrentSkyType() const;
 
 private:
 	friend class Renderer;
 
 	static constexpr std::array<std::string_view, 3> _alignments = {
+	    "evil",
 	    "Ntrl",
 	    "good",
-	    "evil",
 	};
 	static constexpr std::array<std::string_view, 3> _times = {
-	    "day",
-	    "dusk",
 	    "night",
+	    "dusk",
+	    "day",
 	};
 	static constexpr std::array<uint16_t, 3> _textureResolution = {
 	    256,

--- a/src/3D/Sky.h
+++ b/src/3D/Sky.h
@@ -44,10 +44,27 @@ public:
 
 private:
 	friend class Renderer;
+
+	static constexpr std::array<std::string_view, 3> _alignments = {
+	    "Ntrl",
+	    "good",
+	    "evil",
+	};
+	static constexpr std::array<std::string_view, 3> _times = {
+	    "day",
+	    "dusk",
+	    "night",
+	};
+	static constexpr std::array<uint16_t, 3> _textureResolution = {
+	    256,
+	    256,
+	    static_cast<uint16_t>(_alignments.size() * _times.size()),
+	};
+
 	std::unique_ptr<L3DMesh> _model;
 	std::unique_ptr<graphics::Texture2D> _texture; // TODO(bwrsandman): put in a resource manager and store look-up
 
-	std::array<std::array<uint16_t, 256 * 256>, 9> _bitmaps;
+	std::array<uint16_t, _textureResolution[0] * _textureResolution[1] * _textureResolution[2]> _bitmaps;
 
 	float _timeOfDay;
 	float _nightFullTime;

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -388,6 +388,8 @@ bool Game::Run()
 		_renderer->ConfigureView(graphics::RenderPass::Reflection, waterWidth, waterHeight);
 	}
 
+	Game::SetTime(_config.timeOfDay);
+
 	_frameCount = 0;
 	auto last_time = std::chrono::high_resolution_clock::now();
 	while (Update())

--- a/src/Game.h
+++ b/src/Game.h
@@ -123,7 +123,8 @@ public:
 		bool drawFootpaths {false};
 		bool drawStreams {false};
 
-		float timeOfDay {1.0f};
+		float timeOfDay {12.0f};
+		float skyAlignment {0.0f};
 		float bumpMapStrength {1.0f};
 		float smallBumpMapStrength {1.0f};
 

--- a/src/Graphics/ShaderManager.cpp
+++ b/src/Graphics/ShaderManager.cpp
@@ -24,6 +24,8 @@
 #include "ShaderIncluder.h"
 #define SHADER_NAME fs_object
 #include "ShaderIncluder.h"
+#define SHADER_NAME fs_sky
+#include "ShaderIncluder.h"
 
 #define SHADER_NAME vs_terrain
 #include "ShaderIncluder.h"
@@ -42,17 +44,15 @@
 namespace openblack::graphics
 {
 
-const bgfx::EmbeddedShader s_embeddedShaders[] = {BGFX_EMBEDDED_SHADER(vs_line),    BGFX_EMBEDDED_SHADER(vs_line_instanced),
-                                                  BGFX_EMBEDDED_SHADER(fs_line),
-
-                                                  BGFX_EMBEDDED_SHADER(vs_object),  BGFX_EMBEDDED_SHADER(vs_object_instanced),
-                                                  BGFX_EMBEDDED_SHADER(fs_object),
-
-                                                  BGFX_EMBEDDED_SHADER(vs_terrain), BGFX_EMBEDDED_SHADER(fs_terrain),
-
-                                                  BGFX_EMBEDDED_SHADER(vs_water),   BGFX_EMBEDDED_SHADER(fs_water),
-
-                                                  BGFX_EMBEDDED_SHADER_END()};
+const bgfx::EmbeddedShader s_embeddedShaders[] = {
+    BGFX_EMBEDDED_SHADER(vs_line),    BGFX_EMBEDDED_SHADER(vs_line_instanced),   //
+    BGFX_EMBEDDED_SHADER(fs_line),                                               //
+    BGFX_EMBEDDED_SHADER(vs_object),  BGFX_EMBEDDED_SHADER(vs_object_instanced), //
+    BGFX_EMBEDDED_SHADER(fs_object),  BGFX_EMBEDDED_SHADER(fs_sky),              //
+    BGFX_EMBEDDED_SHADER(vs_terrain), BGFX_EMBEDDED_SHADER(fs_terrain),          //
+    BGFX_EMBEDDED_SHADER(vs_water),   BGFX_EMBEDDED_SHADER(fs_water),            //
+    BGFX_EMBEDDED_SHADER_END()                                                   //
+};
 
 ShaderManager::~ShaderManager()
 {

--- a/src/Gui/Gui.cpp
+++ b/src/Gui/Gui.cpp
@@ -10,6 +10,7 @@
 #include "Gui.h"
 
 #include <cinttypes>
+#include <cmath>
 
 #include <bgfx/bgfx.h>
 #include <bgfx/embedded_shader.h>
@@ -32,6 +33,7 @@
 #endif
 
 #include <3D/Camera.h>
+#include <3D/Sky.h>
 #include <Common/FileSystem.h>
 #include <ECS/Components/Transform.h>
 #include <ECS/Components/Villager.h>
@@ -703,8 +705,11 @@ bool Gui::ShowMenu(Game& game)
 
 		if (ImGui::BeginMenu("World"))
 		{
-			if (ImGui::SliderFloat("Time of Day", &config.timeOfDay, 0.0f, 1.0f, "%.3f"))
-				Game::instance()->SetTime(config.timeOfDay);
+			if (ImGui::SliderFloat("Time of Day", &config.timeOfDay, 0.0f, 24.0f, "%.3f"))
+				Game::instance()->SetTime(fmodf(config.timeOfDay, 24.0f));
+
+			ImGui::Text("Sky Type Index %f", game.GetSky().GetCurrentSkyType());
+			ImGui::SliderFloat("Sky alignment", &config.skyAlignment, -1.0f, 1.0f, "%.3f");
 
 			ImGui::EndMenu();
 		}

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -322,6 +322,7 @@ void Renderer::DrawScene(const MeshPack& meshPack, const DrawSceneDesc& drawDesc
 			drawPassDesc.drawDebugCross = false;
 			drawPassDesc.drawBoundingBoxes = false;
 			drawPassDesc.cullBack = true;
+
 			DrawPass(meshPack, drawPassDesc);
 		}
 	}
@@ -391,6 +392,8 @@ void Renderer::DrawPass(const MeshPack& meshPack, const DrawSceneDesc& desc) con
 			bgfx::setState(BGFX_STATE_DEFAULT);
 			waterShader->SetTextureSampler("s_diffuse", 0, *desc.water._texture);
 			waterShader->SetTextureSampler("s_reflection", 1, desc.water.GetFrameBuffer().GetColorAttachment());
+			const glm::vec4 u_sky = {desc.sky.GetCurrentSkyType(), 0.0f, 0.0f, 0.0f};
+			waterShader->SetUniformValue("u_sky", &u_sky); // fs
 			bgfx::submit(static_cast<bgfx::ViewId>(desc.viewId), waterShader->GetRawHandle());
 		}
 	}

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -402,12 +402,12 @@ void Renderer::DrawPass(const MeshPack& meshPack, const DrawSceneDesc& desc) con
 				terrainShader->SetTextureSampler("s0_materials", 0, desc.island.GetAlbedoArray());
 				terrainShader->SetTextureSampler("s1_bump", 1, desc.island.GetBump());
 				terrainShader->SetTextureSampler("s2_smallBump", 2, desc.island.GetSmallBump());
-				terrainShader->SetUniformValue("u_timeOfDay", &desc.timeOfDay);
-				terrainShader->SetUniformValue("u_bumpmapStrength", &desc.bumpMapStrength);
-				terrainShader->SetUniformValue("u_smallBumpmapStrength", &desc.smallBumpMapStrength);
 
-				glm::vec4 mapPosition = block.GetMapPosition();
-				terrainShader->SetUniformValue("u_blockPosition", &mapPosition);
+				// pack uniforms
+				const glm::vec4 mapPosition = block.GetMapPosition();
+				terrainShader->SetUniformValue("u_blockPosition", &mapPosition); // vs
+				const glm::vec4 u_timeOfDayBump = {desc.timeOfDay, desc.bumpMapStrength, desc.smallBumpMapStrength, 0.0f};
+				terrainShader->SetUniformValue("u_timeOfDayBump", &u_timeOfDayBump); // fs
 
 				// clang-format off
 				constexpr auto defaultState = 0u

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -466,6 +466,10 @@ void Renderer::DrawPass(const MeshPack& meshPack, const DrawSceneDesc& desc) con
 					submitDesc.modelMatrices = &identity;
 					submitDesc.matrixCount = 1;
 				}
+
+				const glm::vec4 u_sky = {desc.sky.GetCurrentSkyType(), 0.0f, 0.0f, 0.0f};
+				objectShaderInstanced->SetUniformValue("u_sky", &u_sky); // fs
+
 				// TODO(bwrsandman): choose the correct LOD
 				DrawMesh(mesh, meshPack, submitDesc, std::numeric_limits<uint8_t>::max());
 			}

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -64,6 +64,7 @@ constexpr std::array Shaders {
     ShaderDefinition {"Terrain", "vs_terrain", "fs_terrain"},
     ShaderDefinition {"Object", "vs_object", "fs_object"},
     ShaderDefinition {"ObjectInstanced", "vs_object_instanced", "fs_object"},
+    ShaderDefinition {"Sky", "vs_object", "fs_sky"},
     ShaderDefinition {"Water", "vs_water", "fs_water"},
 };
 


### PR DESCRIPTION
Implement the sky texture interpolation as in fragment shader.
Make use of the time of day values for night, dusk and day.
Use that value for terrain brightness

https://user-images.githubusercontent.com/1013356/149610939-baa9642a-b44a-45a5-8433-475994856950.mp4
