### PR TITLE
Restore windows-2019 tests

### DIFF
--- a/.github/workflows/ci-vcpkg.yml
+++ b/.github/workflows/ci-vcpkg.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         # This is the matrix. They form permutations.
-        os: [ubuntu-latest, macos-latest, windows-latest, windows-2022]
+        os: [ubuntu-latest, macos-latest, windows-latest, windows-2019]
         config: [debug, release]
         cc: [""]
         cxx: [""]


### PR DESCRIPTION
According to https://github.com/actions/virtual-environments, windows-2022 and windows-latest are now the same