### PR TITLE
Readme: Make badges point to master pushed builds

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # openblack
 
-[![VCPKG CI](https://github.com/openblack/openblack/actions/workflows/ci-vcpkg.yml/badge.svg?branch=master&event=push)](https://github.com/openblack/openblack/actions/workflows/ci-vcpkg.yml)
-[![System Deps CI](https://github.com/openblack/openblack/actions/workflows/ci-system-deps.yml/badge.svg?branch=master&event=push)](https://github.com/openblack/openblack/actions/workflows/ci-system-deps.yml)
+[![VCPKG CI](https://github.com/openblack/openblack/actions/workflows/ci-vcpkg.yml/badge.svg?branch=master&event=push)](https://github.com/openblack/openblack/actions/workflows/ci-vcpkg.yml?query=branch%3Amaster+event%3Apush)
+[![System Deps CI](https://github.com/openblack/openblack/actions/workflows/ci-system-deps.yml/badge.svg?branch=master&event=push)](https://github.com/openblack/openblack/actions/workflows/ci-system-deps.yml?query=branch%3Amaster+event%3Apush)
 [![GitHub Stars](https://img.shields.io/github/stars/openblack/openblack?logo=github)](https://github.com/openblack/openblack/stargazers)
 [![Discord chat](https://img.shields.io/discord/608729286513262622?logo=discord&logoColor=white)](https://discord.gg/5QTexBU)
 [![License](https://img.shields.io/github/license/openblack/openblack)](LICENSE.md)


### PR DESCRIPTION
This gives a better view of master builds for times like when a build breaks.
It will no longer be polluted by results of failed PRs.