### PR TITLE
Reset bgfx and camera projection on window resize

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -179,6 +179,16 @@ bool Game::ProcessEvents(const SDL_Event& event)
 		{
 			return false;
 		}
+		else if (event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED)
+		{
+			uint16_t width = static_cast<uint16_t>(event.window.data1);
+			uint16_t height = static_cast<uint16_t>(event.window.data2);
+			_renderer->Reset(width, height);
+			_renderer->ConfigureView(graphics::RenderPass::Main, width, height);
+
+			auto aspect = _window->GetAspectRatio();
+			_camera->SetProjectionMatrixPerspective(_config.cameraXFov, aspect, _config.cameraNearClip, _config.cameraFarClip);
+		}
 		break;
 	case SDL_KEYDOWN:
 		switch (event.key.keysym.sym)

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -392,7 +392,7 @@ bool Game::Run()
 	// create our camera
 	_camera = std::make_unique<Camera>();
 	auto aspect = _window ? _window->GetAspectRatio() : 1.0f;
-	_camera->SetProjectionMatrixPerspective(70.0f, aspect, 1.0f, 65536.0f);
+	_camera->SetProjectionMatrixPerspective(_config.cameraXFov, aspect, _config.cameraNearClip, _config.cameraFarClip);
 
 	_camera->SetPosition(glm::vec3(1441.56f, 24.764f, 2081.76f));
 	_camera->SetRotation(glm::vec3(0.0f, -45.0f, 0.0f));

--- a/src/Game.h
+++ b/src/Game.h
@@ -137,6 +137,10 @@ public:
 		float bumpMapStrength {1.0f};
 		float smallBumpMapStrength {1.0f};
 
+		float cameraXFov {70.0f};
+		float cameraNearClip {1.0f};
+		float cameraFarClip {static_cast<float>(0x10000)};
+
 		bool bgfxDebug {false};
 		bool bgfxProfile {false};
 		bool running {false};

--- a/src/Gui/Gui.cpp
+++ b/src/Gui/Gui.cpp
@@ -209,6 +209,12 @@ bool Gui::ProcessEventSdl2(const SDL_Event& event)
 		io.KeySuper = ((SDL_GetModState() & KMOD_GUI) != 0);
 		return io.WantCaptureKeyboard;
 	}
+	case SDL_WINDOWEVENT:
+		if (event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED)
+		{
+			return false;
+		}
+		break;
 	}
 	return io.WantCaptureMouse;
 }

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -135,11 +135,12 @@ Renderer::Renderer(const GameWindow* window, bgfx::RendererType::Enum rendererTy
 		window->GetNativeHandles(init.platformData.nwh, init.platformData.ndt);
 	}
 
-	init.resolution.reset = BGFX_RESET_NONE;
+	_bgfxReset = BGFX_RESET_NONE;
 	if (vsync)
 	{
-		init.resolution.reset |= BGFX_RESET_VSYNC;
+		_bgfxReset |= BGFX_RESET_VSYNC;
 	}
+	init.resolution.reset = _bgfxReset;
 	init.callback = dynamic_cast<bgfx::CallbackI*>(_bgfxCallback.get());
 
 #ifdef __APPLE__

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -188,6 +188,11 @@ void Renderer::ConfigureView(graphics::RenderPass viewId, uint16_t width, uint16
 	bgfx::setViewRect(static_cast<bgfx::ViewId>(viewId), 0, 0, width, height);
 }
 
+void Renderer::Reset(uint16_t width, uint16_t height) const
+{
+	bgfx::reset(width, height, _bgfxReset);
+}
+
 graphics::ShaderManager& Renderer::GetShaderManager() const
 {
 	return *_shaderManager;

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -122,6 +122,7 @@ private:
 
 	std::unique_ptr<graphics::ShaderManager> _shaderManager;
 	std::unique_ptr<BgfxCallback> _bgfxCallback;
+	uint32_t _bgfxReset;
 
 	std::unique_ptr<graphics::Mesh> _debugCross;
 	std::unique_ptr<graphics::Mesh> _plane;

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -115,6 +115,8 @@ public:
 	void DrawMesh(const L3DMesh& mesh, const MeshPack& meshPack, const L3DMeshSubmitDesc& desc, uint8_t subMeshIndex) const;
 	void Frame();
 
+	void Reset(uint16_t width, uint16_t height) const;
+
 private:
 	void DrawSubMesh(const L3DMesh& mesh, const L3DSubMesh& subMesh, const MeshPack& meshPack, const L3DMeshSubmitDesc& desc,
 	                 bool preserveState) const;


### PR DESCRIPTION
On window resize events, perform a [bgfx::reset](https://bkaradzic.github.io/bgfx/bgfx.html) to reset framebuffers, and reset camera projection.

Fixes #100, #211