### PR TITLE
Use path instead of string in components and apps

### DIFF
--- a/apps/anmtool/anmtool.cpp
+++ b/apps/anmtool/anmtool.cpp
@@ -94,12 +94,12 @@ struct Arguments
 	Mode mode;
 	struct Read
 	{
-		std::vector<std::string> filenames;
+		std::vector<std::filesystem::path> filenames;
 	} read;
 	struct Write
 	{
-		std::string outFilename;
-		std::string gltfFile;
+		std::filesystem::path outFilename;
+		std::filesystem::path gltfFile;
 	} write;
 };
 
@@ -133,20 +133,20 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 	cxxopts::Options options("anmtool", "Inspect and extract files from LionHead ANM files.");
 
 	// clang-format off
-	options.add_options()
-		("h,help", "Display this help message.")
-		("subcommand", "Subcommand.", cxxopts::value<std::string>())
-	;
-	options.positional_help("[read|write] [OPTION...]");
-	options.add_options()
-		("H,header", "Print Header Contents.", cxxopts::value<std::vector<std::string>>())
-		("l,list-keyframes", "List Keyframes.", cxxopts::value<std::vector<std::string>>())
-		("k,keyframe-content", "View Keyframe Contents", cxxopts::value<std::vector<std::string>>())
-	;
-	options.add_options("write from and to glTF format")
-		("o,output", "Output file (required).", cxxopts::value<std::string>())
-		("i,input-mesh", "Input file (required).", cxxopts::value<std::string>())
-	;
+  options.add_options()
+    ("h,help", "Display this help message.")
+    ("subcommand", "Subcommand.", cxxopts::value<std::string>())
+    ;
+  options.positional_help("[read|write] [OPTION...]");
+  options.add_options()
+    ("H,header", "Print Header Contents.", cxxopts::value<std::vector<std::filesystem::path>>())
+    ("l,list-keyframes", "List Keyframes.", cxxopts::value<std::vector<std::filesystem::path>>())
+    ("k,keyframe-content", "View Keyframe Contents", cxxopts::value<std::vector<std::filesystem::path>>())
+    ;
+  options.add_options("write from and to glTF format")
+    ("o,output", "Output file (required).", cxxopts::value<std::filesystem::path>())
+    ("i,input-mesh", "Input file (required).", cxxopts::value<std::filesystem::path>())
+    ;
 	// clang-format on
 
 	options.parse_positional({"subcommand"});
