### PR TITLE
Renderer: Use locator instead of passing managers as args

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -135,6 +135,12 @@ Game::Game(Arguments&& args)
 
 Game::~Game()
 {
+	// Manually delete the assets here before BGFX renderer clears its buffers resulting in invalid handles in our assets
+	auto& resources = Locator::resources::ref();
+	resources.GetMeshes().Clear();
+	resources.GetTextures().Clear();
+	resources.GetAnimations().Clear();
+
 	_water.reset();
 	_sky.reset();
 	_dynamicsSystem.reset();
@@ -541,11 +547,6 @@ bool Game::Run()
 		}
 		_frameCount++;
 	}
-
-	// Manually delete the assets here before BGFX renderer clears its buffers resulting in invalid handles in our assets
-	meshManager.Clear();
-	textureManager.Clear();
-	animationManager.Clear();
 
 	return true;
 }

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -533,7 +533,7 @@ bool Game::Run()
 			    /*smallBumpMapStrength =*/_config.smallBumpMapStrength,
 			};
 
-			_renderer->DrawScene(meshManager, textureManager, drawDesc);
+			_renderer->DrawScene(drawDesc);
 		}
 
 		{

--- a/src/Gui/MeshViewer.cpp
+++ b/src/Gui/MeshViewer.cpp
@@ -197,7 +197,6 @@ void MeshViewer::Draw(Game& game)
 void MeshViewer::Update(Game& game, const Renderer& renderer)
 {
 	auto const& meshes = Locator::resources::ref().GetMeshes();
-	auto const& textures = Locator::resources::ref().GetTextures();
 	auto const& animations = Locator::resources::ref().GetAnimations();
 	auto& shaderManager = game.GetRenderer().GetShaderManager();
 	auto objectShader = shaderManager.GetShader("Object");
@@ -263,7 +262,7 @@ void MeshViewer::Update(Game& game, const Renderer& renderer)
 			desc.modelMatrices = bones.data();
 			desc.matrixCount = static_cast<uint8_t>(bones.size());
 		}
-		renderer.DrawMesh(*mesh, textures, desc, static_cast<uint8_t>(_selectedSubMesh));
+		renderer.DrawMesh(*mesh, desc, static_cast<uint8_t>(_selectedSubMesh));
 		if (_viewBoundingBox)
 		{
 			auto box = mesh->GetBoundingBox();

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -109,17 +109,13 @@ public:
 
 	void ConfigureView(graphics::RenderPass viewId, uint16_t width, uint16_t height) const;
 
-	void DrawScene(const resources::MeshManager& meshes, const resources::TextureManager& textures,
-	               const DrawSceneDesc& drawDesc) const;
-	void DrawMesh(const L3DMesh& mesh, const resources::TextureManager& textures, const L3DMeshSubmitDesc& desc,
-	              uint8_t subMeshIndex) const;
+	void DrawScene(const DrawSceneDesc& drawDesc) const;
+	void DrawMesh(const L3DMesh& mesh, const L3DMeshSubmitDesc& desc, uint8_t subMeshIndex) const;
 	void Frame();
 
 private:
-	void DrawSubMesh(const L3DMesh& mesh, const L3DSubMesh& subMesh, const resources::TextureManager& textures,
-	                 const L3DMeshSubmitDesc& desc, bool preserveState) const;
-	void DrawPass(const resources::MeshManager& meshes, const resources::TextureManager& textures,
-	              const DrawSceneDesc& desc) const;
+	void DrawSubMesh(const L3DMesh& mesh, const L3DSubMesh& subMesh, const L3DMeshSubmitDesc& desc, bool preserveState) const;
+	void DrawPass(const DrawSceneDesc& desc) const;
 
 	std::unique_ptr<graphics::ShaderManager> _shaderManager;
 	std::unique_ptr<BgfxCallback> _bgfxCallback;


### PR DESCRIPTION
Simplify the renderer's call stack by removing mesh and texture resource managers from argument lists.
This actually seems to improve performance and makes the code cleaner.