### PR TITLE
ci: Upload artifacts of builds

### DIFF
--- a/.github/workflows/ci-cross-compile.yml
+++ b/.github/workflows/ci-cross-compile.yml
@@ -56,5 +56,16 @@ jobs:
           configurePreset: '${{ matrix.preset }}'
           buildPreset: '${{ matrix.preset }}-${{ matrix.config }}'
 
+      - id: configstring
+        uses: ASzc/change-string-case-action@v2
+        with:
+          string: ${{ matrix.config }}
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: openblack-${{ matrix.triplet || matrix.ninja-multi-vcpkg }}-${{ matrix.config }}
+          path: cmake-build-presets/ninja-multi-vcpkg/bin/${{ steps.configstring.outputs.capitalized }}/*
+          if-no-files-found: error
+
     env:
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}

--- a/.github/workflows/ci-cross-compile.yml
+++ b/.github/workflows/ci-cross-compile.yml
@@ -56,15 +56,10 @@ jobs:
           configurePreset: '${{ matrix.preset }}'
           buildPreset: '${{ matrix.preset }}-${{ matrix.config }}'
 
-      - id: configstring
-        uses: ASzc/change-string-case-action@v2
-        with:
-          string: ${{ matrix.config }}
-
       - uses: actions/upload-artifact@v3
         with:
-          name: openblack-${{ matrix.triplet || matrix.ninja-multi-vcpkg }}-${{ matrix.config }}
-          path: cmake-build-presets/ninja-multi-vcpkg/bin/${{ steps.configstring.outputs.capitalized }}/*
+          name: openblack-${{ matrix.triplet || matrix.ninja-multi-vcpkg }}
+          path: cmake-build-presets/ninja-multi-vcpkg/bin
           if-no-files-found: error
 
     env:

--- a/.github/workflows/ci-cross-compile.yml
+++ b/.github/workflows/ci-cross-compile.yml
@@ -58,7 +58,7 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: openblack-${{ matrix.triplet || matrix.ninja-multi-vcpkg }}
+          name: openblack-${{ matrix.triplet || matrix.ninja-multi-vcpkg }}-${{github.sha}}
           path: cmake-build-presets/ninja-multi-vcpkg/bin
           if-no-files-found: error
 

--- a/.github/workflows/ci-system-deps.yml
+++ b/.github/workflows/ci-system-deps.yml
@@ -69,6 +69,6 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: openblack-arch-linux-pkg
+          name: openblack-arch-linux-pkg-${{github.sha}}
           path: /tmp/openblack-git/openblack-git*.pkg.tar.*
           if-no-files-found: error

--- a/.github/workflows/ci-system-deps.yml
+++ b/.github/workflows/ci-system-deps.yml
@@ -66,3 +66,9 @@ jobs:
           cd /tmp/openblack-git
           sed "s,source=.*,source=('openblack::git+file://${GITHUB_WORKSPACE}')," -i PKGBUILD
           sudo -u builduser makepkg
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: openblack-arch-linux-pkg
+          path: /tmp/openblack-git/openblack-git*.pkg.tar.*
+          if-no-files-found: error

--- a/.github/workflows/ci-vcpkg.yml
+++ b/.github/workflows/ci-vcpkg.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: matrix.cc == ''
         with:
-          name: openblack-${{ matrix.os }}
+          name: openblack-${{ matrix.os }}-${{github.sha}}
           path: cmake-build-presets/ninja-multi-vcpkg/bin
           if-no-files-found: error
 

--- a/.github/workflows/ci-vcpkg.yml
+++ b/.github/workflows/ci-vcpkg.yml
@@ -55,15 +55,11 @@ jobs:
           buildPreset: 'ninja-multi-vcpkg-${{ matrix.config }}'
           # testPreset: 'ninja-multi-vcpkg-${{ matrix.config }}'
 
-      - id: configstring
-        uses: ASzc/change-string-case-action@v2
-        with:
-          string: ${{ matrix.config }}
-
       - uses: actions/upload-artifact@v3
+        if: matrix.cc == ''
         with:
-          name: openblack-${{ matrix.os }}-${{ matrix.cc || matrix.config }}
-          path: cmake-build-presets/ninja-multi-vcpkg/bin/${{ steps.configstring.outputs.capitalized }}/
+          name: openblack-${{ matrix.os }}
+          path: cmake-build-presets/ninja-multi-vcpkg/bin
           if-no-files-found: error
 
     env:

--- a/.github/workflows/ci-vcpkg.yml
+++ b/.github/workflows/ci-vcpkg.yml
@@ -55,6 +55,17 @@ jobs:
           buildPreset: 'ninja-multi-vcpkg-${{ matrix.config }}'
           # testPreset: 'ninja-multi-vcpkg-${{ matrix.config }}'
 
+      - id: configstring
+        uses: ASzc/change-string-case-action@v2
+        with:
+          string: ${{ matrix.config }}
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: openblack-${{ matrix.os }}-${{ matrix.cc || matrix.config }}
+          path: cmake-build-presets/ninja-multi-vcpkg/bin/${{ steps.configstring.outputs.capitalized }}/
+          if-no-files-found: error
+
     env:
       CC: ${{ matrix.cc }}
       CXX: ${{ matrix.cxx }}

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -39,5 +39,5 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: formatting-fix
+          name: formatting-fix-${{github.sha}}
           path: format.patch

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -39,4 +39,5 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
+          name: formatting-fix
           path: format.patch


### PR DESCRIPTION
Each build will now provide artifacts in the summary of `VCPKG CI`, `Cross Compile CI` and `System Deps CI`.
We can provide these artifacts to users who don't know how to build, we can use them for tagged releases and we can also use them to quickly test a PR.

There may be a way to combine windows Debug and Release artifacts by giving them the same artifact name which will give an artifact with `Debug/` and `Release/` but that would require too much logic in the yaml file and I didn't do this way.

![Screenshot from 2022-04-14 09-09-48](https://user-images.githubusercontent.com/1013356/163397513-dc71fcf0-c6a3-4bc7-a149-d49e732401e9.png)
