### PR TITLE
clang-format: Add order include configuration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -41,7 +41,27 @@ ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 FixNamespaceComments: true
-IncludeBlocks: Preserve
+IncludeBlocks: Regroup
+# https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes
+IncludeCategories:
+  # cpp standard libs starting with c
+  - Regex:           '^<chrono>'
+    Priority:        2
+  # c standard libs
+  - Regex:           '^<c[^\.]*>'
+    Priority:        1
+  # c++ standard libs
+  - Regex:           '^<[^\.]*>'
+    Priority:        2
+  # external libs
+  - Regex:           '^<.*>'
+    Priority:        3
+  # non-relative includes
+  - Regex:           '"[^\.].*"'
+    Priority:        4
+  # everything else
+  - Regex:           '.*'
+    Priority:        5
 IndentCaseLabels: false
 IndentWidth: 4
 IndentWrappedFunctionNames: false

--- a/apps/anmtool/anmtool.cpp
+++ b/apps/anmtool/anmtool.cpp
@@ -7,11 +7,11 @@
  * openblack is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <ANMFile.h>
-
 #include <cstdlib>
+
 #include <string>
 
+#include <ANMFile.h>
 #include <cxxopts.hpp>
 
 #define TINYGLTF_IMPLEMENTATION

--- a/apps/l3dtool/l3dtool.cpp
+++ b/apps/l3dtool/l3dtool.cpp
@@ -7,13 +7,13 @@
  * openblack is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <L3DFile.h>
-
 #include <cstdlib>
+
 #include <filesystem>
 #include <stack>
 #include <string>
 
+#include <L3DFile.h>
 #include <cxxopts.hpp>
 
 #define TINYGLTF_IMPLEMENTATION

--- a/apps/lndtool/lndtool.cpp
+++ b/apps/lndtool/lndtool.cpp
@@ -7,12 +7,13 @@
  * openblack is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <LNDFile.h>
-
 #include <cstdlib>
-#include <cxxopts.hpp>
+
 #include <fstream>
 #include <string>