@@ -171,19 +171,19 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 			if (result["header"].count() > 0)
 			{
 				args.mode = Arguments::Mode::Header;
-				args.read.filenames = result["header"].as<std::vector<std::string>>();
+				args.read.filenames = result["header"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 			if (result["list-keyframes"].count() > 0)
 			{
 				args.mode = Arguments::Mode::ListKeyframes;
-				args.read.filenames = result["list-keyframes"].as<std::vector<std::string>>();
+				args.read.filenames = result["list-keyframes"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 			if (result["keyframe-content"].count() > 0)
 			{
 				args.mode = Arguments::Mode::Keyframe;
-				args.read.filenames = result["keyframe-content"].as<std::vector<std::string>>();
+				args.read.filenames = result["keyframe-content"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 		}
@@ -193,10 +193,10 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 			if (result["output"].count() > 0)
 			{
 				args.mode = Arguments::Mode::Write;
-				args.write.outFilename = result["output"].as<std::string>();
+				args.write.outFilename = result["output"].as<std::filesystem::path>();
 				if (result["input-mesh"].count() > 0)
 				{
-					args.write.gltfFile = result["input-mesh"].as<std::string>();
+					args.write.gltfFile = result["input-mesh"].as<std::filesystem::path>();
 				}
 				return true;
 			}

--- a/apps/l3dtool/l3dtool.cpp
+++ b/apps/l3dtool/l3dtool.cpp
@@ -10,6 +10,7 @@
 #include <L3DFile.h>
 
 #include <cstdlib>
+#include <filesystem>
 #include <stack>
 #include <string>
 
@@ -482,17 +483,17 @@ struct Arguments
 	Mode mode;
 	struct Read
 	{
-		std::vector<std::string> filenames;
+		std::vector<std::filesystem::path> filenames;
 	} read;
 	struct Write
 	{
-		std::string outFilename;
-		std::string gltfFile;
+		std::filesystem::path outFilename;
+		std::filesystem::path gltfFile;
 	} write;
 	struct Extract
 	{
-		std::string inFilename;
-		std::string gltfFile;
+		std::filesystem::path inFilename;
+		std::filesystem::path gltfFile;
 	} extract;
 };
 
@@ -570,7 +571,7 @@ int WriteFile(const Arguments::Write& args)
 	std::string warn;
 
 	loader.SetImageLoader(NoopLoadImageDataFunction, nullptr);
-	bool ret = loader.LoadASCIIFromFile(&gltf, &err, &warn, args.gltfFile,
+	bool ret = loader.LoadASCIIFromFile(&gltf, &err, &warn, args.gltfFile.string(),
 	                                    tinygltf::REQUIRE_VERSION | tinygltf::REQUIRE_ACCESSORS | tinygltf::REQUIRE_BUFFERS |
 	                                        tinygltf::REQUIRE_BUFFER_VIEWS);
 
@@ -845,7 +846,7 @@ int ExtractFile(const Arguments::Extract& args)
 
 	// Scene
 	tinygltf::Scene scene;
-	scene.name = "l3dtool exported scene from " + args.inFilename;
+	scene.name = "l3dtool exported scene from " + args.inFilename.string();
 	scene.nodes.push_back(0);
 	gltf.scenes.push_back(scene);
 	gltf.defaultScene = 0;
@@ -1046,7 +1047,7 @@ int ExtractFile(const Arguments::Extract& args)
 	// TODO: Associate mesh and joints to node
 
 	tinygltf::TinyGLTF exporter;
-	exporter.WriteGltfSceneToFile(&gltf, args.gltfFile, true, true, true, false);
+	exporter.WriteGltfSceneToFile(&gltf, args.gltfFile.string(), true, true, true, false);
 
 	return EXIT_SUCCESS;
 }
@@ -1062,20 +1063,20 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 	;
 	options.positional_help("[read|write|extract] [OPTION...]");
 	options.add_options("read")
-		("H,header", "Print Header Contents.", cxxopts::value<std::vector<std::string>>())
-		("m,mesh-header", "Print Mesh Headers.", cxxopts::value<std::vector<std::string>>())
-		("s,skins", "Print Skins.", cxxopts::value<std::vector<std::string>>())
-		("p,extra-points", "Print Extra Points.", cxxopts::value<std::vector<std::string>>())
-		("P,primitive-header", "Print Primitive Headers.", cxxopts::value<std::vector<std::string>>())
-		("b,bones", "Print Bones.", cxxopts::value<std::vector<std::string>>())
-		("V,vertices", "Print Vertices.", cxxopts::value<std::vector<std::string>>())
-		("I,indices", "Print Indices.", cxxopts::value<std::vector<std::string>>())
-		("L,look-up-tables", "Print Look Up Table Data.", cxxopts::value<std::vector<std::string>>())
-		("B,vertex-blend-values", "Print Vertex Blend Values.", cxxopts::value<std::vector<std::string>>())
+		("H,header", "Print Header Contents.", cxxopts::value<std::vector<std::filesystem::path>>())
+		("m,mesh-header", "Print Mesh Headers.", cxxopts::value<std::vector<std::filesystem::path>>())
+		("s,skins", "Print Skins.", cxxopts::value<std::vector<std::filesystem::path>>())
+		("p,extra-points", "Print Extra Points.", cxxopts::value<std::vector<std::filesystem::path>>())
+		("P,primitive-header", "Print Primitive Headers.", cxxopts::value<std::vector<std::filesystem::path>>())
+		("b,bones", "Print Bones.", cxxopts::value<std::vector<std::filesystem::path>>())
+		("V,vertices", "Print Vertices.", cxxopts::value<std::vector<std::filesystem::path>>())
+		("I,indices", "Print Indices.", cxxopts::value<std::vector<std::filesystem::path>>())
+		("L,look-up-tables", "Print Look Up Table Data.", cxxopts::value<std::vector<std::filesystem::path>>())
+		("B,vertex-blend-values", "Print Vertex Blend Values.", cxxopts::value<std::vector<std::filesystem::path>>())
 	;
 	options.add_options("write/extract from and to glTF format")
-		("o,output", "Output file (required).", cxxopts::value<std::string>())
-		("i,input-mesh", "Input file (required).", cxxopts::value<std::string>())
+		("o,output", "Output file (required).", cxxopts::value<std::filesystem::path>())
+		("i,input-mesh", "Input file (required).", cxxopts::value<std::filesystem::path>())
 	;
 	// clang-format on
 
@@ -1101,61 +1102,61 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 			if (result["header"].count() > 0)
 			{
 				args.mode = Arguments::Mode::Header;
-				args.read.filenames = result["header"].as<std::vector<std::string>>();
+				args.read.filenames = result["header"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 			if (result["mesh-header"].count() > 0)
 			{
 				args.mode = Arguments::Mode::MeshHeader;
-				args.read.filenames = result["mesh-header"].as<std::vector<std::string>>();
+				args.read.filenames = result["mesh-header"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 			if (result["skins"].count() > 0)
 			{
 				args.mode = Arguments::Mode::Skin;
-				args.read.filenames = result["skins"].as<std::vector<std::string>>();
+				args.read.filenames = result["skins"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 			if (result["extra-points"].count() > 0)
 			{
 				args.mode = Arguments::Mode::ExtraPoint;
-				args.read.filenames = result["extra-points"].as<std::vector<std::string>>();
+				args.read.filenames = result["extra-points"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 			if (result["primitive-header"].count() > 0)
 			{
 				args.mode = Arguments::Mode::PrimitiveHeader;
-				args.read.filenames = result["primitive-header"].as<std::vector<std::string>>();
+				args.read.filenames = result["primitive-header"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 			if (result["bones"].count() > 0)
 			{
 				args.mode = Arguments::Mode::Bones;
-				args.read.filenames = result["bones"].as<std::vector<std::string>>();
+				args.read.filenames = result["bones"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 			if (result["vertices"].count() > 0)
 			{
 				args.mode = Arguments::Mode::Vertices;
-				args.read.filenames = result["vertices"].as<std::vector<std::string>>();
+				args.read.filenames = result["vertices"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 			if (result["indices"].count() > 0)
 			{
 				args.mode = Arguments::Mode::Indices;
-				args.read.filenames = result["indices"].as<std::vector<std::string>>();
+				args.read.filenames = result["indices"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 			if (result["look-up-tables"].count() > 0)
 			{
 				args.mode = Arguments::Mode::LookUpTables;
-				args.read.filenames = result["look-up-tables"].as<std::vector<std::string>>();
+				args.read.filenames = result["look-up-tables"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 			if (result["vertex-blend-values"].count() > 0)
 			{
 				args.mode = Arguments::Mode::VertexBlendValues;
-				args.read.filenames = result["vertex-blend-values"].as<std::vector<std::string>>();
+				args.read.filenames = result["vertex-blend-values"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 		}
@@ -1165,10 +1166,10 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 			if (result["output"].count() > 0)
 			{
 				args.mode = Arguments::Mode::Write;
-				args.write.outFilename = result["output"].as<std::string>();
+				args.write.outFilename = result["output"].as<std::filesystem::path>();
 				if (result["input-mesh"].count() > 0)
 				{
-					args.write.gltfFile = result["input-mesh"].as<std::string>();
+					args.write.gltfFile = result["input-mesh"].as<std::filesystem::path>();
 				}
 				return true;
 			}
@@ -1179,10 +1180,10 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 			if (result["output"].count() > 0)
 			{
 				args.mode = Arguments::Mode::Extract;
-				args.extract.inFilename = result["input-mesh"].as<std::string>();
+				args.extract.inFilename = result["input-mesh"].as<std::filesystem::path>();
 				if (result["input-mesh"].count() > 0)
 				{
-					args.extract.gltfFile = result["output"].as<std::string>();
+					args.extract.gltfFile = result["output"].as<std::filesystem::path>();
 				}
 				return true;
 			}

--- a/apps/lndtool/lndtool.cpp
+++ b/apps/lndtool/lndtool.cpp
@@ -330,15 +330,15 @@ struct Arguments
 	Mode mode;
 	struct Read
 	{
-		std::vector<std::string> filenames;
+		std::vector<std::filesystem::path> filenames;
 	} read;
 	struct Write
 	{
-		std::string outFilename;
+		std::filesystem::path outFilename;
 		uint16_t terrainType;
-		std::string noiseMapFile;
-		std::string bumpMapFile;
-		std::vector<std::string> materialArray;
+		std::filesystem::path noiseMapFile;
+		std::filesystem::path bumpMapFile;
+		std::vector<std::filesystem::path> materialArray;
 	} write;
 };
 
@@ -455,20 +455,20 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 	;
 	options.positional_help("[read|write] [OPTION...]");
 	options.add_options("read")
-		("H,header", "Print Header Contents.", cxxopts::value<std::vector<std::string>>())
-		("l,low-resolution-textures", "Print Low Resolution Texture Contents.", cxxopts::value<std::vector<std::string>>())
-		("b,blocks", "Print Block Contents.", cxxopts::value<std::vector<std::string>>())
-		("c,country", "Print Country Contents.", cxxopts::value<std::vector<std::string>>())
-		("m,material", "Print Material Contents.", cxxopts::value<std::vector<std::string>>())
-		("x,extra", "Print Extra Content.", cxxopts::value<std::vector<std::string>>())
-		("u,unaccounted", "Print Unaccounted bytes Content.", cxxopts::value<std::vector<std::string>>())
+		("H,header", "Print Header Contents.", cxxopts::value<std::vector<std::filesystem::path>>())
+		("l,low-resolution-textures", "Print Low Resolution Texture Contents.", cxxopts::value<std::vector<std::filesystem::path>>())
+		("b,blocks", "Print Block Contents.", cxxopts::value<std::vector<std::filesystem::path>>())
+		("c,country", "Print Country Contents.", cxxopts::value<std::vector<std::filesystem::path>>())
+		("m,material", "Print Material Contents.", cxxopts::value<std::vector<std::filesystem::path>>())
+		("x,extra", "Print Extra Content.", cxxopts::value<std::vector<std::filesystem::path>>())
+		("u,unaccounted", "Print Unaccounted bytes Content.", cxxopts::value<std::vector<std::filesystem::path>>())
 	;
 	options.add_options("write")
-		("o,output", "Output file (required).", cxxopts::value<std::string>())
+		("o,output", "Output file (required).", cxxopts::value<std::filesystem::path>())
 		("terrain-type", "Type of terrain (required).", cxxopts::value<uint16_t>())
-		("noise-map", "File with R8 bytes for noise map.", cxxopts::value<std::string>())
-		("bump-map", "File with R8 bytes for bump map.", cxxopts::value<std::string>())
-		("material-array", "Files with RGB5A1 bytes for material array (comma-separated).", cxxopts::value<std::vector<std::string>>())
+		("noise-map", "File with R8 bytes for noise map.", cxxopts::value<std::filesystem::path>())
+		("bump-map", "File with R8 bytes for bump map.", cxxopts::value<std::filesystem::path>())
+		("material-array", "Files with RGB5A1 bytes for material array (comma-separated).", cxxopts::value<std::vector<std::filesystem::path>>())
 	;
 	// clang-format on
 
@@ -494,43 +494,43 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 			if (result["header"].count() > 0)
 			{
 				args.mode = Arguments::Mode::Header;
-				args.read.filenames = result["header"].as<std::vector<std::string>>();
+				args.read.filenames = result["header"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 			if (result["low-resolution-textures"].count() > 0)
 			{
 				args.mode = Arguments::Mode::LowResolution;
-				args.read.filenames = result["low-resolution-textures"].as<std::vector<std::string>>();
+				args.read.filenames = result["low-resolution-textures"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 			if (result["blocks"].count() > 0)
 			{
 				args.mode = Arguments::Mode::Blocks;
-				args.read.filenames = result["blocks"].as<std::vector<std::string>>();
+				args.read.filenames = result["blocks"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 			if (result["country"].count() > 0)
 			{
 				args.mode = Arguments::Mode::Countries;
-				args.read.filenames = result["country"].as<std::vector<std::string>>();
+				args.read.filenames = result["country"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 			if (result["material"].count() > 0)
 			{
 				args.mode = Arguments::Mode::Materials;
-				args.read.filenames = result["material"].as<std::vector<std::string>>();
+				args.read.filenames = result["material"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 			if (result["extra"].count() > 0)
 			{
 				args.mode = Arguments::Mode::Extra;
-				args.read.filenames = result["extra"].as<std::vector<std::string>>();
+				args.read.filenames = result["extra"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 			if (result["unaccounted"].count() > 0)
 			{
 				args.mode = Arguments::Mode::Unaccounted;
-				args.read.filenames = result["unaccounted"].as<std::vector<std::string>>();
+				args.read.filenames = result["unaccounted"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 		}
@@ -540,19 +540,19 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 			if (result["output"].count() > 0 && result["terrain-type"].count() > 0)
 			{
 				args.mode = Arguments::Mode::Write;
-				args.write.outFilename = result["output"].as<std::string>();
+				args.write.outFilename = result["output"].as<std::filesystem::path>();
 				args.write.terrainType = result["terrain-type"].as<uint16_t>();
 				if (result["noise-map"].count() > 0)
 				{
-					args.write.noiseMapFile = result["noise-map"].as<std::string>();
+					args.write.noiseMapFile = result["noise-map"].as<std::filesystem::path>();
 				}
 				if (result["bump-map"].count() > 0)
 				{
-					args.write.bumpMapFile = result["bump-map"].as<std::string>();
+					args.write.bumpMapFile = result["bump-map"].as<std::filesystem::path>();
 				}
 				if (result["material-array"].count() > 0)
 				{
-					args.write.materialArray = result["material-array"].as<std::vector<std::string>>();
+					args.write.materialArray = result["material-array"].as<std::vector<std::filesystem::path>>();
 				}
 				return true;
 			}

--- a/apps/morphtool/morphtool.cpp
+++ b/apps/morphtool/morphtool.cpp
@@ -96,7 +96,7 @@ int PrintSpecs(openblack::morph::MorphFile& morph)
 
 	std::printf("file: %s\n", morph.GetFilename().c_str());
 
-	std::printf("specs path: %s\n", specs.path.c_str());
+	std::printf("specs path: %s\n", specs.path.string().c_str());
 	std::printf("specs version: %u\n", specs.version);
 
 	size_t j = 0;
@@ -335,10 +335,10 @@ struct Arguments
 		ShowExtraData,
 	};
 	Mode mode;
-	std::string spec_directory;
+	std::filesystem::path spec_directory;
 	struct Read
 	{
-		std::vector<std::string> filenames;
+		std::vector<std::filesystem::path> filenames;
 	} read;
 };
 
@@ -354,14 +354,14 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 	;
 	options.positional_help("[read|write] [OPTION...]");
 	options.add_options()
-		("l,list-details", "Print Content Details.", cxxopts::value<std::vector<std::string>>())
-		("H,header", "Print Header Contents.", cxxopts::value<std::vector<std::string>>())
-		("d,spec-files-directory", "Directory of spec files (required).", cxxopts::value<std::string>())
-		("s,list-animation-set", "List content of spec file.", cxxopts::value<std::vector<std::string>>())
-		("b,show-base-animation-set", "Display animation data for the base animation.", cxxopts::value<std::vector<std::string>>())
-		("V,show-variant-animation-sets", "Display animation data for the variant animations.", cxxopts::value<std::vector<std::string>>())
-		("g,show-hair-groups", "Display hair group data.", cxxopts::value<std::vector<std::string>>())
-		("e,show-extra-data", "Display extra data.", cxxopts::value<std::vector<std::string>>())
+		("l,list-details", "Print Content Details.", cxxopts::value<std::vector<std::filesystem::path>>())
+		("H,header", "Print Header Contents.", cxxopts::value<std::vector<std::filesystem::path>>())
+		("d,spec-files-directory", "Directory of spec files (required).", cxxopts::value<std::filesystem::path>())
+		("s,list-animation-set", "List content of spec file.", cxxopts::value<std::vector<std::filesystem::path>>())
+		("b,show-base-animation-set", "Display animation data for the base animation.", cxxopts::value<std::vector<std::filesystem::path>>())
+		("V,show-variant-animation-sets", "Display animation data for the variant animations.", cxxopts::value<std::vector<std::filesystem::path>>())
+		("g,show-hair-groups", "Display hair group data.", cxxopts::value<std::vector<std::filesystem::path>>())
+		("e,show-extra-data", "Display extra data.", cxxopts::value<std::vector<std::filesystem::path>>())
 	;
 	// clang-format on
 
@@ -390,50 +390,50 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 		}
 		else
 		{
-			args.spec_directory = result["spec-files-directory"].as<std::string>();
+			args.spec_directory = result["spec-files-directory"].as<std::filesystem::path>();
 		}
 		if (result["subcommand"].as<std::string>() == "read")
 		{
 			if (result["list-details"].count() > 0)
 			{
 				args.mode = Arguments::Mode::List;
-				args.read.filenames = result["list-details"].as<std::vector<std::string>>();
+				args.read.filenames = result["list-details"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 			if (result["header"].count() > 0)
 			{
 				args.mode = Arguments::Mode::Header;
-				args.read.filenames = result["header"].as<std::vector<std::string>>();
+				args.read.filenames = result["header"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 			if (result["list-animation-set"].count() > 0)
 			{
 				args.mode = Arguments::Mode::ListAnimationSet;
-				args.read.filenames = result["list-animation-set"].as<std::vector<std::string>>();
+				args.read.filenames = result["list-animation-set"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 			if (result["show-base-animation-set"].count() > 0)
 			{
 				args.mode = Arguments::Mode::ShowBaseAnimationSet;
-				args.read.filenames = result["show-base-animation-set"].as<std::vector<std::string>>();
+				args.read.filenames = result["show-base-animation-set"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 			if (result["show-variant-animation-sets"].count() > 0)
 			{
 				args.mode = Arguments::Mode::ShowVariantAnimationSets;
-				args.read.filenames = result["show-variant-animation-sets"].as<std::vector<std::string>>();
+				args.read.filenames = result["show-variant-animation-sets"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 			if (result["show-hair-groups"].count() > 0)
 			{
 				args.mode = Arguments::Mode::ShowHairGroups;
-				args.read.filenames = result["show-hair-groups"].as<std::vector<std::string>>();
+				args.read.filenames = result["show-hair-groups"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 			if (result["show-extra-data"].count() > 0)
 			{
 				args.mode = Arguments::Mode::ShowExtraData;
-				args.read.filenames = result["show-extra-data"].as<std::vector<std::string>>();
+				args.read.filenames = result["show-extra-data"].as<std::vector<std::filesystem::path>>();
 				return true;
 			}
 		}

--- a/apps/packtool/packtool.cpp
+++ b/apps/packtool/packtool.cpp
@@ -50,7 +50,7 @@ int ListBlocks(openblack::pack::PackFile& pack)
 {
 	auto& blocks = pack.GetBlocks();
 
-	std::printf("file: %s\n", pack.GetFilename().string().c_str());
+	std::printf("file: %s\n", pack.GetFilename().c_str());
 	std::printf("%u blocks\n", static_cast<uint32_t>(blocks.size()));
 	std::printf("%u textures\n", static_cast<uint32_t>(pack.GetTextures().size()));
 	std::printf("%u meshes\n", static_cast<uint32_t>(pack.GetMeshes().size()));
@@ -65,10 +65,10 @@ int ListBlocks(openblack::pack::PackFile& pack)
 	return EXIT_SUCCESS;
 }
 
-int ListBlock(openblack::pack::PackFile& pack, const std::string& name, const std::string& outFilename)
+int ListBlock(openblack::pack::PackFile& pack, const std::string& name, const std::filesystem::path& outFilename)
 {
 	auto output_log_stream = stdout;
-	if (outFilename == "stdout")
+	if (outFilename == std::filesystem::path("stdout"))
 	{
 		output_log_stream = stderr;
 	}
@@ -78,17 +78,17 @@ int ListBlock(openblack::pack::PackFile& pack, const std::string& name, const st
 	auto block = blocks.find(name);
 	if (block == blocks.end())
 	{
-		std::fprintf(stderr, "no \"%s\" block in file: %s\n", name.c_str(), pack.GetFilename().string().c_str());
+		std::fprintf(stderr, "no \"%s\" block in file: %s\n", name.c_str(), pack.GetFilename().c_str());
 		return EXIT_FAILURE;
 	}
 
-	std::fprintf(output_log_stream, "file: %s\n", pack.GetFilename().string().c_str());
+	std::fprintf(output_log_stream, "file: %s\n", pack.GetFilename().c_str());
 	std::fprintf(output_log_stream, "name \"%s\", size %u\n", name.c_str(), static_cast<uint32_t>(block->second.size()));
 	std::fprintf(output_log_stream, "\n");
 
 	if (!outFilename.empty())
 	{
-		if (outFilename == "stdout")
+		if (outFilename == std::filesystem::path("stdout"))
 		{
 			std::cout.write(reinterpret_cast<const char*>(block->second.data()), block->second.size());
 		}
@@ -98,7 +98,7 @@ int ListBlock(openblack::pack::PackFile& pack, const std::string& name, const st
 			output.write(reinterpret_cast<const char*>(block->second.data()), block->second.size());
 		}
 
-		std::fprintf(output_log_stream, "\nBlock writen to %s\n", outFilename.c_str());
+		std::fprintf(output_log_stream, "\nBlock writen to %s\n", outFilename.string().c_str());
 	}
 
 	return EXIT_SUCCESS;
@@ -108,7 +108,7 @@ int ViewBytes(openblack::pack::PackFile& pack, const std::string& name)
 {
 	auto& block = pack.GetBlock(name);
 
-	std::printf("file: %s, block %s\n", pack.GetFilename().string().c_str(), name.c_str());
+	std::printf("file: %s, block %s\n", pack.GetFilename().c_str(), name.c_str());
 
 	PrintRawBytes(block.data(), block.size() * sizeof(block[0]));
 
@@ -121,7 +121,7 @@ int ViewInfo(openblack::pack::PackFile& pack)
 	auto lookup = pack.GetInfoBlockLookup();
 	std::sort(lookup.begin(), lookup.end(), [](const Lookup& a, Lookup& b) { return a.blockId < b.blockId; });
 
-	std::printf("file: %s\n", pack.GetFilename().string().c_str());
+	std::printf("file: %s\n", pack.GetFilename().c_str());
 
 	for (auto& item : lookup)
 	{
@@ -135,7 +135,7 @@ int ViewBody(openblack::pack::PackFile& pack)
 {
 	const auto& lookup = pack.GetBodyBlockLookup();
 
-	std::printf("file: %s\n", pack.GetFilename().string().c_str());
+	std::printf("file: %s\n", pack.GetFilename().c_str());
 
 	for (uint32_t i = 0; i < lookup.size(); ++i)
 	{
@@ -149,7 +149,7 @@ int ViewTextures(openblack::pack::PackFile& pack)
 {
 	auto& textures = pack.GetTextures();
 
-	std::printf("file: %s\n", pack.GetFilename().string().c_str());
+	std::printf("file: %s\n", pack.GetFilename().c_str());
 
 	for (auto& [name, texture] : textures)
 	{
@@ -163,7 +163,7 @@ int ViewMeshes(openblack::pack::PackFile& pack)
 {
 	auto& meshes = pack.GetMeshes();
 
-	std::printf("file: %s\n", pack.GetFilename().string().c_str());
+	std::printf("file: %s\n", pack.GetFilename().c_str());
 
 	uint32_t i = 0;
 	for (auto& mesh : meshes)
@@ -178,7 +178,7 @@ int ViewAnimations(openblack::pack::PackFile& pack)
 {
 	auto& animations = pack.GetAnimations();
 
-	std::printf("file: %s\n", pack.GetFilename().string().c_str());
+	std::printf("file: %s\n", pack.GetFilename().c_str());
 
 	uint32_t i = 0;
 	for (auto& animation : animations)
@@ -189,11 +189,11 @@ int ViewAnimations(openblack::pack::PackFile& pack)
 	return EXIT_SUCCESS;
 }
 
-int ViewTexture(openblack::pack::PackFile& pack, const std::string& name, const std::string& outFilename)
+int ViewTexture(openblack::pack::PackFile& pack, const std::string& name, const std::filesystem::path& outFilename)
 {
 	auto& texture = pack.GetTexture(name);
 
-	std::printf("file: %s\n", pack.GetFilename().string().c_str());
+	std::printf("file: %s\n", pack.GetFilename().c_str());
 
 	std::printf("size: %u\n", static_cast<uint32_t>(texture.header.size));
 	std::printf("id: %u\n", static_cast<uint32_t>(texture.header.id));
@@ -233,13 +233,13 @@ int ViewTexture(openblack::pack::PackFile& pack, const std::string& name, const 
 		output.write(reinterpret_cast<const char*>(&texture.ddsHeader), sizeof(texture.ddsHeader));
 		output.write(reinterpret_cast<const char*>(texture.ddsData.data()), texture.ddsData.size());
 
-		std::printf("\nTexture writen to %s\n", outFilename.c_str());
+		std::printf("\nTexture writen to %s\n", outFilename.string().c_str());
 	}
 
 	return EXIT_SUCCESS;
 }
 
-int ViewMesh(openblack::pack::PackFile& pack, uint32_t index, const std::string& outFilename)
+int ViewMesh(openblack::pack::PackFile& pack, uint32_t index, const std::filesystem::path& outFilename)
 {
 	if (index > pack.GetMeshes().size())
 	{
@@ -248,7 +248,7 @@ int ViewMesh(openblack::pack::PackFile& pack, uint32_t index, const std::string&
 
 	auto& mesh = pack.GetMesh(index);
 
-	std::printf("file: %s\n", pack.GetFilename().string().c_str());
+	std::printf("file: %s\n", pack.GetFilename().c_str());
 	std::printf("mesh: %u bytes\n", static_cast<uint32_t>(mesh.size()));
 
 	if (!outFilename.empty())
@@ -256,13 +256,13 @@ int ViewMesh(openblack::pack::PackFile& pack, uint32_t index, const std::string&
 		std::ofstream output(outFilename, std::ios::binary);
 		output.write(reinterpret_cast<const char*>(mesh.data()), mesh.size() * sizeof(mesh[0]));
 
-		std::printf("\nL3D Mesh writen to %s\n", outFilename.c_str());
+		std::printf("\nL3D Mesh writen to %s\n", outFilename.string().c_str());
 	}
 
 	return EXIT_SUCCESS;
 }
 
-int ViewAnimation(openblack::pack::PackFile& pack, uint32_t index, const std::string& outFilename)
+int ViewAnimation(openblack::pack::PackFile& pack, uint32_t index, const std::filesystem::path& outFilename)
 {
 	if (index > pack.GetAnimations().size())
 	{
@@ -271,7 +271,7 @@ int ViewAnimation(openblack::pack::PackFile& pack, uint32_t index, const std::st
 
 	const auto& animation = pack.GetAnimation(index);
 
-	std::printf("file: %s\n", pack.GetFilename().string().c_str());
+	std::printf("file: %s\n", pack.GetFilename().c_str());
 	std::printf("animation: %-32s %u bytes\n", animation.data(), static_cast<uint32_t>(animation.size()));
 
 	if (!outFilename.empty())
@@ -279,13 +279,13 @@ int ViewAnimation(openblack::pack::PackFile& pack, uint32_t index, const std::st
 		std::ofstream output(outFilename, std::ios::binary);
 		output.write(reinterpret_cast<const char*>(animation.data()), animation.size() * sizeof(animation[0]));
 
-		std::printf("\nANM file writen to %s\n", outFilename.c_str());
+		std::printf("\nANM file writen to %s\n", outFilename.string().c_str());
 	}
 
 	return EXIT_SUCCESS;
 }
 
-int WriteRaw(const std::string& outFilename, const std::vector<std::string>& inFilenames)
+int WriteRaw(const std::filesystem::path& outFilename, const std::vector<std::filesystem::path>& inFilenames)
 {
 	openblack::pack::PackFile pack;
 
@@ -294,7 +294,7 @@ int WriteRaw(const std::string& outFilename, const std::vector<std::string>& inF
 		std::ifstream file(filename, std::ios::binary);
 		if (!file.is_open())
 		{
-			std::fprintf(stderr, "Could not open source file \"%s\"\n", filename.c_str());
+			std::fprintf(stderr, "Could not open source file \"%s\"\n", filename.string().c_str());
 			return EXIT_FAILURE;
 		}
 		file.seekg(0, std::ios_base::end);
@@ -308,18 +308,11 @@ int WriteRaw(const std::string& outFilename, const std::vector<std::string>& inF
 		}
 		catch (const std::ios_base::failure& e)
 		{
-			std::fprintf(stderr, "I/O error while reading \"%s\": %s\n", filename.c_str(), e.what());
+			std::fprintf(stderr, "I/O error while reading \"%s\": %s\n", filename.string().c_str(), e.what());
 			return EXIT_FAILURE;
 		}
 
-		const char* blockName = filename.c_str();
-		const char* slash = std::max(std::strrchr(filename.c_str(), '/'), std::strrchr(filename.c_str(), '\\'));
-		if (slash)
-		{
-			blockName = slash + 1;
-		}
-
-		pack.CreateRawBlock(blockName, std::move(data));
+		pack.CreateRawBlock(filename.filename().string(), std::move(data));
 	}
 
 	pack.Write(outFilename);
@@ -327,7 +320,7 @@ int WriteRaw(const std::string& outFilename, const std::vector<std::string>& inF
 	return EXIT_SUCCESS;
 }
 
-int WriteMeshFile(const std::string& outFilename)
+int WriteMeshFile(const std::filesystem::path& outFilename)
 {
 	openblack::pack::PackFile pack;
 
@@ -340,7 +333,7 @@ int WriteMeshFile(const std::string& outFilename)
 	return EXIT_SUCCESS;
 }
 
-int WriteAnimationFile(const std::string& outFilename)
+int WriteAnimationFile(const std::filesystem::path& outFilename)
 {
 	openblack::pack::PackFile pack;
 
@@ -370,11 +363,11 @@ struct Arguments
 		WriteMeshPack,
 		WriteAnimationPack,
 	};
-	std::vector<std::string> filenames;
+	std::vector<std::filesystem::path> filenames;
 	Mode mode;
 	std::string block;
 	uint32_t blockId;
-	std::string outFilename;
+	std::filesystem::path outFilename;
 };
 
 bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
@@ -395,11 +388,11 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 		("t,texture", "View texture statistics.", cxxopts::value<std::string>())
 		("A,animation-block", "List animation block statistics.")
 		("a,animation", "List animation statistics.", cxxopts::value<uint32_t>())
-		("e,extract", "Extract contents of a block to filename (use \"stdout\" for piping to other tool).", cxxopts::value<std::string>())
-		("w,write-raw", "Create Raw Data Pack.", cxxopts::value<std::string>())
-		("write-mesh", "Create Mesh Pack.", cxxopts::value<std::string>())
-		("write-animation", "Create Mesh Pack.", cxxopts::value<std::string>())
-		("pack-files", "Pack Files.", cxxopts::value<std::vector<std::string>>())
+		("e,extract", "Extract contents of a block to filename (use \"stdout\" for piping to other tool).", cxxopts::value<std::filesystem::path>())
+		("w,write-raw", "Create Raw Data Pack.", cxxopts::value<std::filesystem::path>())
+		("write-mesh", "Create Mesh Pack.", cxxopts::value<std::filesystem::path>())
+		("write-animation", "Create Mesh Pack.", cxxopts::value<std::filesystem::path>())
+		("pack-files", "Pack Files.", cxxopts::value<std::vector<std::filesystem::path>>())
 	;
 	// clang-format on
 	options.parse_positional({"pack-files"});
@@ -418,13 +411,13 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 		if (result["write-mesh"].count() > 0)
 		{
 			args.mode = Arguments::Mode::WriteMeshPack;
-			args.outFilename = result["write-mesh"].as<std::string>();
+			args.outFilename = result["write-mesh"].as<std::filesystem::path>();
 			return true;
 		}
 		if (result["write-animation"].count() > 0)
 		{
 			args.mode = Arguments::Mode::WriteAnimationPack;
-			args.outFilename = result["write-animation"].as<std::string>();
+			args.outFilename = result["write-animation"].as<std::filesystem::path>();
 			return true;
 		}
 		// Following this, all args require positional arguments
@@ -435,72 +428,72 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 		if (result["list-blocks"].count() > 0)
 		{
 			args.mode = Arguments::Mode::List;
-			args.filenames = result["pack-files"].as<std::vector<std::string>>();
+			args.filenames = result["pack-files"].as<std::vector<std::filesystem::path>>();
 			return true;
 		}
 		if (result["view-bytes"].count() > 0)
 		{
 			args.mode = Arguments::Mode::Bytes;
-			args.filenames = result["pack-files"].as<std::vector<std::string>>();
+			args.filenames = result["pack-files"].as<std::vector<std::filesystem::path>>();
 			args.block = result["view-bytes"].as<std::string>();
 			return true;
 		}
 		if (result["info-block"].count() > 0)
 		{
 			args.mode = Arguments::Mode::Info;
-			args.filenames = result["pack-files"].as<std::vector<std::string>>();
+			args.filenames = result["pack-files"].as<std::vector<std::filesystem::path>>();
 			return true;
 		}
 		if (result["body-block"].count() > 0)
 		{
 			args.mode = Arguments::Mode::Body;
-			args.filenames = result["pack-files"].as<std::vector<std::string>>();
+			args.filenames = result["pack-files"].as<std::vector<std::filesystem::path>>();
 			return true;
 		}
 		if (result["animation-block"].count() > 0)
 		{
 			args.mode = Arguments::Mode::Animations;
-			args.filenames = result["pack-files"].as<std::vector<std::string>>();
+			args.filenames = result["pack-files"].as<std::vector<std::filesystem::path>>();
 			return true;
 		}
 		if (result["meshes-block"].count() > 0)
 		{
 			args.mode = Arguments::Mode::Meshes;
-			args.filenames = result["pack-files"].as<std::vector<std::string>>();
+			args.filenames = result["pack-files"].as<std::vector<std::filesystem::path>>();
 			return true;
 		}
 		if (result["texture-block"].count() > 0)
 		{
 			args.mode = Arguments::Mode::Textures;
-			args.filenames = result["pack-files"].as<std::vector<std::string>>();
+			args.filenames = result["pack-files"].as<std::vector<std::filesystem::path>>();
 			return true;
 		}
 		if (result["block"].count() > 0)
 		{
 			if (result["extract"].count() > 0)
 			{
-				args.outFilename = result["extract"].as<std::string>();
+				args.outFilename = result["extract"].as<std::filesystem::path>();
 			}
 			args.mode = Arguments::Mode::Block;
-			args.filenames = result["pack-files"].as<std::vector<std::string>>();
+			args.filenames = result["pack-files"].as<std::vector<std::filesystem::path>>();
 			args.block = result["block"].as<std::string>();
 			return true;
 		}
 		if (result["write-raw"].count() > 0)
 		{
-			args.outFilename = result["write-raw"].as<std::string>();
+			args.outFilename = result["write-raw"].as<std::filesystem::path>();
 			args.mode = Arguments::Mode::WriteRaw;
-			args.filenames = result["pack-files"].as<std::vector<std::string>>();
+			args.filenames = result["pack-files"].as<std::vector<std::filesystem::path>>();
 			return true;
 		}
 		if (result["animation"].count() > 0)
 		{
 			if (result["extract"].count() > 0)
 			{
-				args.outFilename = result["extract"].as<std::string>();
+				args.outFilename = result["extract"].as<std::filesystem::path>();
 			}
 			args.mode = Arguments::Mode::Animation;
-			args.filenames = result["pack-files"].as<std::vector<std::string>>();
+			args.filenames = result["pack-files"].as<std::vector<std::filesystem::path>>();
 			args.blockId = result["animation"].as<uint32_t>();
 			return true;
 		}
@@ -508,10 +501,10 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 		{
 			if (result["extract"].count() > 0)
 			{
-				args.outFilename = result["extract"].as<std::string>();
+				args.outFilename = result["extract"].as<std::filesystem::path>();
 			}
 			args.mode = Arguments::Mode::Mesh;
-			args.filenames = result["pack-files"].as<std::vector<std::string>>();
+			args.filenames = result["pack-files"].as<std::vector<std::filesystem::path>>();
 			args.blockId = result["mesh"].as<uint32_t>();
 			return true;
 		}
@@ -519,10 +512,10 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 		{
 			if (result["extract"].count() > 0)
 			{
-				args.outFilename = result["extract"].as<std::string>();
+				args.outFilename = result["extract"].as<std::filesystem::path>();
 			}
 			args.mode = Arguments::Mode::Texture;
-			args.filenames = result["pack-files"].as<std::vector<std::string>>();
+			args.filenames = result["pack-files"].as<std::vector<std::filesystem::path>>();
 			args.block = result["texture"].as<std::string>();
 			return true;
 		}

--- a/components/anm/include/ANMFile.h
+++ b/components/anm/include/ANMFile.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <array>
+#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -55,7 +56,7 @@ protected:
 	/// True when a file has been loaded
 	bool _isLoaded;
 
-	std::string _filename;
+	std::filesystem::path _filename;
 
 	ANMHeader _header;
 	std::vector<ANMFrame> _keyframes;
@@ -75,15 +76,15 @@ public:
 	virtual ~ANMFile() = default;
 
 	/// Read anm file from the filesystem
-	void Open(const std::string& file);
+	void Open(const std::filesystem::path& filepath);
 
 	/// Read anm file from a buffer
 	void Open(const std::vector<uint8_t>& buffer);
 
 	/// Write anm file to path on the filesystem
-	void Write(const std::string& file);
+	void Write(const std::filesystem::path& filepath);
 
-	[[nodiscard]] const std::string& GetFilename() const { return _filename; }
+	[[nodiscard]] std::string GetFilename() const { return _filename.string(); }
 	[[nodiscard]] const ANMHeader& GetHeader() const { return _header; }
 	[[nodiscard]] ANMHeader& GetHeader() { return _header; }
 	[[nodiscard]] const std::vector<ANMFrame>& GetKeyframes() const { return _keyframes; }

--- a/components/anm/src/ANMFile.cpp
+++ b/components/anm/src/ANMFile.cpp
@@ -102,7 +102,7 @@ struct imemstream: virtual membuf, std::istream
 /// Error handling
 void ANMFile::Fail(const std::string& msg)
 {
-	throw std::runtime_error("ANM Error: " + msg + "\nFilename: " + _filename);
+	throw std::runtime_error("ANM Error: " + msg + "\nFilename: " + _filename.string());
 }
 
 ANMFile::ANMFile()
@@ -168,11 +168,11 @@ void ANMFile::WriteFile([[maybe_unused]] std::ostream& stream) const
 	stream.write(reinterpret_cast<const char*>(&_header), sizeof(_header));
 }
 
-void ANMFile::Open(const std::string& file)
+void ANMFile::Open(const std::filesystem::path& filepath)
 {
 	assert(!_isLoaded);
 
-	_filename = file;
+	_filename = filepath;
 
 	std::ifstream stream(_filename, std::ios::binary);
 
@@ -190,16 +190,18 @@ void ANMFile::Open(const std::vector<uint8_t>& buffer)
 
 	imemstream stream(reinterpret_cast<const char*>(buffer.data()), buffer.size() * sizeof(buffer[0]));
 
-	_filename = "buffer";
+	// File name set to "buffer" when file is load from a buffer
+	// Impact code using ANMFile::GetFilename method
+	_filename = std::filesystem::path("buffer");
 
 	ReadFile(stream);
 }
 
-void ANMFile::Write(const std::string& file)
+void ANMFile::Write(const std::filesystem::path& filepath)
 {
 	assert(!_isLoaded);
 
-	_filename = file;
+	_filename = filepath;
 
 	std::ofstream stream(_filename, std::ios::binary);
 

--- a/components/l3d/include/L3DFile.h
+++ b/components/l3d/include/L3DFile.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <array>
+#include <filesystem>
 #include <span>
 #include <string>
 #include <vector>
@@ -233,7 +234,7 @@ protected:
 	/// True when a file has been loaded
 	bool _isLoaded;
 
-	std::string _filename;
+	std::filesystem::path _filename;
 
 	L3DHeader _header;
 	std::vector<L3DSubmeshHeader> _submeshHeaders;
@@ -267,15 +268,15 @@ public:
 	virtual ~L3DFile() = default;
 
 	/// Read l3d file from the filesystem
-	void Open(const std::string& file);
+	void Open(const std::filesystem::path& filepath);
 
 	/// Read l3d file from a buffer
 	void Open(const std::vector<uint8_t>& buffer);
 
 	/// Write l3d file to path on the filesystem
-	void Write(const std::string& file);
+	void Write(const std::filesystem::path& filepath);
 
-	[[nodiscard]] const std::string& GetFilename() const { return _filename; }
+	[[nodiscard]] std::string GetFilename() const { return _filename.string(); }
 	[[nodiscard]] const L3DHeader& GetHeader() const { return _header; }
 	[[nodiscard]] const std::vector<L3DSubmeshHeader>& GetSubmeshHeaders() const { return _submeshHeaders; }
 	[[nodiscard]] const std::vector<L3DTexture>& GetSkins() const { return _skins; }

--- a/components/l3d/src/L3DFile.cpp
+++ b/components/l3d/src/L3DFile.cpp
@@ -193,7 +193,7 @@ void add_span(std::vector<std::span<Item>>& container, typename std::vector<Item
 /// Error handling
 void L3DFile::Fail(const std::string& msg)
 {
-	throw std::runtime_error("L3D Error: " + msg + "\nFilename: " + _filename);
+	throw std::runtime_error("L3D Error: " + msg + "\nFilename: " + _filename.string());
 }
 
 L3DFile::L3DFile()
@@ -624,11 +624,11 @@ void L3DFile::WriteFile(std::ostream& stream) const
 	}
 }
 
-void L3DFile::Open(const std::string& file)
+void L3DFile::Open(const std::filesystem::path& filepath)
 {
 	assert(!_isLoaded);
 
-	_filename = file;
+	_filename = filepath;
 
 	std::ifstream stream(_filename, std::ios::binary);
 
@@ -646,16 +646,18 @@ void L3DFile::Open(const std::vector<uint8_t>& buffer)
 
 	imemstream stream(reinterpret_cast<const char*>(buffer.data()), buffer.size() * sizeof(buffer[0]));
 
-	_filename = "buffer";
+	// File name set to "buffer" when file is load from a buffer
+	// Impact code using L3DFile::GetFilename method
+	_filename = std::filesystem::path("buffer");
 
 	ReadFile(stream);
 }
 
-void L3DFile::Write(const std::string& file)
+void L3DFile::Write(const std::filesystem::path& filepath)
 {
 	assert(!_isLoaded);
 
-	_filename = file;
+	_filename = filepath;
 
 	std::ofstream stream(_filename, std::ios::binary);
 

--- a/components/lnd/include/LNDFile.h
+++ b/components/lnd/include/LNDFile.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -159,7 +160,7 @@ protected:
 	/// True when a file has been loaded
 	bool _isLoaded;
 
-	std::string _filename;
+	std::filesystem::path _filename;
 
 	LNDHeader _header;
 	std::vector<LNDLowResolutionTexture> _lowResolutionTextures;
@@ -188,12 +189,12 @@ public:
 	virtual ~LNDFile() = default;
 
 	/// Read l3d file from the filesystem
-	void Open(const std::string& file);
+	void Open(const std::filesystem::path& filepath);
 
 	/// Write l3d file to path on the filesystem
-	void Write(const std::string& file);
+	void Write(const std::filesystem::path& filepath);
 
-	[[nodiscard]] const std::string& GetFilename() const { return _filename; }
+	[[nodiscard]] std::string GetFilename() const { return _filename.string(); }
 	[[nodiscard]] const auto& GetHeader() const { return _header; }
 	[[nodiscard]] const auto& GetLowResolutionTextures() const { return _lowResolutionTextures; }
 	[[nodiscard]] const auto& GetBlocks() const { return _blocks; }

--- a/components/lnd/src/LNDFile.cpp
+++ b/components/lnd/src/LNDFile.cpp
@@ -119,7 +119,7 @@ LNDFile::LNDFile()
 /// Error handling
 void LNDFile::Fail(const std::string& msg)
 {
-	throw std::runtime_error("LND Error: " + msg + "\nFilename: " + _filename);
+	throw std::runtime_error("LND Error: " + msg + "\nFilename: " + _filename.string());
 }
 
 void LNDFile::ReadFile(std::istream& stream)
@@ -241,11 +241,11 @@ void LNDFile::WriteFile(std::ostream& stream) const
 	stream.write(reinterpret_cast<const char*>(_unaccounted.data()), _unaccounted.size() * sizeof(_unaccounted[0]));
 }
 
-void LNDFile::Open(const std::string& file)
+void LNDFile::Open(const std::filesystem::path& filepath)
 {
 	assert(!_isLoaded);
 
-	_filename = file;
+	_filename = filepath;
 
 	std::ifstream stream(_filename, std::ios::binary);
 
@@ -257,11 +257,11 @@ void LNDFile::Open(const std::string& file)
 	ReadFile(stream);
 }
 
-void LNDFile::Write(const std::string& file)
+void LNDFile::Write(const std::filesystem::path& filepath)
 {
 	assert(!_isLoaded);
 
-	_filename = file;
+	_filename = filepath;
 
 	std::ofstream stream(_filename, std::ios::binary);
 

--- a/components/morph/include/MorphFile.h
+++ b/components/morph/include/MorphFile.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <array>
+#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -124,7 +125,7 @@ struct AnimationSetDesc
 
 struct AnimationSpecs
 {
-	std::string path;
+	std::filesystem::path path;
 	uint32_t version;
 	std::vector<AnimationSetDesc> animation_sets;
 };
@@ -158,7 +159,7 @@ protected:
 	/// True when a file has been loaded
 	bool _isLoaded;
 
-	std::string _filename;
+	std::filesystem::path _filename;
 
 	MorphHeader _header;
 	AnimationSpecs _animation_specs;
@@ -172,8 +173,8 @@ protected:
 	void Fail(const std::string& msg);
 
 	/// Read file from the input source
-	virtual void ReadFile(std::istream& stream, const std::string& specs_directory);
-	void ReadSpecFile(const std::string& spec_file_path);
+	virtual void ReadFile(std::istream& stream, const std::filesystem::path& specs_directory);
+	void ReadSpecFile(const std::filesystem::path& spec_file_path);
 	std::vector<Animation> ReadAnimations(std::istream& stream, const std::vector<uint32_t>& offsets);
 	HairGroup ReadHairGroup(std::istream& stream);
 
@@ -183,12 +184,12 @@ public:
 	virtual ~MorphFile();
 
 	/// Read morph file from the filesystem
-	void Open(const std::string& file, const std::string& specs_directory);
+	void Open(const std::filesystem::path& filepath, const std::filesystem::path& specs_directory);
 
 	/// Read morph file from a buffer
-	void Open(const std::vector<uint8_t>& buffer, const std::string& specs_directory);
+	void Open(const std::vector<uint8_t>& buffer, const std::filesystem::path& specs_directory);
 
-	[[nodiscard]] const std::string& GetFilename() const { return _filename; }
+	[[nodiscard]] std::string GetFilename() const { return _filename.string(); }
 	[[nodiscard]] const MorphHeader& GetHeader() const { return _header; }
 	[[nodiscard]] const AnimationSpecs& GetAnimationSpecs() const { return _animation_specs; }
 	[[nodiscard]] const std::vector<Animation>& GetBaseAnimationSet() const { return _base_animation; }

--- a/components/morph/src/MorphFile.cpp
+++ b/components/morph/src/MorphFile.cpp
@@ -171,7 +171,7 @@ std::istream& safe_getline(std::istream& is, std::string& t)
 /// Error handling
 void MorphFile::Fail(const std::string& msg)
 {
-	throw std::runtime_error("MorphFile Error: " + msg + "\nFilename: " + _filename);
+	throw std::runtime_error("MorphFile Error: " + msg + "\nFilename: " + _filename.string());
 }
 
 MorphFile::MorphFile()
@@ -181,7 +181,7 @@ MorphFile::MorphFile()
 
 MorphFile::~MorphFile() = default;
 
-void MorphFile::ReadSpecFile(const std::string& spec_file_path)
+void MorphFile::ReadSpecFile(const std::filesystem::path& spec_file_path)
 {
 	assert(!_isLoaded);
 
@@ -190,13 +190,13 @@ void MorphFile::ReadSpecFile(const std::string& spec_file_path)
 	std::ifstream spec(_animation_specs.path);
 	if (!spec.good())
 	{
-		Fail("Failed to read spec file: " + _animation_specs.path);
+		Fail("Failed to read spec file: " + _animation_specs.path.string());
 	}
 	std::string line;
 	spec >> _animation_specs.version >> std::ws;
 	if (_header.spec_file_version != _animation_specs.version)
 	{
-		Fail("Spec file version mismatch: " + _animation_specs.path);
+		Fail("Spec file version mismatch: " + _animation_specs.path.string());
 	}
 
 	[[maybe_unused]] bool reached_end = false;
@@ -219,7 +219,7 @@ void MorphFile::ReadSpecFile(const std::string& spec_file_path)
 		{
 			if (_animation_specs.animation_sets.empty())
 			{
-				Fail("Spec file has animations before categories: " + _animation_specs.path);
+				Fail("Spec file has animations before categories: " + _animation_specs.path.string());
 			}
 			_animation_specs.animation_sets.back().animations.emplace_back(
 			    AnimationDesc {line, static_cast<AnimationType>(type)});
@@ -281,7 +281,7 @@ HairGroup MorphFile::ReadHairGroup(std::istream& stream)
 	return hair_group;
 }
 
-void MorphFile::ReadFile(std::istream& stream, const std::string& specs_directory)
+void MorphFile::ReadFile(std::istream& stream, const std::filesystem::path& specs_directory)
 {
 	assert(!_isLoaded);
 
@@ -315,7 +315,7 @@ void MorphFile::ReadFile(std::istream& stream, const std::string& specs_director
 	{
 		spec_name = "hndspec" + std::to_string(_header.spec_file_version) + ".txt";
 	}
-	ReadSpecFile(specs_directory + "/" + spec_name);
+	ReadSpecFile(specs_directory / spec_name);
 	size_t num_animations = 0;
 	for (auto& anim_set : _animation_specs.animation_sets)
 	{
@@ -379,11 +379,11 @@ void MorphFile::ReadFile(std::istream& stream, const std::string& specs_director
 	_isLoaded = true;
 }
 
-void MorphFile::Open(const std::string& file, const std::string& specs_directory)
+void MorphFile::Open(const std::filesystem::path& filepath, const std::filesystem::path& specs_directory)
 {
 	assert(!_isLoaded);
 
-	_filename = file;
+	_filename = filepath;
 
 	std::ifstream stream(_filename, std::ios::binary);
 
@@ -395,7 +395,7 @@ void MorphFile::Open(const std::string& file, const std::string& specs_directory
 	ReadFile(stream, specs_directory);
 }
 
-void MorphFile::Open(const std::vector<uint8_t>& buffer, const std::string& specs_directory)
+void MorphFile::Open(const std::vector<uint8_t>& buffer, const std::filesystem::path& specs_directory)
 {
 	assert(!_isLoaded);
 

--- a/components/pack/include/PackFile.h
+++ b/components/pack/include/PackFile.h
@@ -141,7 +141,7 @@ public:
 	void Open(const std::filesystem::path& file);
 
 	/// Write pack file to path on the filesystem
-	void Write(const std::string& file);
+	void Write(const std::filesystem::path& file);
 
 	/// Create Texture Blocks from textures
 	void CreateTextureBlocks();
@@ -158,7 +158,7 @@ public:
 	/// Create Body block from look-up table
 	void CreateBodyBlock();
 
-	[[nodiscard]] const std::filesystem::path& GetFilename() const { return _filename; }
+	[[nodiscard]] std::string GetFilename() const { return _filename.string(); }
 	[[nodiscard]] const std::map<std::string, std::vector<uint8_t>>& GetBlocks() const { return _blocks; }
 	[[nodiscard]] bool HasBlock(const std::string& name) const { return _blocks.count(name); }
 	[[nodiscard]] const std::vector<uint8_t>& GetBlock(const std::string& name) const { return _blocks.at(name); }

--- a/components/pack/src/PackFile.cpp
+++ b/components/pack/src/PackFile.cpp
@@ -510,7 +510,7 @@ void PackFile::Open(const std::filesystem::path& file)
 	_isLoaded = true;
 }
 
-void PackFile::Write(const std::string& file)
+void PackFile::Write(const std::filesystem::path& file)
 {
 	assert(!_isLoaded);
 

--- a/src/3D/L3DAnim.cpp
+++ b/src/3D/L3DAnim.cpp
@@ -60,7 +60,7 @@ bool L3DAnim::LoadFromFile(const std::filesystem::path& path)
 
 	try
 	{
-		anm.Open(Game::instance()->GetFileSystem().FindPath(path).string());
+		anm.Open(Game::instance()->GetFileSystem().FindPath(path));
 	}
 	catch (std::runtime_error& err)
 	{

--- a/src/3D/L3DMesh.cpp
+++ b/src/3D/L3DMesh.cpp
@@ -77,8 +77,7 @@ void L3DMesh::Load(const l3d::L3DFile& l3d)
 		auto subMesh = std::make_unique<L3DSubMesh>(*this);
 		if (!subMesh->Load(l3d, i))
 		{
-			auto& fileName = l3d.GetFilename();
-			SPDLOG_LOGGER_ERROR(spdlog::get("game"), "Failed to open L3DSubMesh from file: {}", fileName);
+			SPDLOG_LOGGER_ERROR(spdlog::get("game"), "Failed to open L3DSubMesh from file: {}", l3d.GetFilename());
 			continue;
 		}
 		if (subMesh->GetFlags().isPhysics)
@@ -110,7 +109,7 @@ bool L3DMesh::LoadFromFile(const std::filesystem::path& path)
 
 	try
 	{
-		l3d.Open(Game::instance()->GetFileSystem().FindPath(path).string());
+		l3d.Open(Game::instance()->GetFileSystem().FindPath(path));
 	}
 	catch (std::runtime_error& err)
 	{

--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -34,18 +34,18 @@ LandIsland::LandIsland()
 
 LandIsland::~LandIsland() = default;
 
-void LandIsland::LoadFromFile(const std::string& filename)
+void LandIsland::LoadFromFile(const std::filesystem::path& path)
 {
-	SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "Loading Land from file: {}", filename);
+	SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "Loading Land from file: {}", path.string());
 	lnd::LNDFile lnd;
 
 	try
 	{
-		lnd.Open(filename);
+		lnd.Open(path);
 	}
 	catch (std::runtime_error& err)
 	{
-		SPDLOG_LOGGER_ERROR(spdlog::get("game"), "Failed to open lnd file from filesystem {}: {}", filename, err.what());
+		SPDLOG_LOGGER_ERROR(spdlog::get("game"), "Failed to open lnd file from filesystem {}: {}", path.string(), err.what());
 		return;
 	}
 

--- a/src/3D/LandIsland.h
+++ b/src/3D/LandIsland.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <array>
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <vector>
@@ -43,7 +44,7 @@ public:
 	LandIsland();
 	~LandIsland();
 
-	void LoadFromFile(const std::string& filename);
+	void LoadFromFile(const std::filesystem::path& filename);
 
 	[[nodiscard]] float GetHeightAt(glm::vec2) const;
 	[[nodiscard]] const LandBlock* GetBlock(const glm::u8vec2& coordinates) const;

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -649,7 +649,7 @@ void Game::LoadLandscape(const std::filesystem::path& path)
 		throw std::runtime_error("Could not find landscape " + path.generic_string());
 
 	_landIsland = std::make_unique<LandIsland>();
-	_landIsland->LoadFromFile(fixedName.string());
+	_landIsland->LoadFromFile(fixedName);
 
 	_dynamicsSystem->RegisterIslandRigidBodies(*_landIsland);
 }

--- a/src/Parsers/InfoFile.cpp
+++ b/src/Parsers/InfoFile.cpp
@@ -27,7 +27,7 @@ bool InfoFile::LoadFromFile(const std::filesystem::path& path, InfoConstants& in
 	try
 	{
 		pack::PackFile pack;
-		pack.Open(Game::instance()->GetFileSystem().FindPath(path).string());
+		pack.Open(Game::instance()->GetFileSystem().FindPath(path));
 		data = pack.GetBlock("Info");
 		if (data.size() != sizeof(InfoConstants))
 		{


### PR DESCRIPTION
Fixes #377 

In components:

- [x] anm
- [x] l3d
- [x] morph
- [x] lnd
- [x] pack (fix)

In apps:

- [x] anmtool
- [x] l3dtool
- [x] morphtool
- [x] lnd
- [x] packtool