### PR TITLE
ci: Prevent two jobs from having the same cache keys

### DIFF
--- a/.github/workflows/ci-cross-compile.yml
+++ b/.github/workflows/ci-cross-compile.yml
@@ -49,6 +49,8 @@ jobs:
         id: runvcpkg
         with:
           vcpkgJsonGlob: 'vcpkg.json'
+          # Prevent all ubuntu-latest and windows-latest builds from having the same key
+          appendedCacheKey: ${{matrix.preset}}${{matrix.triplet}}
 
       - name: Configure CMake+vcpkg.
         uses: lukka/run-cmake@v10

--- a/.github/workflows/ci-vcpkg.yml
+++ b/.github/workflows/ci-vcpkg.yml
@@ -49,6 +49,8 @@ jobs:
         id: runvcpkg
         with:
           vcpkgJsonGlob: 'vcpkg.json'
+          # Prevent ubuntu-latest and ubuntu-latest (clang) from having the same key
+          appendedCacheKey: ${{matrix.cc}}
             # doNotCache: true
 
       - name: Configure CMake+vcpkg+Ninja to generate.


### PR DESCRIPTION
Currently, windows-latest jobs have the same key as the windows-latest x86 cross compile test.
Additionally, all the android build jobs have the same key regardless of architecture.
They aren't the worst conflicts but they do happen. The clang and non-clang ubuntu are the worst case because they create artifacts of the same name but they aren't the same.
Hopefully this will make for more cache hits.