### PR TITLE
Test for RNGManager Debug mode

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,3 +11,4 @@ macro(OPENBLACK_SETUP_AND_ADD_TEST TEST_NAME TEST_SOURCE)
 endmacro()
 
 OPENBLACK_SETUP_AND_ADD_TEST(test_game_initialize test_game_initialize.cpp)
+OPENBLACK_SETUP_AND_ADD_TEST(test_rng_manager rng_manager/test_rng_manager.cpp)

--- a/test/rng_manager/test_rng_manager.cpp
+++ b/test/rng_manager/test_rng_manager.cpp
@@ -10,42 +10,59 @@
 #include <gtest/gtest.h>
 
 #include <Common/RNGManager.h>
-#include <iostream>
 #include <mutex>
 #include <thread>
 #include <vector>
 
-#define N_TEST 100000
+#define N_TEST 1000000
 #define TEST_SEED 15000
 #define N_THREAD 10
 
+using namespace openblack;
 
-TEST(RngManager, debug_predictable_mono)
+template <class Manager>
+struct TestFunctions
 {
-    openblack::RNGManager& rngManager = openblack::RNGManager::instance();
-    ASSERT_TRUE(rngManager.SetDebugMode(true, TEST_SEED));
+template <typename T>
+static void DebugTest(T min, T max, unsigned int nTest, int seed, unsigned int nThread = 1)
+{
+    Manager rngManager;
+    ASSERT_TRUE(rngManager.SetDebugMode(true, seed));
 
-    std::vector<uint32_t> fstResult(N_TEST);
+    std::vector<T> fstResult(nTest);
     for (auto it=fstResult.begin(); it!=fstResult.end(); ++it)
     {
         *it = rngManager.NextValue(1,500);
     }
 
-    // Two run with the same seed mush give the same vector.
-    ASSERT_TRUE(rngManager.SetDebugMode(true, TEST_SEED));
-    std::vector<uint32_t> sndResult(N_TEST);
-    for (auto it=sndResult.begin(); it!=sndResult.end(); ++it)
+    /*
+     * TODO must guarentee that with multiple thread using RNGManager in debug
+     * mode will use the same sequence of number.
+     */
+    
+    ASSERT_TRUE(rngManager.SetDebugMode(true, seed));
+    int index = 0;
+    int itemPerThread = nTest / nThread;
+    std::vector<T> sndResult(nTest);
+    std::vector<std::thread> threadVector;
+    std::mutex generatorLock, writeLock;
+    for (int i = 0; i < nThread; i++)
     {
-        *it = rngManager.NextValue(1,500);
+        auto l = [itemPerThread, &index, &sndResult, &generatorLock, &writeLock, &rngManager] { randomThread(itemPerThread, index, sndResult, generatorLock, writeLock, rngManager); };
+        threadVector.push_back(std::thread(l));
     }
+    for (auto t = threadVector.begin(); t != threadVector.end(); ++t)
+    {
+        t ->join();
+    }
+
     ASSERT_TRUE(fstResult==sndResult);
 }
-
-void randomThread(int totalIteration, int& counter, std::vector<uint32_t>& result, std::mutex& generatorLock, std::mutex& writeLock) 
+template <typename T>
+static void randomThread(int totalIteration, int& counter, std::vector<T>& result, std::mutex& generatorLock, std::mutex& writeLock, Manager& rngManager)
 {
-    openblack::RNGManager& rngManager = openblack::RNGManager::instance();
     int current(0);
-    uint32_t random(0);
+    T random(0);
 
     for (int i = 0; i < totalIteration; i++)
     {
@@ -61,39 +78,35 @@ void randomThread(int totalIteration, int& counter, std::vector<uint32_t>& resul
             result[current] = random;
         }
     }
+}
+static void DebugTestSeries(unsigned int nTest, int seed, unsigned int nThread = 1)
+{
+    int min(1), max(500);
+
+    // Test serie for Intergers
+    DebugTest<unsigned short int>(min, max, nTest, seed, nThread);
+    DebugTest<unsigned int>(min, max, nTest, seed, nThread);
+    DebugTest<unsigned long int>(min, max, nTest, seed, nThread);
+    DebugTest<short int>(min, max, nTest, seed, nThread);
+    DebugTest<int>(min, max, nTest, seed, nThread);
+    DebugTest<long int>(min, max, nTest, seed, nThread);
+
+    // Test serie for Reals
+    DebugTest<float>(min, max, nTest, seed, nThread);
+    DebugTest<double>(min, max, nTest, seed, nThread);
+}
 };
 
