### PR TITLE
Memory leaks in LHScriptX::Token::_u and  CommandSignature

### DIFF
--- a/src/LHScriptX/CommandSignature.h
+++ b/src/LHScriptX/CommandSignature.h
@@ -37,12 +37,10 @@ public:
 	    : _type(type)
 	{
 	}
-	ScriptCommandParameter(const std::string value)
+	ScriptCommandParameter(const std::string& value)
 	    : _type(ParameterType::String)
 	{
-		// TODO: Hacky, avoid new
-		_value._string = new std::string();
-		*_value._string = value;
+		_string = value;
 	}
 	ScriptCommandParameter(float value)
 	    : _type(ParameterType::Float)
@@ -58,12 +56,12 @@ public:
 
 	[[nodiscard]] ParameterType GetType() const { return _type; };
 
-	[[nodiscard]] std::string& GetString() const { return *_value._string; }
+	[[nodiscard]] const std::string& GetString() const { return _string; }
 	[[nodiscard]] float GetFloat() const { return _value._float; }
 	[[nodiscard]] int32_t GetNumber() const { return _value._number; }
 	void GetVector(float& x, float& y, float& z) const;
 
-	void SetString(const std::string& value) { *_value._string = value; }
+	void SetString(const std::string& value) { _string = value; }
 	void SetFloat(float value) { _value._float = value; };
 	void SetNumber(int32_t value) { _value._number = value; }
 	void SetVector(float x, float y, float z)
@@ -78,11 +76,11 @@ private:
 
 	union
 	{
-		std::string* _string;
 		float _float;
 		int32_t _number;
 		float _vector[3];
 	} _value;
+	std::string _string;
 };
 
 typedef std::vector<ScriptCommandParameter> ScriptCommandParameters;

--- a/src/LHScriptX/Lexer.cpp
+++ b/src/LHScriptX/Lexer.cpp
@@ -256,10 +256,10 @@ void Token::Print(FILE* file) const
 		fprintf(file, "\n");
 		break;
 	case Type::Identifier:
-		fprintf(file, "identifier \"%s\"", this->u_.identifierValue->c_str());
+		fprintf(file, "identifier \"%s\"", this->s_.c_str());
 		break;
 	case Type::String:
-		fprintf(file, "quoted string \"%s\"", this->u_.stringValue->c_str());
+		fprintf(file, "quoted string \"%s\"", this->s_.c_str());
 		break;
 	case Type::Integer:
 		fprintf(file, "integer %d", this->u_.integerValue);

--- a/src/LHScriptX/Lexer.h
+++ b/src/LHScriptX/Lexer.h
@@ -68,13 +68,13 @@ public:
 	static Token MakeIdentifierToken(const std::string& value)
 	{
 		Token tok(Type::Identifier);
-		tok.u_.identifierValue = new std::string(value);
+		tok.s_ = value;
 		return tok;
 	}
 	static Token MakeStringToken(const std::string& value)
 	{
 		Token tok(Type::String);
-		tok.u_.stringValue = new std::string(value);
+		tok.s_ = value;
 		return tok;
 	}
 	static Token MakeIntegerToken(int value)
@@ -103,8 +103,8 @@ public:
 	[[nodiscard]] bool IsOP(Operator op) const { return this->type_ == Type::Operator && this->u_.op == op; }
 
 	// todo: assert check the type for each of these?
-	[[nodiscard]] const std::string& Identifier() const { return *this->u_.identifierValue; }
-	[[nodiscard]] const std::string& StringValue() const { return *this->u_.stringValue; }
+	[[nodiscard]] const std::string& StringValue() const { return this->s_; }
+	[[nodiscard]] const std::string& Identifier() const { return this->s_; }
 	[[nodiscard]] const int* IntegerValue() const { return &this->u_.integerValue; }
 	[[nodiscard]] const float* FloatValue() const { return &this->u_.floatValue; }
 	[[nodiscard]] Operator Op() const { return this->u_.op; }
@@ -121,12 +121,11 @@ private:
 	Type type_;
 	union
 	{
-		std::string* identifierValue;
-		std::string* stringValue;
 		int integerValue;
 		float floatValue;
 		Operator op;
 	} u_;
+	std::string s_;
 };
 
 class Lexer

--- a/src/LHScriptX/Script.cpp
+++ b/src/LHScriptX/Script.cpp
@@ -30,7 +30,7 @@ void Script::Load(const std::string& source)
 
 		if (token->IsIdentifier())
 		{
-			const std::string& identifier = token->Identifier();
+			const std::string identifier = token->Identifier();
 
 			if (!isCommand(identifier))
 				throw std::runtime_error("unknown command: " + identifier);


### PR DESCRIPTION
Fixes #122, #123

Remove use of new (without delete) in Token creation.
Instead, a plain std::string is present in Token, next to the Union.
Overhead (once during script loading):
- One string copy per command
- One std::string init/deletion per numerical or operator token