### PR TITLE
Load scene tests

### DIFF
--- a/src/Game.h
+++ b/src/Game.h
@@ -181,8 +181,22 @@ public:
 	[[nodiscard]] Camera& GetCamera() const { return *_camera; }
 	[[nodiscard]] Sky& GetSky() const { return *_sky; }
 	[[nodiscard]] Water& GetWater() const { return *_water; }
-	LandIsland& GetLandIsland() { return *_landIsland; }
-	[[nodiscard]] LandIsland& GetLandIsland() const { return *_landIsland; }
+	LandIsland& GetLandIsland()
+	{
+		if (_landIsland == nullptr)
+		{
+			throw std::runtime_error("Cannot get landscape before any are loaded");
+		}
+		return *_landIsland;
+	}
+	[[nodiscard]] LandIsland& GetLandIsland() const
+	{
+		if (_landIsland == nullptr)
+		{
+			throw std::runtime_error("Cannot get landscape before any are loaded");
+		}
+		return *_landIsland;
+	}
 	entt::entity GetHand() const;
 	[[nodiscard]] const LHVM::LHVM& GetLhvm() { return *_lhvm; }
 	FileSystem& GetFileSystem() { return *_fileSystem; }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,3 +11,4 @@ macro(OPENBLACK_SETUP_AND_ADD_TEST TEST_NAME TEST_SOURCE)
 endmacro()
 
 OPENBLACK_SETUP_AND_ADD_TEST(test_game_initialize test_game_initialize.cpp)
+OPENBLACK_SETUP_AND_ADD_TEST(test_load_scene test_load_scene.cpp)

--- a/test/mock/CMakeLists.txt
+++ b/test/mock/CMakeLists.txt
@@ -82,7 +82,7 @@ add_custom_target(generate-mock-game-data
   COMMAND l3dtool write -o ${COFFRE_MESH_OUTPUT} -i ${COFFRE_INPUT}
   COMMAND anmtool write -o ${COFFRE_ANIM_OUTPUT} -i ${COFFRE_INPUT}
   # Scripts/info.dat
-  COMMAND Python3::Interpreter ${CMAKE_CURRENT_SOURCE_DIR}/gen_zeroed_file.py --output-files "${INFO_UNPACKED_OUTPUT}" --size 0x8E186
+  COMMAND Python3::Interpreter ${CMAKE_CURRENT_SOURCE_DIR}/gen_info.py --output-file "${INFO_UNPACKED_OUTPUT}"
   COMMAND packtool --write-raw ${INFO_DAT_OUTPUT} ${INFO_UNPACKED_OUTPUT}
   # Scripts/Quests/challenge.chl
   COMMAND Python3::Interpreter ${CMAKE_CURRENT_SOURCE_DIR}/Scripts/Quests/gen_challenge.py --output-file ${QUEST_CHALLENGE_OUTPUT}

--- a/test/mock/gen_info.py
+++ b/test/mock/gen_info.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+import gen_zeroed_file
+
+def main(path):
+    # Set file as zeroed
+    size = 0x8E186
+    gen_zeroed_file.main(path, size)
+
+    # Add abode name used in scene test
+    abode_debug_name = b'ABODE_F'
+    abode_info_array_offset = 0x12bf8 # 0x1b8 long
+    abode_debug_string_offset = 8  # 0x30 long
+    with open(path, "r+b") as f:
+        f.seek(abode_info_array_offset + abode_debug_string_offset)
+        f.write(abode_debug_name)
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Generate Mock info.dat file.')
+    parser.add_argument('--output-file', required=True, help='Where to generate file.')
+    args = parser.parse_args()
+    main(args.output_file)

--- a/test/test_load_scene.cpp
+++ b/test/test_load_scene.cpp
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2018-2022 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ ******************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <Game.h>
+#include <LHScriptX/Script.h>
+
+class LoadScene: public ::testing::Test
+{
+public:
+	void LoadTestScene(const char* sceneScript)
+	{
+		auto script = openblack::lhscriptx::Script(game_.get());
+		script.Load(sceneScript);
+	}
+
+protected:
+	void SetUp() override
+	{
+		static const auto mock_game_path = std::filesystem::path(TEST_BINARY_DIR) / "mock";
+		auto args = openblack::Arguments {
+		    .rendererType = bgfx::RendererType::Enum::Noop,
+		    .gamePath = mock_game_path.string(),
+		    .numFramesToSimulate = 0,
+		    .logFile = "stdout",
+		};
+		std::fill_n(args.logLevels.begin(), args.logLevels.size(), spdlog::level::debug);
+		game_ = std::make_unique<openblack::Game>(std::move(args));
+		ASSERT_TRUE(game_->Initialize());
+	}
+	void TearDown() override {
+		game_.reset();
+	}
+	std::unique_ptr<openblack::Game> game_;
+};
+
+TEST_F(LoadScene, minimal)
+{
+	LoadTestScene(R""""(
+VERSION(2.300000)
+)"""");
+}
+
+TEST_F(LoadScene, landscape_only)
+{
+	LoadTestScene(R""""(
+VERSION(2.300000)
+LOAD_LANDSCAPE(".\Data\Landscape\Land1.lnd")
+)"""");
+}
+
+TEST_F(LoadScene, load_abode_no_landscape)
+{
+	LoadTestScene(R""""(
+VERSION(2.300000)
+CREATE_ABODE(0, "2224.63,2372.52", "CELTIC_ABODE_F", 11100, 1095, 0, 0)
+)"""");
+}
+
+TEST_F(LoadScene, load_celtic_abode_f)
+{
+	LoadTestScene(R""""(
+VERSION(2.300000)
+LOAD_LANDSCAPE(".\Data\Landscape\Land1.lnd")
+CREATE_ABODE(0, "2224.63,2372.52", "CELTIC_ABODE_F", 11100, 1095, 0, 0)
+)"""");
+}

--- a/test/test_load_scene.cpp
+++ b/test/test_load_scene.cpp
@@ -35,9 +35,7 @@ protected:
 		game_ = std::make_unique<openblack::Game>(std::move(args));
 		ASSERT_TRUE(game_->Initialize());
 	}
-	void TearDown() override {
-		game_.reset();
-	}
+	void TearDown() override { game_.reset(); }
 	std::unique_ptr<openblack::Game> game_;
 };
 
@@ -58,10 +56,11 @@ LOAD_LANDSCAPE(".\Data\Landscape\Land1.lnd")
 
 TEST_F(LoadScene, load_abode_no_landscape)
 {
-	LoadTestScene(R""""(
+	const char* sceneScript = R""""(
 VERSION(2.300000)
 CREATE_ABODE(0, "2224.63,2372.52", "CELTIC_ABODE_F", 11100, 1095, 0, 0)
-)"""");
+)"""";
+	ASSERT_THROW(LoadTestScene(sceneScript), std::runtime_error);
 }
 
 TEST_F(LoadScene, load_celtic_abode_f)


### PR DESCRIPTION
Add some unit tests to catch errors in scene file loading. This is useful to build on for more advanced tests like those in #338 

The test revealed some undefined behaviour when trying to get island before one is loaded.

- [x] Depends on #387