+
+TEST(RngManager, debug_predictable_mono)
+{
+    unsigned int nTest(N_TEST);
+    int min(1), max(500), seed(TEST_SEED);
+    TestFunctions<RNGManager>::DebugTest<unsigned short int>(min, max, nTest, seed);
+}
 TEST(RngManager, debug_predictable_multi)
 {
-    openblack::RNGManager& rngManager = openblack::RNGManager::instance();
-    ASSERT_TRUE(rngManager.SetDebugMode(true, TEST_SEED));
-
-    std::vector<uint32_t> fstResult(N_TEST);
-    for (auto it=fstResult.begin(); it!=fstResult.end(); ++it)
-    {
-        *it = rngManager.NextValue(1,500);
-    }
-
-    /*
-     * TODO must guarentee that with multiple thread using RNGManager in debug
-     * mode will use the same sequence of number.
-     */
-    
-    ASSERT_TRUE(rngManager.SetDebugMode(true, TEST_SEED));
-    int index = 0;
-    int itemPerThread = N_TEST / N_THREAD;
-    std::vector<uint32_t> sndResult(N_TEST);
-    std::vector<std::thread> threadVector;
-    std::mutex generatorLock, writeLock;
-    for (int i = 0; i < N_THREAD; i++)
-    {
-        auto l = [itemPerThread, &index, &sndResult, &generatorLock, &writeLock] { randomThread(itemPerThread, index, sndResult, generatorLock, writeLock); };
-        threadVector.push_back(std::thread(l));
-    }
-    for (auto t = threadVector.begin(); t != threadVector.end(); ++t)
-    {
-        t ->join();
-    }
-
-    ASSERT_TRUE(fstResult==sndResult);
+    unsigned int nTest(N_TEST), nThread(N_THREAD);
+    int min(1), max(500), seed(TEST_SEED);
+    TestFunctions<RNGManager>::DebugTest<unsigned short int>(min, max, nTest, seed, nThread);
 }

--- a/test/rng_manager/test_rng_manager.cpp
+++ b/test/rng_manager/test_rng_manager.cpp
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2018-2022 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ ******************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <Common/RNGManager.h>
+#include <iostream>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#define N_TEST 100000
+#define TEST_SEED 15000
+#define N_THREAD 10
+
+
+TEST(RngManager, debug_predictable_mono)
+{
+    openblack::RNGManager& rngManager = openblack::RNGManager::instance();
+    ASSERT_TRUE(rngManager.SetDebugMode(true, TEST_SEED));
+
+    std::vector<uint32_t> fstResult(N_TEST);
+    for (auto it=fstResult.begin(); it!=fstResult.end(); ++it)
+    {
+        *it = rngManager.NextValue(1,500);
+    }
+
+    // Two run with the same seed mush give the same vector.
+    ASSERT_TRUE(rngManager.SetDebugMode(true, TEST_SEED));
+    std::vector<uint32_t> sndResult(N_TEST);
+    for (auto it=sndResult.begin(); it!=sndResult.end(); ++it)
+    {
+        *it = rngManager.NextValue(1,500);
+    }
+    ASSERT_TRUE(fstResult==sndResult);
+}
+
+void randomThread(int totalIteration, int& counter, std::vector<uint32_t>& result, std::mutex& generatorLock, std::mutex& writeLock) 
+{
+    openblack::RNGManager& rngManager = openblack::RNGManager::instance();
+    int current(0);
+    uint32_t random(0);
+
+    for (int i = 0; i < totalIteration; i++)
+    {
+        {
+            std::lock_guard<std::mutex> generatorLocked(generatorLock);
+            random = rngManager.NextValue(1,500);
+            current = counter;
+            counter++;
+        }
+        
+        {
+            std::lock_guard<std::mutex> locked(writeLock);
+            result[current] = random;
+        }
+    }
+};
+
+TEST(RngManager, debug_predictable_multi)
+{
+    openblack::RNGManager& rngManager = openblack::RNGManager::instance();
+    ASSERT_TRUE(rngManager.SetDebugMode(true, TEST_SEED));
+
+    std::vector<uint32_t> fstResult(N_TEST);
+    for (auto it=fstResult.begin(); it!=fstResult.end(); ++it)
+    {
+        *it = rngManager.NextValue(1,500);
+    }
+
+    /*
+     * TODO must guarentee that with multiple thread using RNGManager in debug
+     * mode will use the same sequence of number.
+     */
+    
+    ASSERT_TRUE(rngManager.SetDebugMode(true, TEST_SEED));
+    int index = 0;
+    int itemPerThread = N_TEST / N_THREAD;
+    std::vector<uint32_t> sndResult(N_TEST);
+    std::vector<std::thread> threadVector;
+    std::mutex generatorLock, writeLock;
+    for (int i = 0; i < N_THREAD; i++)
+    {
+        auto l = [itemPerThread, &index, &sndResult, &generatorLock, &writeLock] { randomThread(itemPerThread, index, sndResult, generatorLock, writeLock); };
+        threadVector.push_back(std::thread(l));
+    }
+    for (auto t = threadVector.begin(); t != threadVector.end(); ++t)
+    {
+        t ->join();
+    }
+
+    ASSERT_TRUE(fstResult==sndResult);
+}


### PR DESCRIPTION
A test file to test that the RNGManager follow those properties in debug mode.
- [ ] SetDebugMode set a seed and reset the underlying PRNG, so if i call NextValue n time then call of SetDebugMode with same seed and call NextValue n time again the exact same sequence of number should come out on both.
- [ ] Ensure that this property works in the case of concurrent access on NextValue, each thread can draw a different sequence of number depending on when they call but the underlying generator must go through the same sequence of number.
- [ ] As NextValue is a templated function, use a templated function to allow to test in order to test different type easily.