### PR TITLE
Windows uses backwards slash which breaks raw/texture lookup

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -443,7 +443,7 @@ bool Game::Run()
 			SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "Loading raw texture: {}", f.path().stem().string());
 			try
 			{
-				textureManager.Load(("raw" / f.path().stem()).string(), f);
+				textureManager.Load(fmt::format("raw/{}", f.path().stem().string()), f);
 			}
 			catch (std::runtime_error& err)
 			{


### PR DESCRIPTION
Cherry-picking commit to fix master
Fixes  #382