### PR TITLE
actions: Merge config permutations

### DIFF
--- a/.github/workflows/ci-cross-compile.yml
+++ b/.github/workflows/ci-cross-compile.yml
@@ -50,12 +50,14 @@ jobs:
         with:
           vcpkgJsonGlob: 'vcpkg.json'
 
-      - name: Run CMake+vcpkg to generate (Config).
+      - name: Configure CMake+vcpkg.
         uses: lukka/run-cmake@v10
         with:
           configurePreset: '${{ matrix.preset }}'
         env:
           ANDROID_NDK_HOME: '/usr/local/lib/android/sdk/ndk/23.1.7779620'
+          CXX: ''
+          CC: ''
 
       - name: Run CMake+vcpkg to build (Debug).
         uses: lukka/run-cmake@v10
@@ -64,6 +66,8 @@ jobs:
           buildPreset: '${{ matrix.preset }}-debug'
         env:
           ANDROID_NDK_HOME: '/usr/local/lib/android/sdk/ndk/23.1.7779620'
+          CXX: ''
+          CC: ''
 
       - name: Run CMake+vcpkg to build (Release).
         uses: lukka/run-cmake@v10
@@ -72,6 +76,8 @@ jobs:
           buildPreset: '${{ matrix.preset }}-release'
         env:
           ANDROID_NDK_HOME: '/usr/local/lib/android/sdk/ndk/23.1.7779620'
+          CXX: ''
+          CC: ''
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci-cross-compile.yml
+++ b/.github/workflows/ci-cross-compile.yml
@@ -13,14 +13,12 @@ jobs:
       matrix:
         # This is the matrix. They form permutations.
         os: [ubuntu-latest]
-        config: [debug, release]
         preset: [android-armeabi-v7a-vcpkg, android-arm64-v8a-vcpkg, android-x86-vcpkg, android-x86_64-vcpkg]
         triplet: [""]
         # These are additional individual jobs. There are no permutations of these.
         include:
           # Testing x86-windows bit in debug only
           - os: windows-latest
-            config: debug
             preset: ninja-multi-vcpkg
             triplet: x86-windows
 
@@ -52,12 +50,26 @@ jobs:
         with:
           vcpkgJsonGlob: 'vcpkg.json'
 
-      - name: Run CMake+vcpkg+Ninja+CTest to generate/build.
+      - name: Run CMake+vcpkg to generate (Config).
         uses: lukka/run-cmake@v10
-        id: runcmake
         with:
           configurePreset: '${{ matrix.preset }}'
-          buildPreset: '${{ matrix.preset }}-${{ matrix.config }}'
+        env:
+          ANDROID_NDK_HOME: '/usr/local/lib/android/sdk/ndk/23.1.7779620'
+
+      - name: Run CMake+vcpkg to build (Debug).
+        uses: lukka/run-cmake@v10
+        with:
+          configurePreset: '${{ matrix.preset }}'
+          buildPreset: '${{ matrix.preset }}-debug'
+        env:
+          ANDROID_NDK_HOME: '/usr/local/lib/android/sdk/ndk/23.1.7779620'
+
+      - name: Run CMake+vcpkg to build (Release).
+        uses: lukka/run-cmake@v10
+        with:
+          configurePreset: '${{ matrix.preset }}'
+          buildPreset: '${{ matrix.preset }}-release'
         env:
           ANDROID_NDK_HOME: '/usr/local/lib/android/sdk/ndk/23.1.7779620'
 

--- a/.github/workflows/ci-vcpkg.yml
+++ b/.github/workflows/ci-vcpkg.yml
@@ -13,14 +13,12 @@ jobs:
       matrix:
         # This is the matrix. They form permutations.
         os: [ubuntu-latest, macos-latest, windows-latest, windows-2019]
-        config: [debug, release]
         cc: [""]
         cxx: [""]
         # These are additional individual jobs. There are no permutations of these.
         include:
           # Testing clang
           - os: ubuntu-latest