+
+#include <LNDFile.h>
+#include <cxxopts.hpp>
 
 int PrintRawBytes(const void* data, std::size_t size)
 {

--- a/apps/morphtool/morphtool.cpp
+++ b/apps/morphtool/morphtool.cpp
@@ -7,13 +7,13 @@
  * openblack is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <MorphFile.h>
-
 #include <cstdlib>
+
+#include <fstream>
 #include <string>
 
+#include <MorphFile.h>
 #include <cxxopts.hpp>
-#include <fstream>
 
 int ListDetails(openblack::morph::MorphFile& morph)
 {

--- a/apps/packtool/packtool.cpp
+++ b/apps/packtool/packtool.cpp
@@ -7,12 +7,13 @@
  * openblack is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <PackFile.h>
-
 #include <cstdlib>
-#include <cxxopts.hpp>
+
 #include <fstream>
 #include <string>
+
+#include <PackFile.h>
+#include <cxxopts.hpp>
 
 int PrintRawBytes(const void* data, std::size_t size)
 {

--- a/components/ScriptLibrary/include/LHVM/LHVM.h
+++ b/components/ScriptLibrary/include/LHVM/LHVM.h
@@ -9,10 +9,11 @@
 
 #pragma once
 
-#include <LHVM/VMInstruction.h>
-#include <LHVM/VMScript.h>
 #include <string>
 #include <vector>
+
+#include <LHVM/VMInstruction.h>
+#include <LHVM/VMScript.h>
 
 namespace openblack
 {

--- a/components/ScriptLibrary/include/LHVM/VMInstruction.h
+++ b/components/ScriptLibrary/include/LHVM/VMInstruction.h
@@ -9,7 +9,8 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
+
 #include <string>
 
 namespace openblack

--- a/components/ScriptLibrary/src/LHVM.cpp
+++ b/components/ScriptLibrary/src/LHVM.cpp
@@ -7,14 +7,16 @@
  * openblack is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <array>
+#include "LHVM/LHVM.h"
+
 #include <cstdio>
 #include <cstring>
+
+#include <array>
 #include <stdexcept>
 
-#include <LHVM/LHVM.h>
-#include <LHVM/OpcodeNames.h>
-#include <LHVM/VMInstruction.h>
+#include "LHVM/OpcodeNames.h"
+#include "LHVM/VMInstruction.h"
 
 namespace openblack::LHVM
 {

--- a/components/anm/src/ANMFile.cpp
+++ b/components/anm/src/ANMFile.cpp
@@ -45,10 +45,11 @@
  *
  */
 
-#include <ANMFile.h>
+#include "ANMFile.h"
 
 #include <cassert>
 #include <cstring>
+
 #include <fstream>
 #include <vector>
 

--- a/components/l3d/src/L3DFile.cpp
+++ b/components/l3d/src/L3DFile.cpp
@@ -121,10 +121,11 @@
  *
  */
 
-#include <L3DFile.h>
+#include "L3DFile.h"
 
 #include <cassert>
 #include <cstring>
+
 #include <fstream>
 #include <limits>
 #include <vector>

--- a/components/lnd/src/LNDFile.cpp
+++ b/components/lnd/src/LNDFile.cpp
@@ -102,9 +102,10 @@
  * ------------------------ end of file ----------------------------------------
  */
 
-#include <LNDFile.h>
+#include "LNDFile.h"
 
 #include <cassert>
+
 #include <fstream>
 #include <stdexcept>
 

--- a/components/morph/src/MorphFile.cpp
+++ b/components/morph/src/MorphFile.cpp
@@ -77,11 +77,12 @@
  *
  */
 
-#include <MorphFile.h>
+#include "MorphFile.h"
 
-#include <algorithm>
 #include <cassert>
 #include <cstring>
+
+#include <algorithm>
 #include <fstream>
 #include <vector>
 

--- a/components/pack/src/PackFile.cpp
+++ b/components/pack/src/PackFile.cpp
@@ -79,10 +79,11 @@
  *
  */
 
-#include <PackFile.h>
+#include "PackFile.h"
 
 #include <cassert>
 #include <cstring>
+
 #include <fstream>
 
 using namespace openblack::pack;

--- a/src/3D/AllMeshes.h
+++ b/src/3D/AllMeshes.h
@@ -9,10 +9,10 @@
 
 #pragma once
 
-#include <fmt/format.h>
-
 #include <array>
 #include <string>
+
+#include <fmt/format.h>
 
 //  626 Meshes.
 //  441 Anims.

--- a/src/3D/Camera.cpp
+++ b/src/3D/Camera.cpp
@@ -9,11 +9,12 @@
 
 #include "Camera.h"
 
+#include <optional>
+
 #include <glm/gtx/euler_angles.hpp>
 #include <glm/gtx/intersect.hpp>
 #include <glm/gtx/norm.hpp>
 #include <glm/gtx/spline.hpp>
-#include <optional>
 
 #include "3D/LandIsland.h"
 #include "ECS/Registry.h"

--- a/src/3D/Camera.h
+++ b/src/3D/Camera.h
@@ -9,12 +9,13 @@
 
 #pragma once
 
-#include <SDL_events.h>
 #include <chrono>
-#include <glm/glm.hpp>
-#include <glm/gtc/matrix_transform.hpp>
 #include <memory>
 #include <optional>
+
+#include <SDL_events.h>
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
 
 #include "ECS/Components/Transform.h"
 

--- a/src/3D/L3DMesh.cpp
+++ b/src/3D/L3DMesh.cpp
@@ -9,9 +9,7 @@
 
 #include "L3DMesh.h"
 
-#include "Common/FileSystem.h"
-#include "Common/IStream.h"
-#include "Game.h"
+#include <stdexcept>
 
 #include <BulletCollision/CollisionShapes/btConvexHullShape.h>
 #include <L3DFile.h>
@@ -19,7 +17,9 @@
 #include <glm/matrix.hpp>
 #include <spdlog/spdlog.h>
 
-#include <stdexcept>
+#include "Common/FileSystem.h"
+#include "Common/IStream.h"
+#include "Game.h"
 
 using namespace openblack;
 using namespace openblack::graphics;

--- a/src/3D/L3DSubMesh.cpp
+++ b/src/3D/L3DSubMesh.cpp
@@ -9,17 +9,17 @@
 
 #include "L3DSubMesh.h"
 
-#include "Game.h"
-#include "Graphics/IndexBuffer.h"
-#include "Graphics/ShaderProgram.h"
-#include "Graphics/VertexBuffer.h"
-#include "L3DMesh.h"
-
 #include <glm/glm.hpp>
 #include <glm/gtc/type_ptr.hpp>
 #include <glm/gtx/component_wise.hpp>
 #include <glm/gtx/vec_swizzle.hpp>
 #include <spdlog/spdlog.h>
+
+#include "Game.h"
+#include "Graphics/IndexBuffer.h"
+#include "Graphics/ShaderProgram.h"
+#include "Graphics/VertexBuffer.h"
+#include "L3DMesh.h"
 
 using namespace openblack::graphics;
 

--- a/src/3D/L3DSubMesh.h
+++ b/src/3D/L3DSubMesh.h
@@ -9,16 +9,18 @@
 
 #pragma once
 
-#include "../Graphics/RenderPass.h"
-#include "AxisAlignedBoundingBox.h"
+#include <cstdint>
+
+#include <memory>
+#include <vector>
 
 #include <L3DFile.h>
 #include <bgfx/bgfx.h>
 #include <glm/fwd.hpp>
 
-#include <cstdint>
-#include <memory>
-#include <vector>
+#include "AxisAlignedBoundingBox.h"
+
+#include "../Graphics/RenderPass.h"
 
 namespace openblack
 {

--- a/src/3D/LandBlock.cpp
+++ b/src/3D/LandBlock.cpp
@@ -9,16 +9,17 @@
 
 #include "LandBlock.h"
 
-#include "Dynamics/LandBlockBulletMeshInterface.h"
-#include "Graphics/VertexBuffer.h"
-#include "LandIsland.h"
+#include <cassert>
+
+#include <utility>
 
 #include <BulletDynamics/Dynamics/btRigidBody.h>
 #include <LNDFile.h>
 #include <glm/gtc/type_ptr.hpp>
 
-#include <cassert>
-#include <utility>
+#include "Dynamics/LandBlockBulletMeshInterface.h"
+#include "Graphics/VertexBuffer.h"
+#include "LandIsland.h"
 
 using namespace openblack;
 using namespace openblack::graphics;

--- a/src/3D/LandBlock.h
+++ b/src/3D/LandBlock.h
@@ -9,12 +9,12 @@
 
 #pragma once
 
-#include "Graphics/Mesh.h"
-#include "Graphics/ShaderProgram.h"
+#include <cstdint>
 
 #include <glm/fwd.hpp>
 
-#include <cstdint>
+#include "Graphics/Mesh.h"
+#include "Graphics/ShaderProgram.h"
 
 class btBvhTriangleMeshShape;
 class btRigidBody;

--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -10,16 +10,16 @@
 #include "LandIsland.h"
 
 #define STB_IMAGE_WRITE_IMPLEMENTATION
+#include <stdexcept>
+
+#include <BulletDynamics/Dynamics/btRigidBody.h>
+#include <LNDFile.h>
+#include <spdlog/spdlog.h>
+
 #include "Common/IStream.h"
 #include "Common/stb_image_write.h"
 #include "Dynamics/LandBlockBulletMeshInterface.h"
 #include "Game.h"
-
-#include <BulletDynamics/Dynamics/btRigidBody.h>
-#include <spdlog/spdlog.h>
-
-#include <LNDFile.h>
-#include <stdexcept>
 
 using namespace openblack;
 using namespace openblack::graphics;

--- a/src/3D/Sky.h
+++ b/src/3D/Sky.h
@@ -9,12 +9,12 @@
 
 #pragma once
 
-#include "Graphics/RenderPass.h"
+#include <array>
+#include <memory>
 
 #include <glm/fwd.hpp>
 
-#include <array>
-#include <memory>
+#include "Graphics/RenderPass.h"
 
 namespace openblack
 {

--- a/src/3D/Water.cpp
+++ b/src/3D/Water.cpp
@@ -9,6 +9,8 @@
 
 #include "Water.h"
 
+#include <glm/vec2.hpp>
+
 #include "Common/FileSystem.h"
 #include "Game.h"
 #include "Graphics/FrameBuffer.h"
@@ -17,8 +19,6 @@
 #include "Graphics/ShaderProgram.h"
 #include "Graphics/Texture2D.h"
 #include "Graphics/VertexBuffer.h"
-
-#include <glm/vec2.hpp>
 
 using namespace openblack;
 using namespace openblack::graphics;

--- a/src/Common/Bitmap16B.h
+++ b/src/Common/Bitmap16B.h
@@ -10,9 +10,9 @@
 #pragma once
 
 #include <cstdint>
-#include <string>
 
 #include <filesystem>
+#include <string>
 
 namespace openblack
 {

--- a/src/Common/EventManager.h
+++ b/src/Common/EventManager.h
@@ -7,11 +7,13 @@
  * openblack is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <Common/Queue.h>
-#include <SDL.h>
 #include <functional>
 #include <stdexcept>
 #include <unordered_map>
+
+#include <SDL.h>
+
+#include "Queue.h"
 
 #pragma once
 

--- a/src/Common/FileStream.cpp
+++ b/src/Common/FileStream.cpp
@@ -9,10 +9,11 @@
 
 #include "FileStream.h"
 
-#include <spdlog/fmt/fmt.h>
-
 #include <cassert>
+
 #include <stdexcept>
+
+#include <spdlog/fmt/fmt.h>
 
 namespace openblack
 {

--- a/src/Common/FileStream.h
+++ b/src/Common/FileStream.h
@@ -9,9 +9,9 @@
 
 #pragma once
 
-#include "IStream.h"
-
 #include <filesystem>
+
+#include "IStream.h"
 
 namespace openblack
 {

--- a/src/Common/FileSystem.cpp
+++ b/src/Common/FileSystem.cpp
@@ -9,10 +9,11 @@
 
 #include "FileSystem.h"
 
-#include <algorithm>
-#include <array>
 #include <cctype>
 #include <cstddef>
+
+#include <algorithm>
+#include <array>
 
 namespace openblack
 {

--- a/src/Common/FileSystem.h
+++ b/src/Common/FileSystem.h
@@ -9,12 +9,13 @@
 
 #pragma once
 
-#include "FileStream.h"
-
 #include <cstddef>
+
 #include <list>
 #include <memory>
 #include <vector>
+
+#include "FileStream.h"
 
 namespace openblack
 {

--- a/src/Common/MemoryStream.cpp
+++ b/src/Common/MemoryStream.cpp
@@ -9,9 +9,10 @@
 
 #include "MemoryStream.h"
 
-#include <algorithm>
 #include <cstddef>
 #include <cstdint> // uint8_t
+
+#include <algorithm>
 
 namespace openblack
 {

--- a/src/Common/Zip.cpp
+++ b/src/Common/Zip.cpp
@@ -10,6 +10,7 @@
 #include "Zip.h"
 
 #include <cassert>
+
 #include <limits>
 #include <stdexcept>
 

--- a/src/Common/Zip.h
+++ b/src/Common/Zip.h
@@ -11,6 +11,7 @@
 
 #include <cstddef>
 #include <cstdint>
+
 #include <vector>
 
 namespace openblack::zip

--- a/src/ECS/Components/CameraBookmark.h
+++ b/src/ECS/Components/CameraBookmark.h
@@ -9,8 +9,9 @@
 
 #pragma once
 
-#include <chrono>
 #include <cstdint>
+
+#include <chrono>
 
 namespace openblack::ecs::components
 {

--- a/src/ECS/Components/Hand.h
+++ b/src/ECS/Components/Hand.h
@@ -9,13 +9,13 @@
 
 #pragma once
 
-#include "3D/L3DMesh.h"
-#include "Graphics/Mesh.h"
-#include "Graphics/Texture2D.h"
+#include <memory>
 
 #include <entt/entt.hpp>
 
-#include <memory>
+#include "3D/L3DMesh.h"
+#include "Graphics/Mesh.h"
+#include "Graphics/Texture2D.h"
 
 namespace openblack::ecs::components
 {

--- a/src/ECS/Components/Stream.h
+++ b/src/ECS/Components/Stream.h
@@ -9,13 +9,14 @@
 
 #pragma once
 
-#include "Enums.h"
-
-#include <glm/glm.hpp>
-
 #include <algorithm>
 #include <string>
 #include <vector>
+
+#include <glm/geometric.hpp>
+#include <glm/vec3.hpp>
+
+#include "Enums.h"
 
 namespace openblack::ecs::components
 {

--- a/src/ECS/Components/Villager.h
+++ b/src/ECS/Components/Villager.h
@@ -9,8 +9,9 @@
 
 #pragma once
 
-#include <array>
 #include <cstdint>
+
+#include <array>
 #include <string>
 #include <string_view>
 #include <tuple>

--- a/src/ECS/Map.h
+++ b/src/ECS/Map.h
@@ -9,8 +9,9 @@
 
 #pragma once
 
-#include <array>
 #include <cstdint>
+
+#include <array>
 #include <unordered_set>
 
 #include <entt/fwd.hpp>

--- a/src/ECS/Systems/DynamicsSystem.cpp
+++ b/src/ECS/Systems/DynamicsSystem.cpp
@@ -20,13 +20,12 @@
 #include <glm/gtx/quaternion.hpp>
 #include <glm/gtx/rotate_vector.hpp>
 
+#include "3D/LandBlock.h"
+#include "3D/LandIsland.h"
 #include "ECS/Components/RigidBody.h"
 #include "ECS/Components/Transform.h"
 #include "ECS/Registry.h"
 #include "Game.h"
-
-#include "3D/LandBlock.h"
-#include "3D/LandIsland.h"
 
 using namespace openblack;
 using namespace openblack::ecs::components;

--- a/src/Enums.h
+++ b/src/Enums.h
@@ -9,8 +9,9 @@
 
 #pragma once
 
-#include <array>
 #include <cstdint>
+
+#include <array>
 #include <string_view>
 
 // Enums translated over from ones found in the Creature Isle modding tools.

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -9,6 +9,23 @@
 
 #include "Game.h"
 
+#include <cstdint>
+
+#include <string>
+
+#include <LHVM/LHVM.h>
+#include <Serializer/FotFile.h>
+#include <glm/glm.hpp>
+#include <glm/gtc/constants.hpp>
+#include <glm/gtc/type_ptr.hpp>
+#include <glm/gtx/euler_angles.hpp>
+#include <glm/gtx/intersect.hpp>
+#include <glm/gtx/transform.hpp>
+#include <spdlog/sinks/android_sink.h>
+#include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/spdlog.h>
+
 #include "3D/Camera.h"
 #include "3D/LandIsland.h"
 #include "3D/Sky.h"
@@ -39,22 +56,6 @@
 #include "Renderer.h"
 #include "Resources/Loaders.h"
 #include "Resources/ResourceManager.h"
-
-#include <glm/glm.hpp>
-#include <glm/gtc/constants.hpp>
-#include <glm/gtc/type_ptr.hpp>
-#include <glm/gtx/euler_angles.hpp>
-#include <glm/gtx/intersect.hpp>
-#include <glm/gtx/transform.hpp>
-#include <spdlog/sinks/android_sink.h>
-#include <spdlog/sinks/basic_file_sink.h>
-#include <spdlog/sinks/stdout_color_sinks.h>
-#include <spdlog/spdlog.h>
-
-#include <LHVM/LHVM.h>
-#include <Serializer/FotFile.h>
-#include <cstdint>
-#include <string>
 
 #ifdef WIN32
 #include <Windows.h>

--- a/src/GameWindow.h
+++ b/src/GameWindow.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <cstdint>
+
 #include <memory>
 #include <string>
 

--- a/src/Graphics/DebugLines.cpp
+++ b/src/Graphics/DebugLines.cpp
@@ -9,10 +9,10 @@
 
 #include "DebugLines.h"
 
+#include <array>
+
 #include "Mesh.h"
 #include "VertexBuffer.h"
-
-#include <array>
 
 using namespace openblack::graphics;
 

--- a/src/Graphics/DebugLines.h
+++ b/src/Graphics/DebugLines.h
@@ -9,12 +9,11 @@
 
 #pragma once
 
-#include "RenderPass.h"
-
-#include <bgfx/bgfx.h>
-#include <glm/glm.hpp>
-
 #include <memory>
+
+#include <glm/vec4.hpp>
+
+#include "RenderPass.h"
 
 namespace openblack::graphics
 {

--- a/src/Graphics/FrameBuffer.cpp
+++ b/src/Graphics/FrameBuffer.cpp
@@ -9,8 +9,9 @@
 
 #include "FrameBuffer.h"
 
-#include <array>
 #include <cassert>
+
+#include <array>
 
 using namespace openblack::graphics;
 

--- a/src/Graphics/FrameBuffer.h
+++ b/src/Graphics/FrameBuffer.h
@@ -9,12 +9,13 @@
 
 #pragma once
 
-#include "RenderPass.h"
-#include "Texture2D.h"
-
 #include <cstdint>
+
 #include <memory>
 #include <optional>
+
+#include "RenderPass.h"
+#include "Texture2D.h"
 
 namespace openblack::graphics
 {

--- a/src/Graphics/IndexBuffer.cpp
+++ b/src/Graphics/IndexBuffer.cpp
@@ -10,6 +10,7 @@
 #include "IndexBuffer.h"
 
 #include <cassert>
+
 #include <string>
 #include <utility>
 

--- a/src/Graphics/IndexBuffer.h
+++ b/src/Graphics/IndexBuffer.h
@@ -9,11 +9,12 @@
 
 #pragma once
 
-#include <bgfx/bgfx.h>
-
 #include <cstddef>
 #include <cstdint>
+
 #include <string>
+
+#include <bgfx/bgfx.h>
 
 namespace openblack::graphics
 {

--- a/src/Graphics/Mesh.h
+++ b/src/Graphics/Mesh.h
@@ -9,10 +9,11 @@
 
 #pragma once
 
-#include "RenderPass.h"
-
 #include <cstdint>
+
 #include <memory>
+
+#include "RenderPass.h"
 
 namespace bgfx
 {

--- a/src/Graphics/RenderPass.h
+++ b/src/Graphics/RenderPass.h
@@ -9,8 +9,9 @@
 
 #pragma once
 
-#include <array>
 #include <cstdint>
+
+#include <array>
 #include <string_view>
 
 namespace openblack::graphics

--- a/src/Graphics/ShaderManager.cpp
+++ b/src/Graphics/ShaderManager.cpp
@@ -32,6 +32,11 @@
 
 #include <cstdint> // Shaders below need uint8_t
 
+#include <bgfx/embedded_shader.h>
+
+#include "3D/Camera.h"
+
+// clang-format off
 #define SHADER_NAME vs_line
 #include "ShaderIncluder.h"
 #define SHADER_NAME vs_line_instanced
@@ -62,10 +67,7 @@
 #include "ShaderIncluder.h"
 #define SHADER_NAME fs_sprite
 #include "ShaderIncluder.h"
-
-#include "3D/Camera.h"
-
-#include <bgfx/embedded_shader.h>
+// clang-format on
 
 namespace openblack::graphics
 {

--- a/src/Graphics/ShaderManager.h
+++ b/src/Graphics/ShaderManager.h
@@ -9,11 +9,11 @@
 
 #pragma once
 
-#include "RenderPass.h"
-#include "ShaderProgram.h"
-
 #include <map>
 #include <string>
+
+#include "RenderPass.h"
+#include "ShaderProgram.h"
 
 namespace openblack
 {

--- a/src/Graphics/ShaderProgram.cpp
+++ b/src/Graphics/ShaderProgram.cpp
@@ -9,11 +9,11 @@
 
 #include "ShaderProgram.h"
 
+#include <spdlog/spdlog.h>
+
 #include "Common/FileSystem.h"
 #include "Game.h"
 #include "Texture2D.h"
-
-#include <spdlog/spdlog.h>
 
 namespace openblack::graphics
 {

--- a/src/Graphics/ShaderProgram.h
+++ b/src/Graphics/ShaderProgram.h
@@ -9,11 +9,12 @@
 
 #pragma once
 
-#include <bgfx/bgfx.h>
-
 #include <cstdint>
+
 #include <map>
 #include <string>
+
+#include <bgfx/bgfx.h>
 
 namespace openblack::graphics
 {

--- a/src/Graphics/Texture2D.cpp
+++ b/src/Graphics/Texture2D.cpp
@@ -9,13 +9,14 @@
 
 #include "Texture2D.h"
 
-#include "Common/stb_image_write.h"
-
-#include <spdlog/spdlog.h>
+#include <cassert>
 
 #include <algorithm>
 #include <array>
-#include <cassert>
+
+#include <spdlog/spdlog.h>
+
+#include "Common/stb_image_write.h"
 
 namespace openblack::graphics
 {

--- a/src/Graphics/Texture2D.h
+++ b/src/Graphics/Texture2D.h
@@ -9,11 +9,12 @@
 
 #pragma once
 
-#include <bgfx/bgfx.h>
-
 #include <cstddef>
 #include <cstdint>
+
 #include <string>
+
+#include <bgfx/bgfx.h>
 
 namespace openblack::graphics
 {

--- a/src/Graphics/VertexBuffer.cpp
+++ b/src/Graphics/VertexBuffer.cpp
@@ -9,8 +9,9 @@
 
 #include "VertexBuffer.h"
 
-#include <array>
 #include <cassert>
+
+#include <array>
 
 using namespace openblack::graphics;
 

--- a/src/Graphics/VertexBuffer.h
+++ b/src/Graphics/VertexBuffer.h
@@ -9,12 +9,13 @@
 
 #pragma once
 
-#include <bgfx/bgfx.h>
-
 #include <cstdint>
+
 #include <memory>
 #include <string>
 #include <vector>
+
+#include <bgfx/bgfx.h>
 
 namespace openblack::graphics
 {

--- a/src/Gui/Console.h
+++ b/src/Gui/Console.h
@@ -9,16 +9,16 @@
 
 #pragma once
 
-#include "DebugWindow.h"
-
-#include <imgui.h>
-
 #include <array>
 #include <memory>
 #include <optional>
 #include <string>
 #include <tuple>
 #include <vector>
+
+#include <imgui.h>
+
+#include "DebugWindow.h"
 
 struct ImGuiInputTextCallbackData;
 

--- a/src/Gui/Gui.h
+++ b/src/Gui/Gui.h
@@ -9,17 +9,17 @@
 
 #pragma once
 
-#include <bgfx/bgfx.h>
-#include <glm/fwd.hpp>
-#include <imgui.h>
-
 #include <array>
 #include <functional>
 #include <memory>
 #include <optional>
 #include <vector>
 
-#include <Graphics/RenderPass.h>
+#include <bgfx/bgfx.h>
+#include <glm/fwd.hpp>
+#include <imgui.h>
+
+#include "Graphics/RenderPass.h"
 
 typedef struct SDL_Window SDL_Window;
 typedef struct SDL_Cursor SDL_Cursor;

--- a/src/Gui/LHVMViewer.cpp
+++ b/src/Gui/LHVMViewer.cpp
@@ -15,7 +15,7 @@
 #include <imgui_memory_editor.h>
 #include <imgui_user.h>
 
-#include <Game.h>
+#include "Game.h"
 
 using namespace openblack::gui;
 

--- a/src/Gui/LHVMViewer.h
+++ b/src/Gui/LHVMViewer.h
@@ -9,9 +9,9 @@
 
 #pragma once
 
-#include "DebugWindow.h"
-
 #include <LHVM/LHVM.h>
+
+#include "DebugWindow.h"
 
 namespace openblack::gui
 {

--- a/src/Gui/LandIsland.cpp
+++ b/src/Gui/LandIsland.cpp
@@ -11,8 +11,8 @@
 
 #include <LNDFile.h>
 
-#include <3D/LandIsland.h>
-#include <Game.h>
+#include "3D/LandIsland.h"
+#include "Game.h"
 
 openblack::gui::LandIsland::LandIsland()
     : DebugWindow("Land Island", ImVec2(250.0f, 165.0f))

--- a/src/Gui/MeshViewer.cpp
+++ b/src/Gui/MeshViewer.cpp
@@ -9,6 +9,12 @@
 
 #include "MeshViewer.h"
 
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/type_ptr.hpp>
+#include <glm/gtx/transform.hpp>
+#include <imgui.h>
+#include <imgui_bitfield.h>
+
 #include "3D/L3DAnim.h"
 #include "3D/L3DMesh.h"
 #include "Game.h"
@@ -20,12 +26,6 @@
 #include "Renderer.h"
 #include "Resources/MeshId.h"
 #include "Resources/Resources.h"
-
-#include <glm/gtc/matrix_transform.hpp>
-#include <glm/gtc/type_ptr.hpp>
-#include <glm/gtx/transform.hpp>
-#include <imgui.h>
-#include <imgui_bitfield.h>
 
 using namespace openblack;
 using namespace openblack::gui;

--- a/src/Gui/MeshViewer.h
+++ b/src/Gui/MeshViewer.h
@@ -9,17 +9,17 @@
 
 #pragma once
 
-#include "DebugWindow.h"
-
 #include <memory>
 #include <optional>
 
+#include <entt/entt.hpp>
+#include <glm/vec3.hpp>
+#include <imgui.h>
+
 #include "3D/AllMeshes.h"
+#include "DebugWindow.h"
 #include "Graphics/DebugLines.h"
 #include "Graphics/FrameBuffer.h"
-
-#include <entt/entt.hpp>
-#include <imgui.h>
 
 namespace openblack
 {

--- a/src/Gui/PathFinding.h
+++ b/src/Gui/PathFinding.h
@@ -9,12 +9,12 @@
 
 #pragma once
 
-#include "DebugWindow.h"
-
 #include <optional>
 
 #include <entt/fwd.hpp>
 #include <glm/vec3.hpp>
+
+#include "DebugWindow.h"
 
 namespace openblack::gui
 {

--- a/src/Gui/Profiler.cpp
+++ b/src/Gui/Profiler.cpp
@@ -14,11 +14,12 @@
 #include <bgfx/bgfx.h>
 #include <imgui_widget_flamegraph.h>
 
-#include <ECS/Components/Transform.h>
-#include <ECS/Components/Tree.h>
-#include <ECS/Registry.h>
-#include <Game.h>
-#include <Profiler.h>
+#include "ECS/Components/Transform.h"
+#include "ECS/Components/Tree.h"
+#include "ECS/Registry.h"
+#include "Game.h"
+
+#include "../Profiler.h"
 
 openblack::gui::Profiler::Profiler()
     : DebugWindow("Profiler", ImVec2(650.0f, 800.0f))

--- a/src/Gui/Profiler.h
+++ b/src/Gui/Profiler.h
@@ -9,9 +9,9 @@
 
 #pragma once
 
-#include "DebugWindow.h"
-
 #include <array>
+
+#include "DebugWindow.h"
 
 namespace openblack::gui
 {

--- a/src/Gui/TextureViewer.h
+++ b/src/Gui/TextureViewer.h
@@ -9,9 +9,9 @@
 
 #pragma once
 
-#include "DebugWindow.h"
-
 #include <entt/fwd.hpp>
+
+#include "DebugWindow.h"
 
 namespace openblack
 {

--- a/src/InfoConstants.h
+++ b/src/InfoConstants.h
@@ -9,8 +9,9 @@
 
 #pragma once
 
-#include <array>
 #include <cstdint>
+
+#include <array>
 
 #include <glm/vec2.hpp>
 #include <glm/vec3.hpp>

--- a/src/LHScriptX/FeatureScriptCommands.h
+++ b/src/LHScriptX/FeatureScriptCommands.h
@@ -9,12 +9,11 @@
 
 #pragma once
 
-#include "CommandSignature.h"
-
 #include <array>
 
 #include <glm/vec3.hpp>
 
+#include "CommandSignature.h"
 #include "Enums.h"
 
 namespace openblack::lhscriptx

--- a/src/LHScriptX/Lexer.cpp
+++ b/src/LHScriptX/Lexer.cpp
@@ -10,6 +10,7 @@
 #include "Lexer.h"
 
 #include <cctype>
+
 #include <utility>
 
 using namespace openblack::lhscriptx;

--- a/src/LHScriptX/MapScriptCommands.h
+++ b/src/LHScriptX/MapScriptCommands.h
@@ -9,11 +9,11 @@
 
 #pragma once
 
-#include "CommandSignature.h"
-
 #include <array>
 
 #include <glm/vec3.hpp>
+
+#include "CommandSignature.h"
 
 namespace openblack::lhscriptx
 {

--- a/src/LHScriptX/Script.cpp
+++ b/src/LHScriptX/Script.cpp
@@ -9,12 +9,12 @@
 
 #include "Script.h"
 
-#include "FeatureScriptCommands.h"
-#include "Lexer.h"
+#include <iostream>
 
 #include <spdlog/spdlog.h>
 
-#include <iostream>
+#include "FeatureScriptCommands.h"
+#include "Lexer.h"
 
 using namespace openblack;
 using namespace openblack::lhscriptx;

--- a/src/LHScriptX/Script.h
+++ b/src/LHScriptX/Script.h
@@ -9,9 +9,9 @@
 
 #pragma once
 
-#include "Lexer.h"
-
 #include <vector>
+
+#include "Lexer.h"
 
 namespace openblack
 {

--- a/src/LHScriptX/ScriptingBindingUtils.h
+++ b/src/LHScriptX/ScriptingBindingUtils.h
@@ -9,9 +9,10 @@
 
 #pragma once
 
-#include "CommandSignature.h"
 #include <glm/vec2.hpp>
 #include <glm/vec3.hpp>
+
+#include "CommandSignature.h"
 
 namespace openblack::lhscriptx
 {

--- a/src/Locator.h
+++ b/src/Locator.h
@@ -9,9 +9,9 @@
 
 #pragma once
 
-#include "Resources/Resources.h"
-
 #include <entt/locator/locator.hpp>
+
+#include "Resources/Resources.h"
 
 namespace openblack
 {

--- a/src/Parsers/InfoFile.cpp
+++ b/src/Parsers/InfoFile.cpp
@@ -9,9 +9,8 @@
 
 #include "InfoFile.h"
 
-#include <spdlog/spdlog.h>
-
 #include <PackFile.h>
+#include <spdlog/spdlog.h>
 
 #include "Common/FileSystem.h"
 #include "Game.h"

--- a/src/Profiler.h
+++ b/src/Profiler.h
@@ -9,9 +9,10 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include <array>
 #include <chrono>
-#include <cstdint>
 #include <map>
 #include <string_view>
 

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -9,20 +9,21 @@
 
 #pragma once
 
-#include "Graphics/RenderPass.h"
-#include "Locator.h"
+#include <cstdint>
+
+#include <array>
+#include <chrono>
+#include <memory>
+#include <string_view>
+#include <vector>
 
 #include <SDL.h>
 #include <bgfx/bgfx.h>
 #include <glm/fwd.hpp>
 #include <glm/mat4x4.hpp>
 
-#include <array>
-#include <chrono>
-#include <cstdint>
-#include <memory>
-#include <string_view>
-#include <vector>
+#include "Graphics/RenderPass.h"
+#include "Locator.h"
 
 namespace openblack
 {

--- a/src/Resources/Loaders.h
+++ b/src/Resources/Loaders.h
@@ -9,12 +9,12 @@
 
 #pragma once
 
+#include <PackFile.h>
+#include <entt/entt.hpp>
+
 #include "3D/L3DAnim.h"
 #include "3D/L3DMesh.h"
 #include "Level.h"
-
-#include <PackFile.h>
-#include <entt/entt.hpp>
 
 namespace openblack::resources
 {

--- a/src/Serializer/GameThingSerializer.h
+++ b/src/Serializer/GameThingSerializer.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <cstdint>
+
 #include <memory>
 #include <optional>
 #include <type_traits>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,17 +7,18 @@
  * openblack is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include "Game.h"
-
-#include <SDL_messagebox.h>
-#include <cxxopts.hpp>
 #include <iostream>
 #include <map>
 #include <memory>
 
+#include <SDL_messagebox.h>
+#include <cxxopts.hpp>
+
 #ifdef _WIN32
 #include <windows.h>
 #endif
+
+#include "Game.h"
 
 bool parseOptions(int argc, char** argv, openblack::Arguments& args, int& return_code)
 {


### PR DESCRIPTION
Based on https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes

Include header groups (in order):
1. Header of cpp class
2. C standard library headers
3. C++ standard library headers
4. External projects headers
5. Regular includes
6. Relative includes