### PR TITLE
Use Loader API to load all raw textures

### DIFF
--- a/src/ECS/Archetypes/CameraBookmarkArchetype.cpp
+++ b/src/ECS/Archetypes/CameraBookmarkArchetype.cpp
@@ -14,14 +14,16 @@
 #include "ECS/Registry.h"
 #include "Game.h"
 #include "Graphics/Texture2D.h"
+#include "Locator.h"
 
 using namespace openblack;
 using namespace openblack::ecs::archetypes;
 using namespace openblack::ecs::components;
 
-std::array<entt::entity, 8> CameraBookmarkArchetype::CreateAll(const graphics::Texture2D& texture)
+std::array<entt::entity, 8> CameraBookmarkArchetype::CreateAll()
 {
 	auto& registry = Game::instance()->GetEntityRegistry();
+	auto texture = Locator::resources::ref().GetTextures().Handle(entt::hashed_string("raw/misc0a"));
 
 	auto result = std::array<entt::entity, 8>();
 
@@ -31,7 +33,7 @@ std::array<entt::entity, 8> CameraBookmarkArchetype::CreateAll(const graphics::T
 	for (size_t i = 0; i < result.size(); ++i)
 	{
 		float u = static_cast<float>(i) / static_cast<float>(result.size());
-		registry.Assign<Sprite>(result[i], texture.GetNativeHandle(), glm::vec2 {u, 3.0f / 8.0f}, extent, tint);
+		registry.Assign<Sprite>(result[i], texture->GetNativeHandle(), glm::vec2 {u, 3.0f / 8.0f}, extent, tint);
 		registry.Assign<CameraBookmark>(result[i], static_cast<uint8_t>(i + 1), 0.0f);
 	}
 

--- a/src/ECS/Archetypes/CameraBookmarkArchetype.h
+++ b/src/ECS/Archetypes/CameraBookmarkArchetype.h
@@ -13,18 +13,13 @@
 
 #include <entt/fwd.hpp>
 
-namespace openblack::graphics
-{
-class Texture2D;
-}
-
 namespace openblack::ecs::archetypes
 {
 
 class CameraBookmarkArchetype
 {
 public:
-	static std::array<entt::entity, 8> CreateAll(const graphics::Texture2D& texture);
+	static std::array<entt::entity, 8> CreateAll();
 };
 
 } // namespace openblack::ecs::archetypes

--- a/src/ECS/Systems/CameraBookmarkSystem.cpp
+++ b/src/ECS/Systems/CameraBookmarkSystem.cpp
@@ -15,7 +15,6 @@
 #include "ECS/Components/Transform.h"
 #include "ECS/Registry.h"
 #include "Game.h"
-#include "Graphics/Texture2D.h"
 
 using namespace openblack::ecs::systems;
 using namespace openblack::ecs::components;
@@ -32,9 +31,9 @@ CameraBookmarkSystem& CameraBookmarkSystem::instance()
 
 CameraBookmarkSystem::CameraBookmarkSystem() = default;
 
-bool CameraBookmarkSystem::Initialize(const graphics::Texture2D& texture)
+bool CameraBookmarkSystem::Initialize()
 {
-	_bookmarks = archetypes::CameraBookmarkArchetype::CreateAll(texture);
+	_bookmarks = archetypes::CameraBookmarkArchetype::CreateAll();
 	return true;
 }
 

--- a/src/ECS/Systems/CameraBookmarkSystem.h
+++ b/src/ECS/Systems/CameraBookmarkSystem.h
@@ -10,17 +10,11 @@
 #pragma once
 
 #include <array>
-
-#include <filesystem>
+#include <chrono>
 #include <memory>
 
 #include "entt/fwd.hpp"
 #include "glm/vec3.hpp"
-
-namespace openblack::graphics
-{
-class Texture2D;
-}
 
 namespace openblack::ecs::systems
 {
@@ -28,7 +22,7 @@ class CameraBookmarkSystem
 {
 public:
 	static CameraBookmarkSystem& instance();
-	bool Initialize(const graphics::Texture2D& texture);
+	bool Initialize();
 	void Update(const std::chrono::microseconds& dt) const;
 
 	const std::array<entt::entity, 8>& GetBookmarks() const { return _bookmarks; }

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -136,7 +136,6 @@ Game::Game(Arguments&& args)
 
 Game::~Game()
 {
-	_misc0aTexture.reset();
 	_water.reset();
 	_sky.reset();
 	_animationPack.reset();
@@ -436,17 +435,8 @@ bool Game::Run()
 	_sky = std::make_unique<Sky>();
 	_water = std::make_unique<Water>();
 
-	_misc0aTexture = std::make_unique<graphics::Texture2D>("misc0a.raw");
-	{
-		const uint16_t width = 256;
-		const uint16_t height = 256;
-		const uint16_t bpp = 1;
-		uint32_t size = width * height * bpp;
-		auto data = _fileSystem->ReadAll(_fileSystem->TexturePath() / _misc0aTexture->GetName());
-		assert(data.size() == size);
-		_misc0aTexture->Create(width, height, 1, graphics::Format::R8, graphics::Wrapping::ClampEdge, data.data(), data.size());
-	}
-	CameraBookmarkSystem::instance().Initialize(*_misc0aTexture);
+	textureManager.Load("raw/misc0a", _fileSystem->TexturePath() / "misc0a.raw");
+	CameraBookmarkSystem::instance().Initialize();
 
 	if (!LoadVariables())
 	{
@@ -557,7 +547,7 @@ void Game::LoadMap(const std::filesystem::path& path)
 	// Reset everything. Deletes all entities and their components
 	_entityRegistry->Reset();
 
-	CameraBookmarkSystem::instance().Initialize(*_misc0aTexture);
+	CameraBookmarkSystem::instance().Initialize();
 	// We need a hand for the player
 	_handEntity = ecs::archetypes::HandArchetype::Create(glm::vec3(0.0f), glm::half_pi<float>(), 0.0f, glm::half_pi<float>(),
 	                                                     0.01f, false);

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -390,7 +390,7 @@ bool Game::Run()
 	auto& animationManager = resources.GetAnimations();
 
 	meshManager.Load("hand", "hand", _fileSystem->FindPath(_fileSystem->CreatureMeshPath() / "Hand_Boned_Base2.l3d"));
-	meshManager.Load("testModel", "test_model", _fileSystem->FindPath(_fileSystem->MiscPath() / "coffre.l3d"));
+	meshManager.Load("coffre", "coffre", _fileSystem->FindPath(_fileSystem->MiscPath() / "coffre.l3d"));
 	pack::PackFile pack;
 	pack.Open(_fileSystem->FindPath(_fileSystem->DataPath() / "AllMeshes.g3d"));
 	auto& meshes = pack.GetMeshes();
@@ -406,7 +406,7 @@ bool Game::Run()
 		textureManager.Load(g3dTexture.header.id, name, g3dTexture);
 	}
 
-	animationManager.Load("testAnimation", _fileSystem->FindPath(_fileSystem->MiscPath() / "coffre.anm"));
+	animationManager.Load("coffre", _fileSystem->FindPath(_fileSystem->MiscPath() / "coffre.anm"));
 	pack::PackFile animationPack;
 	animationPack.Open(_fileSystem->FindPath(_fileSystem->DataPath() / "AllAnims.anm"));
 	auto& animations = animationPack.GetAnimations();

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -435,7 +435,21 @@ bool Game::Run()
 	_sky = std::make_unique<Sky>();
 	_water = std::make_unique<Water>();
 
-	textureManager.Load("raw/misc0a", _fileSystem->TexturePath() / "misc0a.raw");
+	for (const auto& f : std::filesystem::directory_iterator {_fileSystem->FindPath(_fileSystem->TexturePath())})
+	{
+		if (f.path().extension() == ".raw")
+		{
+			SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "Loading raw texture: {}", f.path().stem().string());
+			try
+			{
+				textureManager.Load(("raw" / f.path().stem()).string(), f);
+			}
+			catch (std::runtime_error& err)
+			{
+				SPDLOG_LOGGER_ERROR(spdlog::get("game"), "{}", err.what());
+			}
+		}
+	}
 	CameraBookmarkSystem::instance().Initialize();
 
 	if (!LoadVariables())

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -389,8 +389,8 @@ bool Game::Run()
 	auto& textureManager = resources.GetTextures();
 	auto& animationManager = resources.GetAnimations();
 
-	meshManager.Load("hand", "hand", _fileSystem->FindPath(_fileSystem->CreatureMeshPath() / "Hand_Boned_Base2.l3d"));
-	meshManager.Load("coffre", "coffre", _fileSystem->FindPath(_fileSystem->MiscPath() / "coffre.l3d"));
+	meshManager.Load("hand", _fileSystem->FindPath(_fileSystem->CreatureMeshPath() / "Hand_Boned_Base2.l3d"));
+	meshManager.Load("coffre", _fileSystem->FindPath(_fileSystem->MiscPath() / "coffre.l3d"));
 	pack::PackFile pack;
 	pack.Open(_fileSystem->FindPath(_fileSystem->DataPath() / "AllMeshes.g3d"));
 	auto& meshes = pack.GetMeshes();

--- a/src/Game.h
+++ b/src/Game.h
@@ -212,7 +212,6 @@ private:
 	std::unique_ptr<L3DMesh> _testModel;
 	std::unique_ptr<L3DAnim> _testAnimation;
 	std::unique_ptr<L3DMesh> _handModel;
-	std::unique_ptr<graphics::Texture2D> _misc0aTexture;
 	std::unique_ptr<Sky> _sky;
 	std::unique_ptr<Water> _water;
 	std::unique_ptr<lhscriptx::Script> _scriptx;

--- a/src/Graphics/Texture2D.h
+++ b/src/Graphics/Texture2D.h
@@ -110,6 +110,7 @@ public:
 	[[nodiscard]] uint16_t GetWidth() const { return _info.width; }
 	[[nodiscard]] uint16_t GetHeight() const { return _info.height; }
 	[[nodiscard]] uint16_t GetLayerCount() const { return _info.numLayers; }
+	[[nodiscard]] bgfx::TextureFormat::Enum GetFormat() const { return _info.format; }
 
 	void DumpTexture() const;
 

--- a/src/Gui/Gui.cpp
+++ b/src/Gui/Gui.cpp
@@ -47,6 +47,7 @@
 #include "LandIsland.h"
 #include "MeshViewer.h"
 #include "Profiler.h"
+#include "TextureViewer.h"
 
 // Turn off formatting because it adds spaces which break the stringifying
 // clang-format off
@@ -98,6 +99,7 @@ std::unique_ptr<Gui> Gui::create(const GameWindow* window, graphics::RenderPass 
 	std::vector<std::unique_ptr<DebugWindow>> debugWindows;
 	debugWindows.emplace_back(new Profiler);
 	debugWindows.emplace_back(new MeshViewer);
+	debugWindows.emplace_back(new TextureViewer);
 	debugWindows.emplace_back(new Console);
 	debugWindows.emplace_back(new LandIsland);
 	debugWindows.emplace_back(new LHVMViewer);

--- a/src/Gui/TextureViewer.cpp
+++ b/src/Gui/TextureViewer.cpp
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2018-2022 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ ******************************************************************************/
+
+#include "TextureViewer.h"
+
+#include "Graphics/Texture2D.h"
+#include "Gui/Gui.h"
+#include "Locator.h"
+
+using namespace openblack;
+using namespace openblack::gui;
+
+TextureViewer::TextureViewer()
+    : DebugWindow("Texture Viewer", ImVec2(950.0f, 780.0f))
+{
+}
+
+void TextureViewer::Draw(Game& game)
+{
+	float fontSize = ImGui::GetFontSize();
+	auto const& textures = Locator::resources::ref().GetTextures();
+
+	_filter.Draw();
+
+	ImGui::BeginChild("textures", ImVec2(fontSize * 15.0f, 0));
+	auto textureSize = ImGui::GetItemRectSize();
+	ImGui::BeginChild("texturesSelect", ImVec2(textureSize.x - 5, textureSize.y - ImGui::GetTextLineHeight() - 5), true);
+	uint32_t displayedTexture = 0;
+
+	textures.Each([this, &displayedTexture](entt::id_type id, entt::resource_handle<const graphics::Texture2D> texture) {
+		if (_filter.PassFilter(texture->GetName().c_str()))
+		{
+			displayedTexture++;
+
+			if (ImGui::Selectable(texture->GetName().c_str(), id == _selectedTexture))
+			{
+				_selectedTexture = id;
+			}
+			if (ImGui::IsItemHovered())
+			{
+				ImGui::SetTooltip("%s", texture->GetName().c_str());
+			}
+		}
+	});
+	ImGui::EndChild();
+	ImGui::Text("%u textures", displayedTexture);
+	ImGui::EndChild();
+
+	ImGui::SameLine();
+
+	ImGui::BeginChild("viewer", ImVec2(fontSize * -15.0f, 0));
+
+	auto texture = textures.Handle(_selectedTexture);
+	if (texture)
+	{
+		const auto format = texture->GetFormat();
+		std::string formatStr = std::to_string(format);
+		if (format == bgfx::TextureFormat::R8)
+		{
+			formatStr = "R8";
+		}
+		else if (format == bgfx::TextureFormat::RGB8)
+		{
+			formatStr = "RGB8";
+		}
+		ImGui::Text("width: %u, height: %u, format: %s", texture->GetWidth(), texture->GetHeight(), formatStr.c_str());
+		ImGui::Image(texture->GetNativeHandle(), ImVec2(512, 512));
+	}
+
+	ImGui::EndChild();
+}
+
+void TextureViewer::Update(Game& game, const Renderer& renderer) {}
+
+void TextureViewer::ProcessEventOpen([[maybe_unused]] const SDL_Event& event) {}
+
+void TextureViewer::ProcessEventAlways([[maybe_unused]] const SDL_Event& event) {}

--- a/src/Gui/TextureViewer.h
+++ b/src/Gui/TextureViewer.h
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2018-2022 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ ******************************************************************************/
+
+#pragma once
+
+#include "DebugWindow.h"
+
+#include <entt/fwd.hpp>
+
+namespace openblack
+{
+
+namespace gui
+{
+class TextureViewer: public DebugWindow
+{
+public:
+	TextureViewer();
+
+protected:
+	void Draw(Game& game) override;
+	void Update(Game& game, const Renderer& renderer) override;
+	void ProcessEventOpen(const SDL_Event& event) override;
+	void ProcessEventAlways(const SDL_Event& event) override;
+
+private:
+	entt::id_type _selectedTexture;
+	ImGuiTextFilter _filter;
+};
+} // namespace gui
+
+} // namespace openblack

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -581,8 +581,8 @@ void Renderer::DrawPass(const resources::MeshManager& meshes, const resources::T
 				| BGFX_STATE_MSAA
 			;
 			// clang-format on
-			const auto& mesh = meshes.Handle(entt::hashed_string("testModel"));
-			const auto& testAnimation = Locator::resources::ref().GetAnimations().Handle(entt::hashed_string("testAnimation"));
+			const auto& mesh = meshes.Handle(entt::hashed_string("coffre"));
+			const auto& testAnimation = Locator::resources::ref().GetAnimations().Handle(entt::hashed_string("coffre"));
 			const std::vector<uint32_t>& boneParents = mesh->GetBoneParents();
 			auto bones = testAnimation->GetBoneMatrices(desc.time);
 			for (uint32_t i = 0; i < bones.size(); ++i)

--- a/src/Resources/Loaders.cpp
+++ b/src/Resources/Loaders.cpp
@@ -26,9 +26,9 @@ entt::resource_handle<L3DMesh> L3DLoader::load(const std::string& debugName, con
 	return mesh;
 }
 
-entt::resource_handle<L3DMesh> L3DLoader::load(const std::string& debugName, const std::filesystem::path& path) const
+entt::resource_handle<L3DMesh> L3DLoader::load(const std::filesystem::path& path) const
 {
-	auto mesh = std::make_shared<L3DMesh>(debugName);
+	auto mesh = std::make_shared<L3DMesh>(path.stem().string());
 	if (!mesh->LoadFromFile(path))
 	{
 		throw std::runtime_error("Unable to load mesh");

--- a/src/Resources/Loaders.h
+++ b/src/Resources/Loaders.h
@@ -38,6 +38,7 @@ struct Texture2DLoader final: BaseLoader<Texture2DLoader, graphics::Texture2D>
 {
 	[[nodiscard]] entt::resource_handle<graphics::Texture2D> load(const std::string& name,
 	                                                              const pack::G3DTexture g3dTexture) const;
+	[[nodiscard]] entt::resource_handle<graphics::Texture2D> load(const std::filesystem::path& rawTexturePath) const;
 };
 
 struct L3DAnimLoader final: BaseLoader<L3DAnimLoader, L3DAnim>

--- a/src/Resources/Loaders.h
+++ b/src/Resources/Loaders.h
@@ -31,7 +31,7 @@ struct L3DLoader final: BaseLoader<L3DLoader, L3DMesh>
 {
 	[[nodiscard]] entt::resource_handle<L3DMesh> load(const std::string& debugName, const std::vector<uint8_t>& data) const;
 
-	[[nodiscard]] entt::resource_handle<L3DMesh> load(const std::string& debugName, const std::filesystem::path& path) const;
+	[[nodiscard]] entt::resource_handle<L3DMesh> load(const std::filesystem::path& path) const;
 };
 
 struct Texture2DLoader final: BaseLoader<Texture2DLoader, graphics::Texture2D>


### PR DESCRIPTION
* Cleaned up our resource loading.
* If loading from a path, use the stem (base name without extension) as the id.
* Add viewer for textures

![Screenshot from 2022-04-19 21-41-07](https://user-images.githubusercontent.com/1013356/164129817-54b8b277-3f52-4f70-8c7e-8bb1eb961d5b.png)
