### PR TITLE
CI System Deps: Speed-up compilation

### DIFF
--- a/.github/workflows/ci-system-deps.yml
+++ b/.github/workflows/ci-system-deps.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install dependencies and configure system
         run: |
           pacman -Syu --noconfirm --noprogressbar --needed git cmake mesa libx11 fmt spdlog sdl2 glm bullet
-          sed -i "s|MAKEFLAGS=.*|MAKEFLAGS=-j$(nproc)|" /etc/makepkg.conf
+          sed -E -i "s|#? ?MAKEFLAGS=.*|MAKEFLAGS=-j$(nproc)|" /etc/makepkg.conf
           useradd builduser -p ""
           printf 'builduser ALL=(ALL) ALL\n' >> /etc/sudoers
 


### PR DESCRIPTION
It dawned on me that the system deps are probably compiling single threaded.
On a new system, `MAKEFLAGS` is commented out.
This change to the regex makes sure to uncomment the line if it is commented out.

For reference ubuntu vcpkg config takes 2 minutes 25 seconds to compile