### PR TITLE
logging: Undo regression to logger for debug builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,11 +115,12 @@ target_compile_definitions(openblack_lib
   "GLM_FORCE_LEFT_HANDED"
   "GLM_FORCE_RADIANS"
   "GLM_ENABLE_EXPERIMENTAL"
-  "$<$<CONFIG:DEBUG>:OPENBLACK_DEBUG>"
   # Compile-time optimize out log messages (debug level if debug, else info)
   "SPDLOG_ACTIVE_LEVEL=$<IF:$<CONFIG:DEBUG>,SPDLOG_LEVEL_DEBUG,SPDLOG_LEVEL_INFO>"
   # Suppress WinMain() and main hijacking, provided by SDL
   "SDL_MAIN_HANDLED"
+  PUBLIC
+  "$<$<CONFIG:DEBUG>:OPENBLACK_DEBUG>"
 )
 
 if(MSVC)


### PR DESCRIPTION
When we moved to static lib, we lost logging to the console for debug builds.