### PR TITLE
water: Perform y-flip for texProj on non OpenGL platforms

### DIFF
--- a/assets/shaders/vs_water.sc
+++ b/assets/shaders/vs_water.sc
@@ -5,10 +5,11 @@ $output v_texcoord0, v_texcoord1
 
 vec4 ScreenSpacePosition(vec4 position)
 {
-	vec4 v = (position * 0.5);
-    v.xy = (vec2(v.x, v.y) + v.w);
-    v.zw = position.zw;
-
+    vec4 v = position;
+#if !BGFX_SHADER_LANGUAGE_GLSL
+    v.y *= -1.0f;
+#endif
+    v.xy = (v.xy + v.w) * 0.5f;
     return v;
 }
 


### PR DESCRIPTION
OpenGL is unique in the way it orients the y coordinate internally.
Here `texProj` was sampling the reflection framebuffer upside down.

I didn't check Direct3D but I assume the same issue is present and fixed

![Screenshot from 2022-04-19 11-47-50](https://user-images.githubusercontent.com/1013356/164051178-95f51e47-4792-4d43-90b5-697753f84e8e.png)