-            config: debug
             cc: clang
             cxx: clang++
 
@@ -53,13 +51,24 @@ jobs:
           vcpkgJsonGlob: 'vcpkg.json'
             # doNotCache: true
 
-      - name: Run CMake+vcpkg+Ninja+CTest to generate/build/test.
+      - name: Run CMake+vcpkg+Ninja to generate (Config).
         uses: lukka/run-cmake@v10
-        id: runcmake
         with:
           configurePreset: 'ninja-multi-vcpkg'
-          buildPreset: 'ninja-multi-vcpkg-${{ matrix.config }}'
-          testPreset: 'ninja-multi-vcpkg-${{ matrix.config }}'
+
+      - name: Run CMake+vcpkg+Ninja+CTest to build/test (Debug).
+        uses: lukka/run-cmake@v10
+        with:
+          configurePreset: 'ninja-multi-vcpkg'
+          buildPreset: 'ninja-multi-vcpkg-debug'
+          testPreset: 'ninja-multi-vcpkg-debug'
+
+      - name: Run CMake+vcpkg+Ninja+CTest to build/test (Release).
+        uses: lukka/run-cmake@v10
+        with:
+          configurePreset: 'ninja-multi-vcpkg'
+          buildPreset: 'ninja-multi-vcpkg-release'
+          testPreset: 'ninja-multi-vcpkg-release'
 
       - name: Upload compiled openblack and tools
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci-vcpkg.yml
+++ b/.github/workflows/ci-vcpkg.yml
@@ -51,10 +51,13 @@ jobs:
           vcpkgJsonGlob: 'vcpkg.json'
             # doNotCache: true
 
-      - name: Run CMake+vcpkg+Ninja to generate (Config).
+      - name: Configure CMake+vcpkg+Ninja to generate.
         uses: lukka/run-cmake@v10
         with:
           configurePreset: 'ninja-multi-vcpkg'
+        env:
+          CC: ${{matrix.cc}}
+          CXX: ${{matrix.cxx}}
 
       - name: Run CMake+vcpkg+Ninja+CTest to build/test (Debug).
         uses: lukka/run-cmake@v10
@@ -62,6 +65,9 @@ jobs:
           configurePreset: 'ninja-multi-vcpkg'
           buildPreset: 'ninja-multi-vcpkg-debug'
           testPreset: 'ninja-multi-vcpkg-debug'
+        env:
+          CC: ${{matrix.cc}}
+          CXX: ${{matrix.cxx}}
 
       - name: Run CMake+vcpkg+Ninja+CTest to build/test (Release).
         uses: lukka/run-cmake@v10
@@ -69,6 +75,9 @@ jobs:
           configurePreset: 'ninja-multi-vcpkg'
           buildPreset: 'ninja-multi-vcpkg-release'
           testPreset: 'ninja-multi-vcpkg-release'
+        env:
+          CC: ${{matrix.cc}}
+          CXX: ${{matrix.cxx}}
 
       - name: Upload compiled openblack and tools
         uses: actions/upload-artifact@v3

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -22,6 +22,7 @@
       "name": "template-android-vcpkg",
       "hidden": true,
       "binaryDir": "${sourceDir}/cmake-build-presets/${presetName}",
+      "generator": "Ninja Multi-Config",
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": {
           "type": "FILEPATH",


### PR DESCRIPTION
Implements #410 

Since the configure step using vcpkg builds both `dbg` and `rel`, we're losing a lot of time to rebuilding vcpkg dependencies by doing config in the two types of config builds.
In the case of a cache miss, it can take 15-25 minutes to rebuild the vcpkg dependencies for both Debug and Release builds.
Merging both debug and release into the same build allows us to remove one Config step (15-25 minutes).
It also cuts the number of builds by half which would reduce the load on the caching which probably will result in more cache hits.
Building openblack after configuration takes about 2-4 minutes so in the case of a cache hit, the build takes 2-4 minutes longer. However, there are less builds running per commit, therefore more runners can go simultaneously.