### PR TITLE
Additional clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,5 +21,14 @@ Checks: >-
   -google-build-using-namespace,
   -google-runtime-references,
   -google-readability-todo,
-  -google-readability-*,
+  readability-*,
+  -readability-magic-numbers,
+  -readability-uppercase-literal-suffix,
+  -readability-function-cognitive-complexity,
+  -readability-make-member-function-const,
+  -readability-convert-member-functions-to-static,
+  -readability-named-parameter,
+CheckOptions:
+  - key:   readability-function-cognitive-complexity.Threshold
+    value: 35 # TODO: bring that number down to 25
 # WarningsAsErrors: '*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,6 +6,7 @@ Checks: >-
   -modernize-use-trailing-return-type,
   -modernize-use-using,
   cppcoreguidelines-pro-bounds-constant-array-index,
+  cppcoreguidelines-avoid-non-const-global-variables,
   performance-*,
   -performance-unnecessary-value-param,
   misc-*,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -29,6 +29,28 @@ Checks: >-
   -readability-convert-member-functions-to-static,
   -readability-named-parameter,
 CheckOptions:
-  - key:   readability-function-cognitive-complexity.Threshold
+  - key: readability-function-cognitive-complexity.Threshold
     value: 35 # TODO: bring that number down to 25
+  - key: readability-identifier-naming.GlobalConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.GlobalConstantPrefix
+    value: k_
+  - key: readability-identifier-naming.GlobalConstantIgnoredRegexp
+    value: '^Disassembly_[^_]*'
+  - key: readability-identifier-naming.MethodCase
+    value: CamelCase
+  - key: readability-identifier-naming.MethodIgnoredRegexp
+    value: 'Disassembly_[^_]*|load'
+  - key: readability-identifier-naming.VariableCase
+    value: camelBack
+  - key: readability-identifier-naming.VariableIgnoredRegexp
+    value: '^u_[^_]*'
+  - key: readability-identifier-naming.ParameterCase
+    value: camelBack
+  - key: readability-identifier-naming.MemberCase
+    value: camelBack
+  - key: readability-identifier-naming.PrivateMemberPrefix
+    value: _
+  - key: readability-identifier-naming.ProtectedMemberPrefix
+    value: _
 # WarningsAsErrors: '*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,7 +4,6 @@ Checks: >-
   clang-analyzer-*,
   modernize-*,
   -modernize-use-trailing-return-type,
-  -modernize-use-using,
   cppcoreguidelines-pro-bounds-constant-array-index,
   cppcoreguidelines-avoid-non-const-global-variables,
   performance-*,

--- a/apps/anmtool/anmtool.cpp
+++ b/apps/anmtool/anmtool.cpp
@@ -46,7 +46,7 @@ int PrintHeader(openblack::anm::ANMFile& anm)
 
 int ListKeyframes(openblack::anm::ANMFile& anm)
 {
-	auto& keyframes = anm.GetKeyframes();
+	const auto& keyframes = anm.GetKeyframes();
 
 	std::printf("file: %s\n", anm.GetFilename().c_str());
 

--- a/apps/anmtool/anmtool.cpp
+++ b/apps/anmtool/anmtool.cpp
@@ -27,19 +27,19 @@ int PrintHeader(openblack::anm::ANMFile& anm)
 	std::printf("file: %s\n", anm.GetFilename().c_str());
 
 	std::printf("name: %s\n", header.name.data());
-	std::printf("unknown_0x20: 0x%X\n", header.unknown_0x20);
-	std::printf("unknown_0x24: %f\n", header.unknown_0x24);
-	std::printf("unknown_0x28: %f\n", header.unknown_0x28);
-	std::printf("unknown_0x2C: %f\n", header.unknown_0x2C);
-	std::printf("unknown_0x30: %f\n", header.unknown_0x30);
-	std::printf("unknown_0x34: %f\n", header.unknown_0x34);
-	std::printf("frame count: %u\n", header.frame_count);
-	std::printf("unknown_0x3C: 0x%X\n", header.unknown_0x3C);
-	std::printf("animation_duration: %u\n", header.animation_duration);
-	std::printf("unknown_0x44: 0x%X\n", header.unknown_0x44);
-	std::printf("unknown_0x48: 0x%X\n", header.unknown_0x48);
-	std::printf("frames base: 0x%X\n", header.frames_base);
-	std::printf("unknown_0x50: 0x%X\n", header.unknown_0x50);
+	std::printf("unknown0x20: 0x%X\n", header.unknown0x20);
+	std::printf("unknown0x24: %f\n", header.unknown0x24);
+	std::printf("unknown0x28: %f\n", header.unknown0x28);
+	std::printf("unknown0x2C: %f\n", header.unknown0x2C);
+	std::printf("unknown0x30: %f\n", header.unknown0x30);
+	std::printf("unknown0x34: %f\n", header.unknown0x34);
+	std::printf("frame count: %u\n", header.frameCount);
+	std::printf("unknown0x3C: 0x%X\n", header.unknown0x3C);
+	std::printf("animation_duration: %u\n", header.animationDuration);
+	std::printf("unknown0x44: 0x%X\n", header.unknown0x44);
+	std::printf("unknown0x48: 0x%X\n", header.unknown0x48);
+	std::printf("frames base: 0x%X\n", header.framesBase);
+	std::printf("unknown0x50: 0x%X\n", header.unknown0x50);
 
 	return EXIT_SUCCESS;
 }
@@ -50,11 +50,11 @@ int ListKeyframes(openblack::anm::ANMFile& anm)
 
 	std::printf("file: %s\n", anm.GetFilename().c_str());
 
-	uint32_t last_time = 0;
+	uint32_t lastTime = 0;
 	for (uint32_t i = 0; i < keyframes.size(); ++i)
 	{
-		std::printf("%u: time %u (+%u)\n", i, keyframes[i].time, keyframes[i].time - last_time);
-		last_time = keyframes[i].time;
+		std::printf("%u: time %u (+%u)\n", i, keyframes[i].time, keyframes[i].time - lastTime);
+		lastTime = keyframes[i].time;
 	}
 
 	return EXIT_SUCCESS;
@@ -122,14 +122,14 @@ int WriteFile(const Arguments::Write& args) noexcept
 	const std::string name = "TODO";
 	memcpy(anm.GetHeader().name.data(), name.c_str(),
 	       std::min(sizeof(anm.GetHeader().name[0]) * anm.GetHeader().name.size(), name.length()));
-	anm.GetHeader().frame_count = 0;
-	anm.GetHeader().animation_duration = 0;
+	anm.GetHeader().frameCount = 0;
+	anm.GetHeader().animationDuration = 0;
 	anm.Write(args.outFilename);
 
 	return EXIT_SUCCESS;
 }
 
-bool parseOptions(int argc, char** argv, Arguments& args, int& return_code) noexcept
+bool parseOptions(int argc, char** argv, Arguments& args, int& returnCode) noexcept
 {
 	cxxopts::Options options("anmtool", "Inspect and extract files from LionHead ANM files.");
 
@@ -155,7 +155,7 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code) noex
 	catch (const std::exception& e)
 	{
 		std::cerr << e.what() << '\n';
-		return_code = EXIT_FAILURE;
+		returnCode = EXIT_FAILURE;
 		return false;
 	}
 
@@ -165,13 +165,13 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code) noex
 		if (result["help"].as<bool>())
 		{
 			std::cout << options.help() << std::endl;
-			return_code = EXIT_SUCCESS;
+			returnCode = EXIT_SUCCESS;
 			return false;
 		}
 		if (result["subcommand"].count() == 0)
 		{
 			std::cerr << options.help() << std::endl;
-			return_code = EXIT_FAILURE;
+			returnCode = EXIT_FAILURE;
 			return false;
 		}
 		if (result["subcommand"].as<std::string>() == "read")
@@ -216,17 +216,17 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code) noex
 	}
 
 	std::cerr << options.help() << std::endl;
-	return_code = EXIT_FAILURE;
+	returnCode = EXIT_FAILURE;
 	return false;
 }
 
 int main(int argc, char* argv[]) noexcept
 {
 	Arguments args;
-	int return_code = EXIT_SUCCESS;
-	if (!parseOptions(argc, argv, args, return_code))
+	int returnCode = EXIT_SUCCESS;
+	if (!parseOptions(argc, argv, args, returnCode))
 	{
-		return return_code;
+		return returnCode;
 	}
 
 	if (args.mode == Arguments::Mode::Write)
@@ -245,25 +245,25 @@ int main(int argc, char* argv[]) noexcept
 			switch (args.mode)
 			{
 			case Arguments::Mode::Header:
-				return_code |= PrintHeader(anm);
+				returnCode |= PrintHeader(anm);
 				break;
 			case Arguments::Mode::ListKeyframes:
-				return_code |= ListKeyframes(anm);
+				returnCode |= ListKeyframes(anm);
 				break;
 			case Arguments::Mode::Keyframe:
-				return_code |= ViewKeyframe(anm);
+				returnCode |= ViewKeyframe(anm);
 				break;
 			default:
-				return_code = EXIT_FAILURE;
+				returnCode = EXIT_FAILURE;
 				break;
 			}
 		}
 		catch (std::exception& err)
 		{
 			std::cerr << err.what() << std::endl;
-			return_code |= EXIT_FAILURE;
+			returnCode |= EXIT_FAILURE;
 		}
 	}
 
-	return return_code;
+	return returnCode;
 }

--- a/apps/l3dtool/l3dtool.cpp
+++ b/apps/l3dtool/l3dtool.cpp
@@ -56,136 +56,136 @@ int PrintRawBytes(const void* data, std::size_t size)
 
 int PrintHeader(openblack::l3d::L3DFile& l3d)
 {
-	auto& header = l3d.GetHeader();
+	const auto& header = l3d.GetHeader();
 
 	using L3DMeshFlags = openblack::l3d::L3DMeshFlags;
 	auto flagToString = [](L3DMeshFlags flag) {
 		std::string result;
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown1))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown1)) != 0)
 		{
 			result += "Unknown1|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown2))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown2)) != 0)
 		{
 			result += "Unknown2|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown3))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown3)) != 0)
 		{
 			result += "Unknown3|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown4))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown4)) != 0)
 		{
 			result += "Unknown4|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown5))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown5)) != 0)
 		{
 			result += "Unknown5|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown6))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown6)) != 0)
 		{
 			result += "Unknown6|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown7))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown7)) != 0)
 		{
 			result += "Unknown7|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown8))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown8)) != 0)
 		{
 			result += "Unknown8|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::HasBones))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::HasBones)) != 0)
 		{
 			result += "HasBones|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown10))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown10)) != 0)
 		{
 			result += "Unknown10|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown11))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown11)) != 0)
 		{
 			result += "Unknown11|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::HasDoorPosition))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::HasDoorPosition)) != 0)
 		{
 			result += "HasDoorPosition|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Packed))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Packed)) != 0)
 		{
 			result += "Packed|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::NoDraw))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::NoDraw)) != 0)
 		{
 			result += "NoDraw|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown15))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown15)) != 0)
 		{
 			result += "Unknown15|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::ContainsLandscapeFeature))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::ContainsLandscapeFeature)) != 0)
 		{
 			result += "ContainsLandscapeFeature|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown17))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown17)) != 0)
 		{
 			result += "Unknown17|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown18))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown18)) != 0)
 		{
 			result += "Unknown18|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::ContainsUV2))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::ContainsUV2)) != 0)
 		{
 			result += "ContainsUV2|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::ContainsNameData))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::ContainsNameData)) != 0)
 		{
 			result += "ContainsNameData|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::ContainsExtraMetrics))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::ContainsExtraMetrics)) != 0)
 		{
 			result += "ContainsExtraMetrics|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::ContainsEBone))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::ContainsEBone)) != 0)
 		{
 			result += "ContainsEBone|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::ContainsTnLData))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::ContainsTnLData)) != 0)
 		{
 			result += "ContainsTnLData|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::ContainsNewEP))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::ContainsNewEP)) != 0)
 		{
 			result += "ContainsNewEP|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown25))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown25)) != 0)
 		{
 			result += "Unknown25|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown26))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown26)) != 0)
 		{
 			result += "Unknown26|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown27))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown27)) != 0)
 		{
 			result += "Unknown27|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown28))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown28)) != 0)
 		{
 			result += "Unknown28|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown29))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown29)) != 0)
 		{
 			result += "Unknown29|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown30))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown30)) != 0)
 		{
 			result += "Unknown30|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown31))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown31)) != 0)
 		{
 			result += "Unknown31|";
 		}
-		if (static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown32))
+		if ((static_cast<uint32_t>(flag) & static_cast<uint32_t>(L3DMeshFlags::Unknown32)) != 0)
 		{
 			result += "Unknown32|";
 		}
@@ -217,7 +217,7 @@ int PrintHeader(openblack::l3d::L3DFile& l3d)
 
 int PrintMeshHeaders(openblack::l3d::L3DFile& l3d)
 {
-	auto& meshHeaders = l3d.GetSubmeshHeaders();
+	const auto& meshHeaders = l3d.GetSubmeshHeaders();
 	std::printf("file: %s\n", l3d.GetFilename().c_str());
 
 	uint32_t i = 0;
@@ -230,7 +230,7 @@ int PrintMeshHeaders(openblack::l3d::L3DFile& l3d)
 		}
 		result += "|LOD" + std::to_string(flags.lod);
 		result += "|status=" + std::to_string(flags.status);
-		if (flags.unknown1)
+		if (flags.unknown1 != 0u)
 		{
 			result += "|unknown1";
 		}
@@ -244,7 +244,7 @@ int PrintMeshHeaders(openblack::l3d::L3DFile& l3d)
 		}
 		return result;
 	};
-	for (auto& header : meshHeaders)
+	for (const auto& header : meshHeaders)
 	{
 		std::printf("mesh #%u\n", ++i);
 		std::printf("flags: %s\n", flagToString(header.flags).c_str());
@@ -260,18 +260,18 @@ int PrintMeshHeaders(openblack::l3d::L3DFile& l3d)
 
 int PrintSkins(openblack::l3d::L3DFile& l3d)
 {
-	auto& skins = l3d.GetSkins();
+	const auto& skins = l3d.GetSkins();
 	std::printf("file: %s\n", l3d.GetFilename().c_str());
 
-	for (auto& skin : skins)
+	for (const auto& skin : skins)
 	{
 		std::printf("skin id: 0x%X\n", skin.id);
 		std::printf("data:\n");
 		constexpr uint16_t subsample = 8;
 		constexpr uint16_t magnitude = (subsample * subsample) / 16;
-		for (uint16_t y = 0; y < skin.height / subsample; ++y)
+		for (uint16_t y = 0; y < openblack::l3d::L3DTexture::height / subsample; ++y)
 		{
-			for (uint16_t x = 0; x < skin.width / subsample; ++x)
+			for (uint16_t x = 0; x < openblack::l3d::L3DTexture::width / subsample; ++x)
 			{
 				uint32_t red = 0;
 				uint32_t green = 0;
@@ -280,7 +280,8 @@ int PrintSkins(openblack::l3d::L3DFile& l3d)
 				{
 					for (uint16_t i = 0; i < subsample; ++i)
 					{
-						auto& color = skin.texels.at(x * subsample + i + (y * subsample + j) * skin.width);
+						const auto& color =
+						    skin.texels.at(x * subsample + i + (y * subsample + j) * openblack::l3d::L3DTexture::width);
 						red += color.R;
 						green += color.G;
 						blue += color.B;
@@ -301,10 +302,10 @@ int PrintSkins(openblack::l3d::L3DFile& l3d)
 
 int PrintExtraPoints(openblack::l3d::L3DFile& l3d)
 {
-	auto& points = l3d.GetExtraPoints();
+	const auto& points = l3d.GetExtraPoints();
 	std::printf("file: %s\n", l3d.GetFilename().c_str());
 
-	for (auto& point : points)
+	for (const auto& point : points)
 	{
 		std::printf("(%.3f, %.3f, %.3f)\n", point.x, point.y, point.z);
 	}
@@ -314,11 +315,11 @@ int PrintExtraPoints(openblack::l3d::L3DFile& l3d)
 
 int PrintPrimitiveHeaders(openblack::l3d::L3DFile& l3d)
 {
-	auto& primitiveHeaders = l3d.GetPrimitiveHeaders();
+	const auto& primitiveHeaders = l3d.GetPrimitiveHeaders();
 	std::printf("file: %s\n", l3d.GetFilename().c_str());
 
 	uint32_t i = 0;
-	for (auto& header : primitiveHeaders)
+	for (const auto& header : primitiveHeaders)
 	{
 		std::printf("primitive #%u\n", ++i);
 		static const std::array<const char*, static_cast<uint32_t>(openblack::l3d::L3DMaterial::Type::_Count)> typeMap = {{
@@ -374,11 +375,11 @@ int PrintPrimitiveHeaders(openblack::l3d::L3DFile& l3d)
 
 int PrintBones(openblack::l3d::L3DFile& l3d)
 {
-	auto bones = l3d.GetBones();
+	const auto& bones = l3d.GetBones();
 	std::printf("file: %s\n", l3d.GetFilename().c_str());
 
 	uint32_t i = 0;
-	for (auto& bone : bones)
+	for (const auto& bone : bones)
 	{
 		std::printf("bone #%u\n", i++);
 		if (bone.parent == std::numeric_limits<uint32_t>::max())
@@ -418,12 +419,12 @@ int PrintBones(openblack::l3d::L3DFile& l3d)
 
 int PrintVertices(openblack::l3d::L3DFile& l3d)
 {
-	auto& vertices = l3d.GetVertices();
+	const auto& vertices = l3d.GetVertices();
 	std::printf("file: %s\n", l3d.GetFilename().c_str());
 	std::printf("|     position     |   uv coord   |        normal        |\n");
 	std::printf("|------------------|--------------|----------------------|\n");
 
-	for (auto& vertex : vertices)
+	for (const auto& vertex : vertices)
 	{
 		std::printf("|%5.1f %5.1f %5.1f |%6.3f %6.3f | %6.3f %6.3f %6.3f |\n", vertex.position.x, vertex.position.y,
 		            vertex.position.z, vertex.texCoord.x, vertex.texCoord.y, vertex.normal.x, vertex.normal.y, vertex.normal.z);
@@ -435,7 +436,7 @@ int PrintVertices(openblack::l3d::L3DFile& l3d)
 int PrintIndices(openblack::l3d::L3DFile& l3d)
 {
 	constexpr uint8_t indexPerLine = 12;
-	auto& indices = l3d.GetIndices();
+	const auto& indices = l3d.GetIndices();
 	std::printf("file: %s\n", l3d.GetFilename().c_str());
 
 	for (std::size_t i = 0; i < indices.size(); ++i)
@@ -449,14 +450,14 @@ int PrintIndices(openblack::l3d::L3DFile& l3d)
 
 int PrintLookUpTables(openblack::l3d::L3DFile& l3d)
 {
-	auto& lookUpTable = l3d.GetLookUpTableData();
+	const auto& lookUpTable = l3d.GetLookUpTableData();
 	std::printf("file: %s\n", l3d.GetFilename().c_str());
 	return PrintRawBytes(lookUpTable.data(), lookUpTable.size() * sizeof(lookUpTable[0]));
 }
 
 int PrintBlendValues(openblack::l3d::L3DFile& l3d)
 {
-	auto& blendValues = l3d.GetLookUpTableData();
+	const auto& blendValues = l3d.GetLookUpTableData();
 	std::printf("file: %s\n", l3d.GetFilename().c_str());
 	return PrintRawBytes(blendValues.data(), blendValues.size() * sizeof(blendValues[0]));
 }
@@ -547,8 +548,9 @@ void copyBufferView(desT* dst, const uint8_t* src, size_t count, uint32_t compon
 	}
 }
 
-bool NoopLoadImageDataFunction(tinygltf::Image*, const int, std::string*, std::string*, int, int, const unsigned char*, int,
-                               void*)
+bool NoopLoadImageDataFunction(tinygltf::Image* /*unused*/, const int /*unused*/, std::string* /*unused*/,
+                               std::string* /*unused*/, int /*unused*/, int /*unused*/, const unsigned char* /*unused*/,
+                               int /*unused*/, void* /*unused*/)
 {
 	std::cerr << "Warn: GLTF Image Data function called but not implemented." << std::endl;
 	return true;
@@ -678,7 +680,7 @@ int WriteFile(const Arguments::Write& args) noexcept
 						bone.position.y = static_cast<float>(gltfJoint.translation[1]);
 						bone.position.z = static_cast<float>(gltfJoint.translation[2]);
 						buildJoints(gltfJoint.children, id);
-						if (leftSibbling)
+						if (leftSibbling != nullptr)
 						{
 							leftSibbling->rightSibling = id;
 						}
@@ -774,18 +776,18 @@ int WriteFile(const Arguments::Write& args) noexcept
 			for (uint32_t j = 0; j < count; ++j)
 			{
 				auto& vertex = vertices[j];
-				if (attributes[0].type)
+				if (attributes[0].type != 0)
 				{
 					vertex.position.x = attributes[0].values[j * attributes[0].type + 0];
 					vertex.position.y = attributes[0].values[j * attributes[0].type + 1];
 					vertex.position.z = attributes[0].values[j * attributes[0].type + 2];
 				}
-				if (attributes[1].type)
+				if (attributes[1].type != 0)
 				{
 					vertex.texCoord.x = attributes[1].values[j * attributes[1].type + 0];
 					vertex.texCoord.y = attributes[1].values[j * attributes[1].type + 1];
 				}
-				if (attributes[2].type)
+				if (attributes[2].type != 0)
 				{
 					vertex.normal.x = attributes[2].values[j * attributes[2].type + 0];
 					vertex.normal.y = attributes[2].values[j * attributes[2].type + 1];
@@ -979,7 +981,7 @@ int ExtractFile(const Arguments::Extract& args) noexcept
 		gltf.nodes.push_back(node);
 	}
 
-	auto& bones = l3d.GetBones();
+	const auto& bones = l3d.GetBones();
 	std::vector<uint32_t> roots;
 	for (uint32_t i = 0; i < bones.size(); ++i)
 	{
@@ -1066,7 +1068,8 @@ int ExtractFile(const Arguments::Extract& args) noexcept
 			traversal_stack.emplace(i, rootNodeIndex);
 
 			tinygltf::Node node;
-			uint32_t index, parent_index;
+			uint32_t index;
+			uint32_t parent_index;
 			while (!traversal_stack.empty())
 			{
 				std::tie(index, parent_index) = traversal_stack.top();
@@ -1081,7 +1084,7 @@ int ExtractFile(const Arguments::Extract& args) noexcept
 				}
 
 				gltf.nodes[parent_index].children.push_back(static_cast<int>(gltf.nodes.size()));
-				auto& l3d_node = bones[index];
+				const auto& l3d_node = bones[index];
 				bone_to_node(node, l3d_node);
 				gltf.nodes.emplace_back(node);
 

--- a/apps/lndtool/lndtool.cpp
+++ b/apps/lndtool/lndtool.cpp
@@ -182,10 +182,10 @@ int PrintBlocks(openblack::lnd::LNDFile& lnd)
 		std::printf("nextSortingPtr: 0x%X\n", block.nextSortingPtr);
 		std::printf("valueSorting: %f\n", block.valueSorting);
 		std::printf("lowResTexture: %f\n", block.lowResTexture);
-		std::printf("fu_lrs: %f\n", block.fu_lrs);
-		std::printf("fv_lrs: %f\n", block.fv_lrs);
-		std::printf("iu_lrs: %f\n", block.iu_lrs);
-		std::printf("iv_lrs: %f\n", block.iv_lrs);
+		std::printf("fuLrs: %f\n", block.fuLrs);
+		std::printf("fvLrs: %f\n", block.fvLrs);
+		std::printf("iuLrs: %f\n", block.iuLrs);
+		std::printf("ivLrs: %f\n", block.ivLrs);
 		std::printf("smallTextUpdated: 0x%X\n", block.smallTextUpdated);
 	}
 	std::printf("\n");
@@ -228,9 +228,9 @@ int PrintMaterials(openblack::lnd::LNDFile& lnd)
 		std::printf("data:\n");
 		constexpr uint16_t subsample = 8;
 		constexpr uint16_t magnitude = (subsample * subsample) / 8;
-		for (uint16_t y = 0; y < openblack::lnd::LNDMaterial::height / subsample; ++y)
+		for (uint16_t y = 0; y < openblack::lnd::LNDMaterial::k_Height / subsample; ++y)
 		{
-			for (uint16_t x = 0; x < openblack::lnd::LNDMaterial::width / subsample; ++x)
+			for (uint16_t x = 0; x < openblack::lnd::LNDMaterial::k_Width / subsample; ++x)
 			{
 				uint32_t red = 0;
 				uint32_t green = 0;
@@ -240,10 +240,10 @@ int PrintMaterials(openblack::lnd::LNDFile& lnd)
 					for (uint16_t i = 0; i < subsample; ++i)
 					{
 						const auto& color =
-						    material.texels.at(x * subsample + i + (y * subsample + j) * openblack::lnd::LNDMaterial::width);
-						red += color.R;
-						green += color.G;
-						blue += color.B;
+						    material.texels.at(x * subsample + i + (y * subsample + j) * openblack::lnd::LNDMaterial::k_Width);
+						red += color.r;
+						green += color.g;
+						blue += color.b;
 					}
 				}
 				red /= magnitude;
@@ -268,16 +268,17 @@ int PrintExtra(openblack::lnd::LNDFile& lnd)
 	constexpr uint16_t subsample = 8;
 	constexpr uint16_t magnitude = (subsample * subsample);
 	std::printf("noise:\n");
-	for (uint16_t y = 0; y < openblack::lnd::LNDBumpMap::height / subsample; ++y)
+	for (uint16_t y = 0; y < openblack::lnd::LNDBumpMap::k_Height / subsample; ++y)
 	{
-		for (uint16_t x = 0; x < openblack::lnd::LNDBumpMap::width / subsample; ++x)
+		for (uint16_t x = 0; x < openblack::lnd::LNDBumpMap::k_Width / subsample; ++x)
 		{
 			uint32_t color = 0;
 			for (uint16_t j = 0; j < subsample; ++j)
 			{
 				for (uint16_t i = 0; i < subsample; ++i)
 				{
-					color += extra.noise.texels.at(x * subsample + i + (y * subsample + j) * openblack::lnd::LNDBumpMap::width);
+					color +=
+					    extra.noise.texels.at(x * subsample + i + (y * subsample + j) * openblack::lnd::LNDBumpMap::k_Width);
 				}
 			}
 			color /= magnitude;
@@ -287,16 +288,17 @@ int PrintExtra(openblack::lnd::LNDFile& lnd)
 		std::printf("\n");
 	}
 	std::printf("bump:\n");
-	for (uint16_t y = 0; y < openblack::lnd::LNDBumpMap::height / subsample; ++y)
+	for (uint16_t y = 0; y < openblack::lnd::LNDBumpMap::k_Height / subsample; ++y)
 	{
-		for (uint16_t x = 0; x < openblack::lnd::LNDBumpMap::width / subsample; ++x)
+		for (uint16_t x = 0; x < openblack::lnd::LNDBumpMap::k_Width / subsample; ++x)
 		{
 			uint32_t color = 0;
 			for (uint16_t j = 0; j < subsample; ++j)
 			{
 				for (uint16_t i = 0; i < subsample; ++i)
 				{
-					color += extra.bump.texels.at(x * subsample + i + (y * subsample + j) * openblack::lnd::LNDBumpMap::width);
+					color +=
+					    extra.bump.texels.at(x * subsample + i + (y * subsample + j) * openblack::lnd::LNDBumpMap::k_Width);
 				}
 			}
 			color /= magnitude;
@@ -375,8 +377,8 @@ int WriteFile(const Arguments::Write& args) noexcept
 			// clang-format off
 			std::cerr << "File " << filename
 			          << " is not the right size to be a "
-			          << openblack::lnd::LNDMaterial::width << "x"
-			          << openblack::lnd::LNDMaterial::height
+			          << openblack::lnd::LNDMaterial::k_Width << "x"
+			          << openblack::lnd::LNDMaterial::k_Height
 			          << " RGB5A1 texture: size should be "
 			          << fsize << std::endl;
 			// clang-format on
@@ -406,8 +408,8 @@ int WriteFile(const Arguments::Write& args) noexcept
 			// clang-format off
 			std::cerr << "File " << args.noiseMapFile
 			          << " is not the right size to be a "
-			          << openblack::lnd::LNDBumpMap::width << "x"
-			          << openblack::lnd::LNDBumpMap::height
+			          << openblack::lnd::LNDBumpMap::k_Width << "x"
+			          << openblack::lnd::LNDBumpMap::k_Height
 			          << " R8 texture: size should be "
 			          << fsize << std::endl;
 			// clang-format on
@@ -435,8 +437,8 @@ int WriteFile(const Arguments::Write& args) noexcept
 			// clang-format off
 			std::cerr << "File " << args.bumpMapFile
 			          << " is not the right size to be a "
-			          << openblack::lnd::LNDBumpMap::width << "x"
-			          << openblack::lnd::LNDBumpMap::height
+			          << openblack::lnd::LNDBumpMap::k_Width << "x"
+			          << openblack::lnd::LNDBumpMap::k_Height
 			          << " R8 texture: size should be "
 			          << fsize << std::endl;
 			// clang-format on
@@ -451,7 +453,7 @@ int WriteFile(const Arguments::Write& args) noexcept
 	return EXIT_SUCCESS;
 }
 
-bool parseOptions(int argc, char** argv, Arguments& args, int& return_code) noexcept
+bool parseOptions(int argc, char** argv, Arguments& args, int& returnCode) noexcept
 {
 	cxxopts::Options options("lndtool", "Inspect and extract files from LionHead LND files.");
 
@@ -485,7 +487,7 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code) noex
 	catch (const std::exception& e)
 	{
 		std::cerr << e.what() << '\n';
-		return_code = EXIT_FAILURE;
+		returnCode = EXIT_FAILURE;
 		return false;
 	}
 
@@ -495,13 +497,13 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code) noex
 		if (result["help"].as<bool>())
 		{
 			std::cout << options.help() << std::endl;
-			return_code = EXIT_SUCCESS;
+			returnCode = EXIT_SUCCESS;
 			return false;
 		}
 		if (result["subcommand"].count() == 0)
 		{
 			std::cerr << options.help() << std::endl;
-			return_code = EXIT_FAILURE;
+			returnCode = EXIT_FAILURE;
 			return false;
 		}
 		if (result["subcommand"].as<std::string>() == "read")
@@ -579,17 +581,17 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code) noex
 	}
 
 	std::cerr << options.help() << std::endl;
-	return_code = EXIT_FAILURE;
+	returnCode = EXIT_FAILURE;
 	return false;
 }
 
 int main(int argc, char* argv[]) noexcept
 {
 	Arguments args;
-	int return_code = EXIT_SUCCESS;
-	if (!parseOptions(argc, argv, args, return_code))
+	int returnCode = EXIT_SUCCESS;
+	if (!parseOptions(argc, argv, args, returnCode))
 	{
-		return return_code;
+		return returnCode;
 	}
 
 	if (args.mode == Arguments::Mode::Write)
@@ -608,37 +610,37 @@ int main(int argc, char* argv[]) noexcept
 			switch (args.mode)
 			{
 			case Arguments::Mode::Header:
-				return_code |= PrintHeader(lnd);
+				returnCode |= PrintHeader(lnd);
 				break;
 			case Arguments::Mode::LowResolution:
-				return_code |= PrintLowRes(lnd);
+				returnCode |= PrintLowRes(lnd);
 				break;
 			case Arguments::Mode::Blocks:
-				return_code |= PrintBlocks(lnd);
+				returnCode |= PrintBlocks(lnd);
 				break;
 			case Arguments::Mode::Countries:
-				return_code |= PrintCountries(lnd);
+				returnCode |= PrintCountries(lnd);
 				break;
 			case Arguments::Mode::Materials:
-				return_code |= PrintMaterials(lnd);
+				returnCode |= PrintMaterials(lnd);
 				break;
 			case Arguments::Mode::Extra:
-				return_code |= PrintExtra(lnd);
+				returnCode |= PrintExtra(lnd);
 				break;
 			case Arguments::Mode::Unaccounted:
-				return_code |= PrintUnaccounted(lnd);
+				returnCode |= PrintUnaccounted(lnd);
 				break;
 			default:
-				return_code = EXIT_FAILURE;
+				returnCode = EXIT_FAILURE;
 				break;
 			}
 		}
 		catch (std::exception& err)
 		{
 			std::cerr << err.what() << std::endl;
-			return_code |= EXIT_FAILURE;
+			returnCode |= EXIT_FAILURE;
 		}
 	}
 
-	return return_code;
+	return returnCode;
 }

--- a/apps/lndtool/lndtool.cpp
+++ b/apps/lndtool/lndtool.cpp
@@ -49,7 +49,7 @@ int PrintRawBytes(const void* data, std::size_t size)
 
 int PrintHeader(openblack::lnd::LNDFile& lnd)
 {
-	auto& header = lnd.GetHeader();
+	const auto& header = lnd.GetHeader();
 
 	std::printf("file: %s\n", lnd.GetFilename().c_str());
 	std::printf("block count: %u\n", header.blockCount);
@@ -71,11 +71,11 @@ int PrintHeader(openblack::lnd::LNDFile& lnd)
 
 int PrintLowRes(openblack::lnd::LNDFile& lnd)
 {
-	auto& textures = lnd.GetLowResolutionTextures();
+	const auto& textures = lnd.GetLowResolutionTextures();
 
 	std::printf("file: %s\n", lnd.GetFilename().c_str());
 	uint32_t i = 0;
-	for (auto& texture : textures)
+	for (const auto& texture : textures)
 	{
 		std::printf("texture #%u:\n", i++);
 		std::printf("unknown header:\n");
@@ -89,11 +89,11 @@ int PrintLowRes(openblack::lnd::LNDFile& lnd)
 
 int PrintBlocks(openblack::lnd::LNDFile& lnd)
 {
-	auto& blocks = lnd.GetBlocks();
+	const auto& blocks = lnd.GetBlocks();
 
 	std::printf("file: %s\n", lnd.GetFilename().c_str());
 	uint32_t i = 0;
-	for (auto& block : blocks)
+	for (const auto& block : blocks)
 	{
 		std::printf("block #%u:\n", i++);
 		std::printf("cells:\n");
@@ -134,7 +134,7 @@ int PrintBlocks(openblack::lnd::LNDFile& lnd)
 			}
 			return ret;
 		};
-		for (auto& cell : block.cells)
+		for (const auto& cell : block.cells)
 		{
 			std::printf("    %u: r %u, g %u, b %u, luminosity %u, altitude %u, saveColor %u, country %u properties %s "
 			            "flags 0x%02X\n",
@@ -195,16 +195,16 @@ int PrintBlocks(openblack::lnd::LNDFile& lnd)
 
 int PrintCountries(openblack::lnd::LNDFile& lnd)
 {
-	auto& countries = lnd.GetCountries();
+	const auto& countries = lnd.GetCountries();
 
 	std::printf("file: %s\n", lnd.GetFilename().c_str());
 	uint32_t i = 0;
-	for (auto& country : countries)
+	for (const auto& country : countries)
 	{
 		std::printf("country #%u:\n", i++);
 		std::printf("materials:\n");
 		uint32_t j = 0;
-		for (auto& material : country.materials)
+		for (const auto& material : country.materials)
 		{
 			std::printf("    %3u: indices %3u %3u coefficient 0x%02X\n", j++, material.indices[0], material.indices[1],
 			            material.coefficient);
@@ -217,11 +217,11 @@ int PrintCountries(openblack::lnd::LNDFile& lnd)
 
 int PrintMaterials(openblack::lnd::LNDFile& lnd)
 {
-	auto& materials = lnd.GetMaterials();
+	const auto& materials = lnd.GetMaterials();
 
 	std::printf("file: %s\n", lnd.GetFilename().c_str());
 	uint32_t k = 0;
-	for (auto& material : materials)
+	for (const auto& material : materials)
 	{
 		std::printf("material #%u:\n", k++);
 		std::printf("type: #%u:\n", material.type);
@@ -262,7 +262,7 @@ int PrintMaterials(openblack::lnd::LNDFile& lnd)
 
 int PrintExtra(openblack::lnd::LNDFile& lnd)
 {
-	auto& extra = lnd.GetExtra();
+	const auto& extra = lnd.GetExtra();
 
 	std::printf("file: %s\n", lnd.GetFilename().c_str());
 	constexpr uint16_t subsample = 8;
@@ -312,7 +312,7 @@ int PrintExtra(openblack::lnd::LNDFile& lnd)
 
 int PrintUnaccounted(openblack::lnd::LNDFile& lnd)
 {
-	auto& unaccounted = lnd.GetUnaccounted();
+	const auto& unaccounted = lnd.GetUnaccounted();
 
 	std::printf("file: %s\n", lnd.GetFilename().c_str());
 	PrintRawBytes(unaccounted.data(), unaccounted.size());
@@ -355,7 +355,7 @@ int WriteFile(const Arguments::Write& args) noexcept
 
 	openblack::lnd::LNDMaterial material;
 	material.type = args.terrainType;
-	for (auto& filename : args.materialArray)
+	for (const auto& filename : args.materialArray)
 	{
 		std::ifstream stream(filename, std::ios::binary);
 		if (!stream.is_open())

--- a/apps/morphtool/morphtool.cpp
+++ b/apps/morphtool/morphtool.cpp
@@ -17,7 +17,7 @@
 
 int ListDetails(openblack::morph::MorphFile& morph)
 {
-	auto& header = morph.GetHeader();
+	const auto& header = morph.GetHeader();
 
 	std::printf("file: %s\n", morph.GetFilename().c_str());
 
@@ -41,8 +41,8 @@ int ListDetails(openblack::morph::MorphFile& morph)
 	std::printf("\n");
 
 	size_t num_animation_sets = 0;
-	auto& specs = morph.GetAnimationSpecs();
-	for (auto& anim_set : specs.animation_sets)
+	const auto& specs = morph.GetAnimationSpecs();
+	for (const auto& anim_set : specs.animation_sets)
 	{
 		num_animation_sets += anim_set.animations.size();
 	}
@@ -52,16 +52,16 @@ int ListDetails(openblack::morph::MorphFile& morph)
 	std::printf("%zu base animations\n", morph.GetBaseAnimationSet().size());
 	for (uint8_t i = 0; i < std::min(4u, num_variants); ++i)
 	{
-		auto& animation_set = morph.GetVariantAnimationSet(i);
+		const auto& animation_set = morph.GetVariantAnimationSet(i);
 		std::printf("%zu animations for \"%s\"\n", animation_set.size(), header.variant_mesh_names.at(i).data());
 	}
 
 	std::printf("%zu hair groups\n", morph.GetHairGroups().size());
 
-	auto& extra_data = morph.GetExtraData();
+	const auto& extra_data = morph.GetExtraData();
 
 	size_t extra_data_total = 0;
-	for (auto& data : extra_data)
+	for (const auto& data : extra_data)
 	{
 		extra_data_total += data.size();
 	}
@@ -74,7 +74,7 @@ int ListDetails(openblack::morph::MorphFile& morph)
 
 int PrintHeader(openblack::morph::MorphFile& morph)
 {
-	auto& header = morph.GetHeader();
+	const auto& header = morph.GetHeader();
 
 	std::printf("file: %s\n", morph.GetFilename().c_str());
 
@@ -92,7 +92,7 @@ int PrintHeader(openblack::morph::MorphFile& morph)
 
 int PrintSpecs(openblack::morph::MorphFile& morph)
 {
-	auto& specs = morph.GetAnimationSpecs();
+	const auto& specs = morph.GetAnimationSpecs();
 
 	std::printf("file: %s\n", morph.GetFilename().c_str());
 
@@ -100,7 +100,7 @@ int PrintSpecs(openblack::morph::MorphFile& morph)
 	std::printf("specs version: %u\n", specs.version);
 
 	size_t j = 0;
-	for (auto& anim_set : specs.animation_sets)
+	for (const auto& anim_set : specs.animation_sets)
 	{
 		j += anim_set.animations.size();
 	}
@@ -108,11 +108,11 @@ int PrintSpecs(openblack::morph::MorphFile& morph)
 
 	uint32_t i = 0;
 	j = 0;
-	for (auto& anim_set : specs.animation_sets)
+	for (const auto& anim_set : specs.animation_sets)
 	{
 		std::printf("[%u] category \"%s\" with %zu animations:\n", i, anim_set.name.c_str(), anim_set.animations.size());
 		i++;
-		for (auto& desc : anim_set.animations)
+		for (const auto& desc : anim_set.animations)
 		{
 			std::printf("\t[%3zu] type: %c, \"%s\":\n", j, static_cast<char>(desc.type), desc.name.c_str());
 			j++;
@@ -154,7 +154,7 @@ void PrintAnimation(const openblack::morph::Animation& animation)
 	std::printf("\tKeyframes:\n");
 
 	uint32_t i = 0;
-	for (auto& frame : animation.keyframes)
+	for (const auto& frame : animation.keyframes)
 	{
 		std::printf("\t\t[%2u]\n", i);
 		std::printf("\t\teuler_angles: [");
@@ -175,7 +175,7 @@ void PrintAnimation(const openblack::morph::Animation& animation)
 
 int ShowBaseAnimationSet(openblack::morph::MorphFile& morph)
 {
-	auto& animation_set = morph.GetBaseAnimationSet();
+	const auto& animation_set = morph.GetBaseAnimationSet();
 
 	std::printf("file: %s\n", morph.GetFilename().c_str());
 	std::printf("%zu base animations\n", animation_set.size());
@@ -193,7 +193,7 @@ int ShowBaseAnimationSet(openblack::morph::MorphFile& morph)
 
 int ShowVariantAnimationSets(openblack::morph::MorphFile& morph)
 {
-	auto& header = morph.GetHeader();
+	const auto& header = morph.GetHeader();
 
 	std::printf("file: %s\n", morph.GetFilename().c_str());
 
@@ -209,7 +209,7 @@ int ShowVariantAnimationSets(openblack::morph::MorphFile& morph)
 
 	for (uint8_t i = 0; i < num_variants; ++i)
 	{
-		auto& animation_set = morph.GetVariantAnimationSet(i);
+		const auto& animation_set = morph.GetVariantAnimationSet(i);
 		std::printf("%zu animations for \"%s\"\n", animation_set.size(), header.variant_mesh_names.at(i).data());
 		uint32_t j = 0;
 		for (const auto& animation : animation_set)
@@ -224,7 +224,7 @@ int ShowVariantAnimationSets(openblack::morph::MorphFile& morph)
 
 int ShowHairGroups(openblack::morph::MorphFile& morph)
 {
-	auto& hair_groups = morph.GetHairGroups();
+	const auto& hair_groups = morph.GetHairGroups();
 
 	std::printf("file: %s\n", morph.GetFilename().c_str());
 	std::printf("%zu hair groups\n", hair_groups.size());
@@ -278,11 +278,11 @@ int ShowHairGroups(openblack::morph::MorphFile& morph)
 
 int ShowExtraData(openblack::morph::MorphFile& morph)
 {
-	auto& extra_data = morph.GetExtraData();
-	auto& specs = morph.GetAnimationSpecs();
+	const auto& extra_data = morph.GetExtraData();
+	const auto& specs = morph.GetAnimationSpecs();
 
 	size_t extra_data_total = 0;
-	for (auto& data : extra_data)
+	for (const auto& data : extra_data)
 	{
 		extra_data_total += data.size();
 	}
@@ -294,14 +294,14 @@ int ShowExtraData(openblack::morph::MorphFile& morph)
 	uint32_t i = 0;
 	uint32_t category_index = 0;
 	size_t animation_index = 0;
-	for (auto& list : extra_data)
+	for (const auto& list : extra_data)
 	{
 		uint32_t j = 0;
 		std::printf("[%2u]: %s (%s)\n", i, specs.animation_sets[category_index].animations[animation_index].name.c_str(),
 		            specs.animation_sets[category_index].name.c_str());
 
 		std::printf("\t%zu segments\n", list.size());
-		for (auto& data : list)
+		for (const auto& data : list)
 		{
 			std::printf("\t[%2u]\n", j);
 			std::printf("\t\tunknown_0x0: 0x%08X\n", data.unknown_0x0);
@@ -397,10 +397,8 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code) noex
 			return_code = EXIT_FAILURE;
 			return false;
 		}
-		else
-		{
-			args.spec_directory = result["spec-files-directory"].as<std::filesystem::path>();
-		}
+
+		args.spec_directory = result["spec-files-directory"].as<std::filesystem::path>();
 		if (result["subcommand"].as<std::string>() == "read")
 		{
 			if (result["list-details"].count() > 0)

--- a/apps/morphtool/morphtool.cpp
+++ b/apps/morphtool/morphtool.cpp
@@ -21,17 +21,17 @@ int ListDetails(openblack::morph::MorphFile& morph)
 
 	std::printf("file: %s\n", morph.GetFilename().c_str());
 
-	std::printf("base mesh: \"%s\"\n", header.base_mesh_name.data());
-	uint32_t num_variants = 0;
-	for (const auto& meshes : header.variant_mesh_names)
+	std::printf("base mesh: \"%s\"\n", header.baseMeshName.data());
+	uint32_t numVariants = 0;
+	for (const auto& meshes : header.variantMeshNames)
 	{
 		if (std::strlen(meshes.data()) > 0)
 		{
-			++num_variants;
+			++numVariants;
 		}
 	}
-	std::printf("%u variant meshes:", num_variants);
-	for (const auto& meshes : header.variant_mesh_names)
+	std::printf("%u variant meshes:", numVariants);
+	for (const auto& meshes : header.variantMeshNames)
 	{
 		if (std::strlen(meshes.data()) > 0)
 		{
@@ -40,34 +40,34 @@ int ListDetails(openblack::morph::MorphFile& morph)
 	}
 	std::printf("\n");
 
-	size_t num_animation_sets = 0;
+	size_t numAnimationSets = 0;
 	const auto& specs = morph.GetAnimationSpecs();
-	for (const auto& anim_set : specs.animation_sets)
+	for (const auto& animSet : specs.animationSets)
 	{
-		num_animation_sets += anim_set.animations.size();
+		numAnimationSets += animSet.animations.size();
 	}
-	std::printf("%zu animations from %zu categories:\n", num_animation_sets, specs.animation_sets.size());
-	std::printf("%u variant animation sets\n", std::min(4u, num_variants));
+	std::printf("%zu animations from %zu categories:\n", numAnimationSets, specs.animationSets.size());
+	std::printf("%u variant animation sets\n", std::min(4u, numVariants));
 
 	std::printf("%zu base animations\n", morph.GetBaseAnimationSet().size());
-	for (uint8_t i = 0; i < std::min(4u, num_variants); ++i)
+	for (uint8_t i = 0; i < std::min(4u, numVariants); ++i)
 	{
-		const auto& animation_set = morph.GetVariantAnimationSet(i);
-		std::printf("%zu animations for \"%s\"\n", animation_set.size(), header.variant_mesh_names.at(i).data());
+		const auto& animationSet = morph.GetVariantAnimationSet(i);
+		std::printf("%zu animations for \"%s\"\n", animationSet.size(), header.variantMeshNames.at(i).data());
 	}
 
 	std::printf("%zu hair groups\n", morph.GetHairGroups().size());
 
-	const auto& extra_data = morph.GetExtraData();
+	const auto& extraData = morph.GetExtraData();
 
-	size_t extra_data_total = 0;
-	for (const auto& data : extra_data)
+	size_t extraDataTotal = 0;
+	for (const auto& data : extraData)
 	{
-		extra_data_total += data.size();
+		extraDataTotal += data.size();
 	}
 
-	std::printf("%zu total extra data segments\n", extra_data_total);
-	std::printf("%zu extra data groups\n", extra_data.size());
+	std::printf("%zu total extra data segments\n", extraDataTotal);
+	std::printf("%zu extra data groups\n", extraData.size());
 
 	return EXIT_SUCCESS;
 }
@@ -78,13 +78,13 @@ int PrintHeader(openblack::morph::MorphFile& morph)
 
 	std::printf("file: %s\n", morph.GetFilename().c_str());
 
-	std::printf("unknown_0x0: 0x%08X\n", header.unknown_0x0);
-	std::printf("spec_file_version: %u\n", header.spec_file_version);
-	std::printf("binary_version: %u\n", header.binary_version);
-	std::printf("base_mesh_name: %s\n", header.base_mesh_name.data());
+	std::printf("unknown0x0: 0x%08X\n", header.unknown0x0);
+	std::printf("specFileVersion: %u\n", header.specFileVersion);
+	std::printf("binaryVersion: %u\n", header.binaryVersion);
+	std::printf("baseMeshName: %s\n", header.baseMeshName.data());
 	for (uint8_t i = 0; i < 6; ++i)
 	{
-		std::printf("variant_mesh_names[%u]: %s\n", i, header.variant_mesh_names.at(i).data());
+		std::printf("variantMeshNames[%u]: %s\n", i, header.variantMeshNames.at(i).data());
 	}
 
 	return EXIT_SUCCESS;
@@ -100,19 +100,19 @@ int PrintSpecs(openblack::morph::MorphFile& morph)
 	std::printf("specs version: %u\n", specs.version);
 
 	size_t j = 0;
-	for (const auto& anim_set : specs.animation_sets)
+	for (const auto& animSet : specs.animationSets)
 	{
-		j += anim_set.animations.size();
+		j += animSet.animations.size();
 	}
-	std::printf("%zu animations from %zu categories:\n", j, specs.animation_sets.size());
+	std::printf("%zu animations from %zu categories:\n", j, specs.animationSets.size());
 
 	uint32_t i = 0;
 	j = 0;
-	for (const auto& anim_set : specs.animation_sets)
+	for (const auto& animSet : specs.animationSets)
 	{
-		std::printf("[%u] category \"%s\" with %zu animations:\n", i, anim_set.name.c_str(), anim_set.animations.size());
+		std::printf("[%u] category \"%s\" with %zu animations:\n", i, animSet.name.c_str(), animSet.animations.size());
 		i++;
-		for (const auto& desc : anim_set.animations)
+		for (const auto& desc : animSet.animations)
 		{
 			std::printf("\t[%3zu] type: %c, \"%s\":\n", j, static_cast<char>(desc.type), desc.name.c_str());
 			j++;
@@ -125,27 +125,27 @@ int PrintSpecs(openblack::morph::MorphFile& morph)
 void PrintAnimation(const openblack::morph::Animation& animation)
 {
 	std::printf("\tHeader:\n");
-	std::printf("\t\tunknown_0x0: 0x%08X\n", animation.header.unknown_0x0);
-	std::printf("\t\tunknown_0x4: 0x%08X\n", animation.header.unknown_0x4);
-	std::printf("\t\tunknown_0x8: %f\n", animation.header.unknown_0x8);
-	std::printf("\t\tunknown_0xc: %f\n", animation.header.unknown_0xc);
-	std::printf("\t\tunknown_0x10: %f\n", animation.header.unknown_0x10);
-	std::printf("\t\tunknown_0x14: %f\n", animation.header.unknown_0x14);
-	std::printf("\t\tunknown_0x18: %f\n", animation.header.unknown_0x18);
-	std::printf("\t\tframe_count: %u\n", animation.header.frame_count);
-	std::printf("\t\tmesh_bone_count: %u\n", animation.header.mesh_bone_count);
-	std::printf("\t\trotated_joint_count: %u\n", animation.header.rotated_joint_count);
-	std::printf("\t\ttranslated_joint_count: %u\n", animation.header.translated_joint_count);
+	std::printf("\t\tunknown0x0: 0x%08X\n", animation.header.unknown0x0);
+	std::printf("\t\tunknown0x4: 0x%08X\n", animation.header.unknown0x4);
+	std::printf("\t\tunknown0x8: %f\n", animation.header.unknown0x8);
+	std::printf("\t\tunknown0xc: %f\n", animation.header.unknown0xc);
+	std::printf("\t\tunknown0x10: %f\n", animation.header.unknown0x10);
+	std::printf("\t\tunknown0x14: %f\n", animation.header.unknown0x14);
+	std::printf("\t\tunknown0x18: %f\n", animation.header.unknown0x18);
+	std::printf("\t\tframeCount: %u\n", animation.header.frameCount);
+	std::printf("\t\tmeshBoneCount: %u\n", animation.header.meshBoneCount);
+	std::printf("\t\trotatedJointCount: %u\n", animation.header.rotatedJointCount);
+	std::printf("\t\ttranslatedJointCount: %u\n", animation.header.translatedJointCount);
 
-	std::printf("\trotated_joint_indices: [");
-	for (uint32_t index : animation.rotated_joint_indices)
+	std::printf("\trotatedJointIndices: [");
+	for (uint32_t index : animation.rotatedJointIndices)
 	{
 		std::printf("%u, ", index);
 	}
 	std::printf("]\n");
 
-	std::printf("\ttranslated_joint_indices: [");
-	for (uint32_t index : animation.translated_joint_indices)
+	std::printf("\ttranslatedJointIndices: [");
+	for (uint32_t index : animation.translatedJointIndices)
 	{
 		std::printf("%u, ", index);
 	}
@@ -157,8 +157,8 @@ void PrintAnimation(const openblack::morph::Animation& animation)
 	for (const auto& frame : animation.keyframes)
 	{
 		std::printf("\t\t[%2u]\n", i);
-		std::printf("\t\teuler_angles: [");
-		for (auto angles : frame.euler_angles)
+		std::printf("\t\teulerAngles: [");
+		for (auto angles : frame.eulerAngles)
 		{
 			std::printf("(%f, %f, %f), ", angles[0], angles[1], angles[2]);
 		}
@@ -175,13 +175,13 @@ void PrintAnimation(const openblack::morph::Animation& animation)
 
 int ShowBaseAnimationSet(openblack::morph::MorphFile& morph)
 {
-	const auto& animation_set = morph.GetBaseAnimationSet();
+	const auto& animationSet = morph.GetBaseAnimationSet();
 
 	std::printf("file: %s\n", morph.GetFilename().c_str());
-	std::printf("%zu base animations\n", animation_set.size());
+	std::printf("%zu base animations\n", animationSet.size());
 
 	uint32_t i = 0;
-	for (const auto& animation : animation_set)
+	for (const auto& animation : animationSet)
 	{
 		std::printf("\t[%2u]\n", i);
 		PrintAnimation(animation);
@@ -197,22 +197,22 @@ int ShowVariantAnimationSets(openblack::morph::MorphFile& morph)
 
 	std::printf("file: %s\n", morph.GetFilename().c_str());
 
-	uint8_t num_variants = 0;
+	uint8_t numVariants = 0;
 	for (uint8_t i = 0; i < 4; ++i)
 	{
-		if (std::strlen(header.variant_mesh_names.at(i).data()) > 0 && !morph.GetVariantAnimationSet(i).empty())
+		if (std::strlen(header.variantMeshNames.at(i).data()) > 0 && !morph.GetVariantAnimationSet(i).empty())
 		{
-			++num_variants;
+			++numVariants;
 		}
 	}
-	std::printf("%u animation set variants\n", num_variants);
+	std::printf("%u animation set variants\n", numVariants);
 
-	for (uint8_t i = 0; i < num_variants; ++i)
+	for (uint8_t i = 0; i < numVariants; ++i)
 	{
-		const auto& animation_set = morph.GetVariantAnimationSet(i);
-		std::printf("%zu animations for \"%s\"\n", animation_set.size(), header.variant_mesh_names.at(i).data());
+		const auto& animationSet = morph.GetVariantAnimationSet(i);
+		std::printf("%zu animations for \"%s\"\n", animationSet.size(), header.variantMeshNames.at(i).data());
 		uint32_t j = 0;
-		for (const auto& animation : animation_set)
+		for (const auto& animation : animationSet)
 		{
 			std::printf("\t[%2u]\n", j);
 			PrintAnimation(animation);
@@ -224,47 +224,47 @@ int ShowVariantAnimationSets(openblack::morph::MorphFile& morph)
 
 int ShowHairGroups(openblack::morph::MorphFile& morph)
 {
-	const auto& hair_groups = morph.GetHairGroups();
+	const auto& hairGroups = morph.GetHairGroups();
 
 	std::printf("file: %s\n", morph.GetFilename().c_str());
-	std::printf("%zu hair groups\n", hair_groups.size());
+	std::printf("%zu hair groups\n", hairGroups.size());
 
 	uint32_t i = 0;
-	for (const auto& group : hair_groups)
+	for (const auto& group : hairGroups)
 	{
 		std::printf("[%2u]\n", i);
 		std::printf("\tHeader:\n");
-		std::printf("\t\tunknown_0x0: 0x%08X\n", group.header.unknown_0x0);
-		std::printf("\t\thair_count: %d\n", group.header.hair_count);
-		std::printf("\t\tunknown_0x8: 0x%08X\n", group.header.unknown_0x8);
-		std::printf("\t\tunknown_0xc: 0x%08X\n", group.header.unknown_0xc);
-		for (size_t j = 0; j < group.header.unknown_0x10.size(); ++j)
+		std::printf("\t\tunknown0x0: 0x%08X\n", group.header.unknown0x0);
+		std::printf("\t\thairCount: %d\n", group.header.hairCount);
+		std::printf("\t\tunknown0x8: 0x%08X\n", group.header.unknown0x8);
+		std::printf("\t\tunknown0xc: 0x%08X\n", group.header.unknown0xc);
+		for (size_t j = 0; j < group.header.unknown0x10.size(); ++j)
 		{
-			std::printf("\t\tunknown_0x10[%2zu]:\n", j);
-			std::printf("\t\t\tunknown_0x0: 0x%08X\n", group.header.unknown_0x10.at(j).unknown_0x0);
-			std::printf("\t\t\tunknown_0x4: 0x%08X\n", group.header.unknown_0x10.at(j).unknown_0x4);
-			std::printf("\t\t\tunknown_0x8: 0x%08X\n", group.header.unknown_0x10.at(j).unknown_0x8);
-			std::printf("\t\t\tunknown_0xc: %f\n", group.header.unknown_0x10.at(j).unknown_0xc);
-			std::printf("\t\t\tunknown_0x10: %f\n", group.header.unknown_0x10.at(j).unknown_0x10);
-			std::printf("\t\t\tunknown_0x14: %f\n", group.header.unknown_0x10.at(j).unknown_0x14);
-			std::printf("\t\t\tunknown_0x18: %f\n", group.header.unknown_0x10.at(j).unknown_0x18);
+			std::printf("\t\tunknown0x10[%2zu]:\n", j);
+			std::printf("\t\t\tunknown0x0: 0x%08X\n", group.header.unknown0x10.at(j).unknown0x0);
+			std::printf("\t\t\tunknown0x4: 0x%08X\n", group.header.unknown0x10.at(j).unknown0x4);
+			std::printf("\t\t\tunknown0x8: 0x%08X\n", group.header.unknown0x10.at(j).unknown0x8);
+			std::printf("\t\t\tunknown0xc: %f\n", group.header.unknown0x10.at(j).unknown0xc);
+			std::printf("\t\t\tunknown0x10: %f\n", group.header.unknown0x10.at(j).unknown0x10);
+			std::printf("\t\t\tunknown0x14: %f\n", group.header.unknown0x10.at(j).unknown0x14);
+			std::printf("\t\t\tunknown0x18: %f\n", group.header.unknown0x10.at(j).unknown0x18);
 		}
 		std::printf("\tHairs:\n");
 		for (size_t j = 0; j < group.hairs.size(); ++j)
 		{
 			std::printf("\t[%2zu]\n", j);
-			std::printf("\t\tunknown_0x0: 0x%08X\n", group.hairs[j].unknown_0x0);
+			std::printf("\t\tunknown0x0: 0x%08X\n", group.hairs[j].unknown0x0);
 
 			std::printf("\t\tintersection:\n");
-			std::printf("\t\t\tunknown_0x0: 0x%08X\n", group.hairs[j].intersection.unknown_0x0);
-			std::printf("\t\t\tunknown_0x4: 0x%08X\n", group.hairs[j].intersection.unknown_0x4);
-			std::printf("\t\t\tunknown_0x8: 0x%08X\n", group.hairs[j].intersection.unknown_0x8);
-			std::printf("\t\t\tunknown_0xc: 0x%08X\n", group.hairs[j].intersection.unknown_0xc);
-			std::printf("\t\t\tunknown_0x10: 0x%08X\n", group.hairs[j].intersection.unknown_0x10);
-			std::printf("\t\t\tunknown_0x14: 0x%08X\n", group.hairs[j].intersection.unknown_0x14);
-			std::printf("\t\t\tunknown_0x18: 0x%08X\n", group.hairs[j].intersection.unknown_0x18);
-			std::printf("\t\t\tunknown_0x1c: %f\n", group.hairs[j].intersection.unknown_0x1c);
-			std::printf("\t\t\tunknown_0x20: %f\n", group.hairs[j].intersection.unknown_0x20);
+			std::printf("\t\t\tunknown0x0: 0x%08X\n", group.hairs[j].intersection.unknown0x0);
+			std::printf("\t\t\tunknown0x4: 0x%08X\n", group.hairs[j].intersection.unknown0x4);
+			std::printf("\t\t\tunknown0x8: 0x%08X\n", group.hairs[j].intersection.unknown0x8);
+			std::printf("\t\t\tunknown0xc: 0x%08X\n", group.hairs[j].intersection.unknown0xc);
+			std::printf("\t\t\tunknown0x10: 0x%08X\n", group.hairs[j].intersection.unknown0x10);
+			std::printf("\t\t\tunknown0x14: 0x%08X\n", group.hairs[j].intersection.unknown0x14);
+			std::printf("\t\t\tunknown0x18: 0x%08X\n", group.hairs[j].intersection.unknown0x18);
+			std::printf("\t\t\tunknown0x1c: %f\n", group.hairs[j].intersection.unknown0x1c);
+			std::printf("\t\t\tunknown0x20: %f\n", group.hairs[j].intersection.unknown0x20);
 
 			std::printf("\t\txs: [%f, %f, %f]\n", group.hairs[j].xs[0], group.hairs[j].xs[1], group.hairs[j].xs[2]);
 			std::printf("\t\tys: [%f, %f, %f]\n", group.hairs[j].ys[0], group.hairs[j].ys[1], group.hairs[j].ys[2]);
@@ -278,44 +278,44 @@ int ShowHairGroups(openblack::morph::MorphFile& morph)
 
 int ShowExtraData(openblack::morph::MorphFile& morph)
 {
-	const auto& extra_data = morph.GetExtraData();
+	const auto& extraData = morph.GetExtraData();
 	const auto& specs = morph.GetAnimationSpecs();
 
-	size_t extra_data_total = 0;
-	for (const auto& data : extra_data)
+	size_t extraDataTotal = 0;
+	for (const auto& data : extraData)
 	{
-		extra_data_total += data.size();
+		extraDataTotal += data.size();
 	}
 
 	std::printf("file: %s\n", morph.GetFilename().c_str());
-	std::printf("%zu total extra data segments\n", extra_data_total);
-	std::printf("%zu extra data groups (one per animation)\n", extra_data.size());
+	std::printf("%zu total extra data segments\n", extraDataTotal);
+	std::printf("%zu extra data groups (one per animation)\n", extraData.size());
 
 	uint32_t i = 0;
-	uint32_t category_index = 0;
-	size_t animation_index = 0;
-	for (const auto& list : extra_data)
+	uint32_t categoryIndex = 0;
+	size_t animationIndex = 0;
+	for (const auto& list : extraData)
 	{
 		uint32_t j = 0;
-		std::printf("[%2u]: %s (%s)\n", i, specs.animation_sets[category_index].animations[animation_index].name.c_str(),
-		            specs.animation_sets[category_index].name.c_str());
+		std::printf("[%2u]: %s (%s)\n", i, specs.animationSets[categoryIndex].animations[animationIndex].name.c_str(),
+		            specs.animationSets[categoryIndex].name.c_str());
 
 		std::printf("\t%zu segments\n", list.size());
 		for (const auto& data : list)
 		{
 			std::printf("\t[%2u]\n", j);
-			std::printf("\t\tunknown_0x0: 0x%08X\n", data.unknown_0x0);
-			std::printf("\t\tunknown_0x4: 0x%08X\n", data.unknown_0x4);
-			std::printf("\t\tunknown_0x8: 0x%08X\n", data.unknown_0x8);
-			std::printf("\t\tunknown_0xc: 0x%08X\n", data.unknown_0xc);
+			std::printf("\t\tunknown0x0: 0x%08X\n", data.unknown0x0);
+			std::printf("\t\tunknown0x4: 0x%08X\n", data.unknown0x4);
+			std::printf("\t\tunknown0x8: 0x%08X\n", data.unknown0x8);
+			std::printf("\t\tunknown0xc: 0x%08X\n", data.unknown0xc);
 			++j;
 		}
 		++i;
-		++animation_index;
-		if (animation_index >= specs.animation_sets[category_index].animations.size())
+		++animationIndex;
+		if (animationIndex >= specs.animationSets[categoryIndex].animations.size())
 		{
-			animation_index = 0;
-			category_index++;
+			animationIndex = 0;
+			categoryIndex++;
 		}
 	}
 
@@ -335,14 +335,14 @@ struct Arguments
 		ShowExtraData,
 	};
 	Mode mode;
-	std::filesystem::path spec_directory;
+	std::filesystem::path specDirectory;
 	struct Read
 	{
 		std::vector<std::filesystem::path> filenames;
 	} read;
 };
 
-bool parseOptions(int argc, char** argv, Arguments& args, int& return_code) noexcept
+bool parseOptions(int argc, char** argv, Arguments& args, int& returnCode) noexcept
 {
 	cxxopts::Options options("morphtool", "Inspect and read data files from LionHead CBN and HBN files internal segment (use "
 	                                      "\"stdin\" if piping from packtool).");
@@ -372,7 +372,7 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code) noex
 	catch (const std::exception& e)
 	{
 		std::cerr << e.what() << '\n';
-		return_code = EXIT_FAILURE;
+		returnCode = EXIT_FAILURE;
 		return false;
 	}
 
@@ -382,23 +382,23 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code) noex
 		if (result["help"].as<bool>())
 		{
 			std::cout << options.help() << std::endl;
-			return_code = EXIT_SUCCESS;
+			returnCode = EXIT_SUCCESS;
 			return false;
 		}
 		if (result["subcommand"].count() == 0)
 		{
 			std::cerr << options.help() << std::endl;
-			return_code = EXIT_FAILURE;
+			returnCode = EXIT_FAILURE;
 			return false;
 		}
 		if (result["spec-files-directory"].count() == 0)
 		{
 			std::cerr << options.help() << std::endl;
-			return_code = EXIT_FAILURE;
+			returnCode = EXIT_FAILURE;
 			return false;
 		}
 
-		args.spec_directory = result["spec-files-directory"].as<std::filesystem::path>();
+		args.specDirectory = result["spec-files-directory"].as<std::filesystem::path>();
 		if (result["subcommand"].as<std::string>() == "read")
 		{
 			if (result["list-details"].count() > 0)
@@ -451,17 +451,17 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code) noex
 	}
 
 	std::cerr << options.help() << std::endl;
-	return_code = EXIT_FAILURE;
+	returnCode = EXIT_FAILURE;
 	return false;
 }
 
 int main(int argc, char* argv[]) noexcept
 {
 	Arguments args;
-	int return_code = EXIT_SUCCESS;
-	if (!parseOptions(argc, argv, args, return_code))
+	int returnCode = EXIT_SUCCESS;
+	if (!parseOptions(argc, argv, args, returnCode))
 	{
-		return return_code;
+		return returnCode;
 	}
 
 	for (auto& filename : args.read.filenames)
@@ -483,47 +483,47 @@ int main(int argc, char* argv[]) noexcept
 					}
 				}
 				printf("got %zu bytes from stdin\n", buffer.size());
-				morph.Open(buffer, args.spec_directory);
+				morph.Open(buffer, args.specDirectory);
 			}
 			else
 			{
-				morph.Open(filename, args.spec_directory);
+				morph.Open(filename, args.specDirectory);
 			}
 
 			switch (args.mode)
 			{
 			case Arguments::Mode::List:
-				return_code |= ListDetails(morph);
+				returnCode |= ListDetails(morph);
 				break;
 			case Arguments::Mode::Header:
-				return_code |= PrintHeader(morph);
+				returnCode |= PrintHeader(morph);
 				break;
 			case Arguments::Mode::ListAnimationSet:
-				return_code |= PrintSpecs(morph);
+				returnCode |= PrintSpecs(morph);
 				break;
 			case Arguments::Mode::ShowBaseAnimationSet:
-				return_code |= ShowBaseAnimationSet(morph);
+				returnCode |= ShowBaseAnimationSet(morph);
 				break;
 			case Arguments::Mode::ShowVariantAnimationSets:
-				return_code |= ShowVariantAnimationSets(morph);
+				returnCode |= ShowVariantAnimationSets(morph);
 				break;
 			case Arguments::Mode::ShowHairGroups:
-				return_code |= ShowHairGroups(morph);
+				returnCode |= ShowHairGroups(morph);
 				break;
 			case Arguments::Mode::ShowExtraData:
-				return_code |= ShowExtraData(morph);
+				returnCode |= ShowExtraData(morph);
 				break;
 			default:
-				return_code = EXIT_FAILURE;
+				returnCode = EXIT_FAILURE;
 				break;
 			}
 		}
 		catch (const std::exception& err)
 		{
 			std::cerr << err.what() << std::endl;
-			return_code |= EXIT_FAILURE;
+			returnCode |= EXIT_FAILURE;
 		}
 	}
 
-	return return_code;
+	return returnCode;
 }

--- a/apps/packtool/packtool.cpp
+++ b/apps/packtool/packtool.cpp
@@ -68,10 +68,10 @@ int ListBlocks(openblack::pack::PackFile& pack)
 
 int ListBlock(openblack::pack::PackFile& pack, const std::string& name, const std::filesystem::path& outFilename)
 {
-	auto* output_log_stream = stdout;
+	auto* outputLogStream = stdout;
 	if (outFilename == std::filesystem::path("stdout"))
 	{
-		output_log_stream = stderr;
+		outputLogStream = stderr;
 	}
 
 	const auto& blocks = pack.GetBlocks();
@@ -83,9 +83,9 @@ int ListBlock(openblack::pack::PackFile& pack, const std::string& name, const st
 		return EXIT_FAILURE;
 	}
 
-	std::fprintf(output_log_stream, "file: %s\n", pack.GetFilename().c_str());
-	std::fprintf(output_log_stream, "name \"%s\", size %u\n", name.c_str(), static_cast<uint32_t>(block->second.size()));
-	std::fprintf(output_log_stream, "\n");
+	std::fprintf(outputLogStream, "file: %s\n", pack.GetFilename().c_str());
+	std::fprintf(outputLogStream, "name \"%s\", size %u\n", name.c_str(), static_cast<uint32_t>(block->second.size()));
+	std::fprintf(outputLogStream, "\n");
 
 	if (!outFilename.empty())
 	{
@@ -99,7 +99,7 @@ int ListBlock(openblack::pack::PackFile& pack, const std::string& name, const st
 			output.write(reinterpret_cast<const char*>(block->second.data()), block->second.size());
 		}
 
-		std::fprintf(output_log_stream, "\nBlock writen to %s\n", outFilename.string().c_str());
+		std::fprintf(outputLogStream, "\nBlock writen to %s\n", outFilename.string().c_str());
 	}
 
 	return EXIT_SUCCESS;
@@ -376,7 +376,7 @@ struct Arguments
 	std::filesystem::path outFilename;
 };
 
-bool parseOptions(int argc, char** argv, Arguments& args, int& return_code) noexcept
+bool parseOptions(int argc, char** argv, Arguments& args, int& returnCode) noexcept
 {
 	cxxopts::Options options("packtool", "Inspect and extract files from LionHead pack files.");
 
@@ -409,7 +409,7 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code) noex
 	catch (const std::exception& e)
 	{
 		std::cerr << e.what() << '\n';
-		return_code = EXIT_FAILURE;
+		returnCode = EXIT_FAILURE;
 		return false;
 	}
 
@@ -420,7 +420,7 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code) noex
 		if (result["help"].as<bool>())
 		{
 			std::cout << options.help() << std::endl;
-			return_code = EXIT_SUCCESS;
+			returnCode = EXIT_SUCCESS;
 			return false;
 		}
 		if (result["write-mesh"].count() > 0)
@@ -541,17 +541,17 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code) noex
 	}
 
 	std::cerr << options.help() << std::endl;
-	return_code = EXIT_FAILURE;
+	returnCode = EXIT_FAILURE;
 	return false;
 }
 
 int main(int argc, char* argv[]) noexcept
 {
 	Arguments args;
-	int return_code = EXIT_SUCCESS;
-	if (!parseOptions(argc, argv, args, return_code))
+	int returnCode = EXIT_SUCCESS;
+	if (!parseOptions(argc, argv, args, returnCode))
 	{
-		return return_code;
+		return returnCode;
 	}
 
 	if (args.mode == Arguments::Mode::WriteRaw)
@@ -580,49 +580,49 @@ int main(int argc, char* argv[]) noexcept
 			switch (args.mode)
 			{
 			case Arguments::Mode::List:
-				return_code |= ListBlocks(pack);
+				returnCode |= ListBlocks(pack);
 				break;
 			case Arguments::Mode::Block:
-				return_code |= ListBlock(pack, args.block, args.outFilename);
+				returnCode |= ListBlock(pack, args.block, args.outFilename);
 				break;
 			case Arguments::Mode::Bytes:
-				return_code |= ViewBytes(pack, args.block);
+				returnCode |= ViewBytes(pack, args.block);
 				break;
 			case Arguments::Mode::Info:
-				return_code |= ViewInfo(pack);
+				returnCode |= ViewInfo(pack);
 				break;
 			case Arguments::Mode::Body:
-				return_code |= ViewBody(pack);
+				returnCode |= ViewBody(pack);
 				break;
 			case Arguments::Mode::Textures:
-				return_code |= ViewTextures(pack);
+				returnCode |= ViewTextures(pack);
 				break;
 			case Arguments::Mode::Meshes:
-				return_code |= ViewMeshes(pack);
+				returnCode |= ViewMeshes(pack);
 				break;
 			case Arguments::Mode::Animations:
-				return_code |= ViewAnimations(pack);
+				returnCode |= ViewAnimations(pack);
 				break;
 			case Arguments::Mode::Texture:
-				return_code |= ViewTexture(pack, args.block, args.outFilename);
+				returnCode |= ViewTexture(pack, args.block, args.outFilename);
 				break;
 			case Arguments::Mode::Mesh:
-				return_code |= ViewMesh(pack, args.blockId, args.outFilename);
+				returnCode |= ViewMesh(pack, args.blockId, args.outFilename);
 				break;
 			case Arguments::Mode::Animation:
-				return_code |= ViewAnimation(pack, args.blockId, args.outFilename);
+				returnCode |= ViewAnimation(pack, args.blockId, args.outFilename);
 				break;
 			default:
-				return_code = EXIT_FAILURE;
+				returnCode = EXIT_FAILURE;
 				break;
 			}
 		}
 		catch (std::exception& err)
 		{
 			std::cerr << err.what() << std::endl;
-			return_code |= EXIT_FAILURE;
+			returnCode |= EXIT_FAILURE;
 		}
 	}
 
-	return return_code;
+	return returnCode;
 }

--- a/apps/packtool/packtool.cpp
+++ b/apps/packtool/packtool.cpp
@@ -49,7 +49,7 @@ int PrintRawBytes(const void* data, std::size_t size)
 
 int ListBlocks(openblack::pack::PackFile& pack)
 {
-	auto& blocks = pack.GetBlocks();
+	const auto& blocks = pack.GetBlocks();
 
 	std::printf("file: %s\n", pack.GetFilename().c_str());
 	std::printf("%u blocks\n", static_cast<uint32_t>(blocks.size()));
@@ -57,7 +57,7 @@ int ListBlocks(openblack::pack::PackFile& pack)
 	std::printf("%u meshes\n", static_cast<uint32_t>(pack.GetMeshes().size()));
 	std::printf("%u animations\n", static_cast<uint32_t>(pack.GetAnimations().size()));
 	uint32_t i = 0;
-	for (auto& [name, data] : blocks)
+	for (const auto& [name, data] : blocks)
 	{
 		std::printf("%u: name \"%s\", size %u\n", ++i, name.c_str(), static_cast<uint32_t>(data.size()));
 	}
@@ -68,13 +68,13 @@ int ListBlocks(openblack::pack::PackFile& pack)
 
 int ListBlock(openblack::pack::PackFile& pack, const std::string& name, const std::filesystem::path& outFilename)
 {
-	auto output_log_stream = stdout;
+	auto* output_log_stream = stdout;
 	if (outFilename == std::filesystem::path("stdout"))
 	{
 		output_log_stream = stderr;
 	}
 
-	auto& blocks = pack.GetBlocks();
+	const auto& blocks = pack.GetBlocks();
 
 	auto block = blocks.find(name);
 	if (block == blocks.end())
@@ -107,7 +107,7 @@ int ListBlock(openblack::pack::PackFile& pack, const std::string& name, const st
 
 int ViewBytes(openblack::pack::PackFile& pack, const std::string& name)
 {
-	auto& block = pack.GetBlock(name);
+	const auto& block = pack.GetBlock(name);
 
 	std::printf("file: %s, block %s\n", pack.GetFilename().c_str(), name.c_str());
 
@@ -148,11 +148,11 @@ int ViewBody(openblack::pack::PackFile& pack)
 
 int ViewTextures(openblack::pack::PackFile& pack)
 {
-	auto& textures = pack.GetTextures();
+	const auto& textures = pack.GetTextures();
 
 	std::printf("file: %s\n", pack.GetFilename().c_str());
 
-	for (auto& [name, texture] : textures)
+	for (const auto& [name, texture] : textures)
 	{
 		std::printf("%s: type %u, size %u\n", name.c_str(), texture.header.type, texture.header.size);
 	}
@@ -162,12 +162,12 @@ int ViewTextures(openblack::pack::PackFile& pack)
 
 int ViewMeshes(openblack::pack::PackFile& pack)
 {
-	auto& meshes = pack.GetMeshes();
+	const auto& meshes = pack.GetMeshes();
 
 	std::printf("file: %s\n", pack.GetFilename().c_str());
 
 	uint32_t i = 0;
-	for (auto& mesh : meshes)
+	for (const auto& mesh : meshes)
 	{
 		std::printf("mesh #%-5d size %u\n", i++, static_cast<uint32_t>(mesh.size()));
 	}
@@ -177,12 +177,12 @@ int ViewMeshes(openblack::pack::PackFile& pack)
 
 int ViewAnimations(openblack::pack::PackFile& pack)
 {
-	auto& animations = pack.GetAnimations();
+	const auto& animations = pack.GetAnimations();
 
 	std::printf("file: %s\n", pack.GetFilename().c_str());
 
 	uint32_t i = 0;
-	for (auto& animation : animations)
+	for (const auto& animation : animations)
 	{
 		std::printf("animation #%-5d %-32s size %u\n", i++, animation.data(), static_cast<uint32_t>(animation.size()));
 	}
@@ -192,7 +192,7 @@ int ViewAnimations(openblack::pack::PackFile& pack)
 
 int ViewTexture(openblack::pack::PackFile& pack, const std::string& name, const std::filesystem::path& outFilename)
 {
-	auto& texture = pack.GetTexture(name);
+	const auto& texture = pack.GetTexture(name);
 
 	std::printf("file: %s\n", pack.GetFilename().c_str());
 
@@ -247,7 +247,7 @@ int ViewMesh(openblack::pack::PackFile& pack, uint32_t index, const std::filesys
 		return EXIT_FAILURE;
 	}
 
-	auto& mesh = pack.GetMesh(index);
+	const auto& mesh = pack.GetMesh(index);
 
 	std::printf("file: %s\n", pack.GetFilename().c_str());
 	std::printf("mesh: %u bytes\n", static_cast<uint32_t>(mesh.size()));

--- a/components/ScriptLibrary/include/LHVM/LHVM.h
+++ b/components/ScriptLibrary/include/LHVM/LHVM.h
@@ -42,11 +42,11 @@ public:
 	[[nodiscard]] Version GetVersion() const { return _version; }
 
 private:
-	void loadVariables(std::FILE* file, std::vector<std::string>& variables);
-	void loadCode(std::FILE* file);
-	void loadAuto(std::FILE* file);
-	void loadScripts(std::FILE* file);
-	void loadData(std::FILE* file);
+	void LoadVariables(std::FILE* file, std::vector<std::string>& variables);
+	void LoadCode(std::FILE* file);
+	void LoadAuto(std::FILE* file);
+	void LoadScripts(std::FILE* file);
+	void LoadData(std::FILE* file);
 
 	Version _version;
 

--- a/components/ScriptLibrary/include/LHVM/VMScript.h
+++ b/components/ScriptLibrary/include/LHVM/VMScript.h
@@ -19,16 +19,16 @@ class VMScript
 {
 public:
 	VMScript() = delete;
-	VMScript(std::string name, std::string filename, uint32_t type, uint32_t var_offset, std::vector<std::string> variables,
-	         uint32_t instruction_address, uint32_t parameter_count, uint32_t script_id)
+	VMScript(std::string name, std::string filename, uint32_t type, uint32_t varOffset, std::vector<std::string> variables,
+	         uint32_t instructionAddress, uint32_t parameterCount, uint32_t scriptId)
 	    : _name(std::move(name))
 	    , _filename(std::move(filename))
 	    , _type(type)
 	    , _variables(std::move(variables))
-	    , _variables_offset(var_offset)
-	    , _instruction_address(instruction_address)
-	    , _parameter_count(parameter_count)
-	    , _script_id(script_id)
+	    , _variablesOffset(varOffset)
+	    , _instructionAddress(instructionAddress)
+	    , _parameterCount(parameterCount)
+	    , _scriptId(scriptId)
 	{
 	}
 	~VMScript() = default;
@@ -36,10 +36,10 @@ public:
 	[[nodiscard]] const std::string& GetName() const { return _name; }
 	[[nodiscard]] const std::string& GetFileName() const { return _filename; }
 	[[nodiscard]] const std::vector<std::string>& GetVariables() const { return _variables; }
-	[[nodiscard]] uint32_t GetVariableOffset() const { return _variables_offset; }
-	[[nodiscard]] uint32_t GetInstructionAddress() const { return _instruction_address; }
-	[[nodiscard]] uint32_t GetParameterCount() const { return _parameter_count; }
-	[[nodiscard]] uint32_t GetScriptID() const { return _script_id; }
+	[[nodiscard]] uint32_t GetVariableOffset() const { return _variablesOffset; }
+	[[nodiscard]] uint32_t GetInstructionAddress() const { return _instructionAddress; }
+	[[nodiscard]] uint32_t GetParameterCount() const { return _parameterCount; }
+	[[nodiscard]] uint32_t GetScriptID() const { return _scriptId; }
 
 private:
 	std::string _name;
@@ -47,10 +47,10 @@ private:
 	uint32_t _type;
 	std::vector<std::string> _variables;
 
-	uint32_t _variables_offset;
-	uint32_t _instruction_address;
-	uint32_t _parameter_count;
-	uint32_t _script_id;
+	uint32_t _variablesOffset;
+	uint32_t _instructionAddress;
+	uint32_t _parameterCount;
+	uint32_t _scriptId;
 };
 
 } // namespace openblack::LHVM

--- a/components/ScriptLibrary/src/LHVM.cpp
+++ b/components/ScriptLibrary/src/LHVM.cpp
@@ -40,11 +40,11 @@ void LHVM::LoadBinary(const std::string& filename)
 	if (count != 1 || _version != Version::BlackAndWhite)
 		throw std::runtime_error("unsupported LHVM version");
 
-	loadVariables(file, _variables);
-	loadCode(file);
-	loadAuto(file);
-	loadScripts(file);
-	loadData(file);
+	LoadVariables(file, _variables);
+	LoadCode(file);
+	LoadAuto(file);
+	LoadScripts(file);
+	LoadData(file);
 
 	// creature isle
 	if (_version == Version::CreatureIsle)
@@ -56,7 +56,7 @@ void LHVM::LoadBinary(const std::string& filename)
 	std::fclose(file);
 }
 
-void LHVM::loadVariables(std::FILE* file, std::vector<std::string>& variables)
+void LHVM::LoadVariables(std::FILE* file, std::vector<std::string>& variables)
 {
 	int32_t count;
 
@@ -85,7 +85,7 @@ void LHVM::loadVariables(std::FILE* file, std::vector<std::string>& variables)
 	}
 }
 
-void LHVM::loadCode(std::FILE* file)
+void LHVM::LoadCode(std::FILE* file)
 {
 	int32_t count;
 	if (std::fread(&count, sizeof(count), 1, file) != 1)
@@ -107,7 +107,7 @@ void LHVM::loadCode(std::FILE* file)
 	}
 }
 
-void LHVM::loadAuto(std::FILE* file)
+void LHVM::LoadAuto(std::FILE* file)
 {
 	int32_t count;
 	if (std::fread(&count, sizeof(count), 1, file) != 1)
@@ -123,7 +123,7 @@ void LHVM::loadAuto(std::FILE* file)
 		throw std::runtime_error("error reading ids");
 }
 
-void LHVM::loadScripts(std::FILE* file)
+void LHVM::LoadScripts(std::FILE* file)
 {
 	int32_t count;
 	if (std::fread(&count, sizeof(count), 1, file) != 1)
@@ -159,7 +159,7 @@ void LHVM::loadScripts(std::FILE* file)
 			throw std::runtime_error("error reading script variables offset");
 
 		std::vector<std::string> variables;
-		loadVariables(file, variables);
+		LoadVariables(file, variables);
 
 		uint32_t instruction_address, parameter_count, script_id;
 		if (std::fread(&instruction_address, sizeof(instruction_address), 1, file) != 1)
@@ -174,7 +174,7 @@ void LHVM::loadScripts(std::FILE* file)
 	}
 }
 
-void LHVM::loadData(std::FILE* file)
+void LHVM::LoadData(std::FILE* file)
 {
 	int32_t size;
 	if (std::fread(&size, sizeof(size), 1, file) != 1)

--- a/components/anm/include/ANMFile.h
+++ b/components/anm/include/ANMFile.h
@@ -20,19 +20,19 @@ namespace openblack::anm
 struct ANMHeader
 {
 	std::array<char, 0x20> name;
-	uint32_t unknown_0x20; // Seems to be a uint16_t padded
-	float unknown_0x24;
-	float unknown_0x28;
-	float unknown_0x2C;
-	float unknown_0x30;
-	float unknown_0x34;
-	uint32_t frame_count;
-	uint32_t unknown_0x3C; // Always 1 in Body Block, a count
-	uint32_t animation_duration;
-	uint32_t unknown_0x44; // Always 1 in Body Block
-	uint32_t unknown_0x48; // Always 0 in Body Block
-	uint32_t frames_base;
-	uint32_t unknown_0x50; // Seems to be a uint16_t padded
+	uint32_t unknown0x20; // Seems to be a uint16_t padded
+	float unknown0x24;
+	float unknown0x28;
+	float unknown0x2C;
+	float unknown0x30;
+	float unknown0x34;
+	uint32_t frameCount;
+	uint32_t unknown0x3C; // Always 1 in Body Block, a count
+	uint32_t animationDuration;
+	uint32_t unknown0x44; // Always 1 in Body Block
+	uint32_t unknown0x48; // Always 0 in Body Block
+	uint32_t framesBase;
+	uint32_t unknown0x50; // Seems to be a uint16_t padded
 };
 static_assert(sizeof(ANMHeader) == 0x54);
 

--- a/components/anm/src/ANMFile.cpp
+++ b/components/anm/src/ANMFile.cpp
@@ -127,10 +127,10 @@ void ANMFile::ReadFile(std::istream& stream)
 	// First 84 bytes
 	stream.read(reinterpret_cast<char*>(&_header), sizeof(ANMHeader));
 
-	_keyframes.resize(_header.frame_count);
-	for (uint32_t i = 0; i < _header.frame_count; ++i)
+	_keyframes.resize(_header.frameCount);
+	for (uint32_t i = 0; i < _header.frameCount; ++i)
 	{
-		stream.seekg(_header.frames_base + i * sizeof(uint32_t));
+		stream.seekg(_header.framesBase + i * sizeof(uint32_t));
 
 		// In Keyframe offset block
 		uint32_t offset;
@@ -146,12 +146,12 @@ void ANMFile::ReadFile(std::istream& stream)
 
 		// Bone block
 		stream.seekg(offset);
-		uint32_t bone_count;
-		stream.read(reinterpret_cast<char*>(&bone_count), sizeof(bone_count));
+		uint32_t boneCount;
+		stream.read(reinterpret_cast<char*>(&boneCount), sizeof(boneCount));
 
 		stream.read(reinterpret_cast<char*>(&_keyframes[i].time), sizeof(_keyframes[i].time));
 
-		_keyframes[i].bones.resize(bone_count);
+		_keyframes[i].bones.resize(boneCount);
 		stream.read(reinterpret_cast<char*>(_keyframes[i].bones.data()),
 		            _keyframes[i].bones.size() * sizeof(_keyframes[i].bones[0]));
 	}

--- a/components/l3d/include/L3DFile.h
+++ b/components/l3d/include/L3DFile.h
@@ -120,17 +120,17 @@ struct L3DTexture
 {
 	struct RGBA4
 	{
-		uint16_t B : 4;
-		uint16_t G : 4;
-		uint16_t R : 4;
-		uint16_t A : 4;
+		uint16_t b : 4;
+		uint16_t g : 4;
+		uint16_t r : 4;
+		uint16_t a : 4;
 	};
 	static_assert(sizeof(RGBA4) == sizeof(uint16_t));
 	uint32_t id;
-	static constexpr uint16_t width = 256;
-	static constexpr uint16_t height = 256;
-	std::array<RGBA4, width * height> texels;
-	static_assert(sizeof(texels) == width * height * sizeof(uint16_t));
+	static constexpr uint16_t k_Width = 256;
+	static constexpr uint16_t k_Height = 256;
+	std::array<RGBA4, k_Width * k_Height> texels;
+	static_assert(sizeof(texels) == k_Width * k_Height * sizeof(uint16_t));
 };
 static_assert(sizeof(L3DTexture) == sizeof(uint32_t) + 256 * 256 * sizeof(uint16_t));
 
@@ -229,7 +229,7 @@ static_assert(sizeof(L3DBlend) == 8);
 class L3DFile
 {
 protected:
-	static constexpr const std::array<char, 4> kMagic = {'L', '3', 'D', '0'};
+	static constexpr const std::array<char, 4> k_Magic = {'L', '3', 'D', '0'};
 
 	/// True when a file has been loaded
 	bool _isLoaded {false};

--- a/components/l3d/src/L3DFile.cpp
+++ b/components/l3d/src/L3DFile.cpp
@@ -217,7 +217,7 @@ void L3DFile::ReadFile(std::istream& stream)
 
 	// First 76 bytes
 	stream.read(reinterpret_cast<char*>(&_header), sizeof(L3DHeader));
-	if (_header.magic != kMagic)
+	if (_header.magic != k_Magic)
 	{
 		Fail("Unrecognized L3D header");
 	}
@@ -482,12 +482,12 @@ void L3DFile::ReadFile(std::istream& stream)
 	{
 		uint32_t primitiveStart = 0;
 		uint32_t boneStart = 0;
-		for (auto& _submeshHeader : _submeshHeaders)
+		for (auto& submeshHeader : _submeshHeaders)
 		{
-			add_span(_primitiveSpans, _primitiveHeaders, primitiveStart, _submeshHeader.numPrimitives);
-			add_span(_boneSpans, _bones, boneStart, _submeshHeader.numBones);
-			primitiveStart += _submeshHeader.numPrimitives;
-			boneStart += _submeshHeader.numBones;
+			add_span(_primitiveSpans, _primitiveHeaders, primitiveStart, submeshHeader.numPrimitives);
+			add_span(_boneSpans, _bones, boneStart, submeshHeader.numBones);
+			primitiveStart += submeshHeader.numPrimitives;
+			boneStart += submeshHeader.numBones;
 		}
 	}
 
@@ -664,7 +664,7 @@ void L3DFile::Write(const std::filesystem::path& filepath)
 	}
 
 	// Set magic number
-	_header.magic = kMagic;
+	_header.magic = k_Magic;
 	_header.submeshCount = static_cast<uint32_t>(_submeshHeaders.size());
 	_header.skinCount = static_cast<uint32_t>(_skins.size());
 	_header.extraDataCount = static_cast<uint32_t>(_extraPoints.size());

--- a/components/l3d/src/L3DFile.cpp
+++ b/components/l3d/src/L3DFile.cpp
@@ -550,7 +550,7 @@ void L3DFile::WriteFile(std::ostream& stream) const
 		skinOffsetsBase += sizeof(_skins[0]);
 	}
 	uint32_t totalPrimitives = 0;
-	for (auto& header : _submeshHeaders)
+	for (const auto& header : _submeshHeaders)
 	{
 		totalPrimitives += header.numPrimitives;
 	}
@@ -701,9 +701,9 @@ void L3DFile::Write(const std::filesystem::path& filepath)
 	for (size_t i = 0; i < _primitiveHeaders.size(); ++i)
 	{
 		_primitiveHeaders[i].verticesOffset =
-		    _vertexSpans[i].size() > 0 ? static_cast<uint32_t>(vertexBase) : std::numeric_limits<uint32_t>::max();
+		    !_vertexSpans[i].empty() ? static_cast<uint32_t>(vertexBase) : std::numeric_limits<uint32_t>::max();
 		_primitiveHeaders[i].trianglesOffset =
-		    _indexSpans[i].size() > 0 ? static_cast<uint32_t>(triangleBase) : std::numeric_limits<uint32_t>::max();
+		    !_indexSpans[i].empty() ? static_cast<uint32_t>(triangleBase) : std::numeric_limits<uint32_t>::max();
 		_primitiveHeaders[i].groupsOffset = std::numeric_limits<uint32_t>::max();       // TODO boneVertLUTBase;
 		_primitiveHeaders[i].vertexBlendsOffset = std::numeric_limits<uint32_t>::max(); // TODO vertexBlendsBase;
 		vertexBase += _vertexSpans[i].size() * sizeof(_vertices[0]);
@@ -716,8 +716,8 @@ void L3DFile::Write(const std::filesystem::path& filepath)
 	{
 		// TODO Set flags
 		header.primitivesOffset =
-		    header.numPrimitives ? static_cast<uint32_t>(primitiveOffsetBase) : std::numeric_limits<uint32_t>::max();
-		header.bonesOffset = header.numBones ? static_cast<uint32_t>(boneBase) : std::numeric_limits<uint32_t>::max();
+		    header.numPrimitives != 0u ? static_cast<uint32_t>(primitiveOffsetBase) : std::numeric_limits<uint32_t>::max();
+		header.bonesOffset = header.numBones != 0u ? static_cast<uint32_t>(boneBase) : std::numeric_limits<uint32_t>::max();
 		primitiveBase += header.numPrimitives * sizeof(L3DPrimitiveHeader);
 		boneBase += header.numBones * sizeof(L3DBone);
 	}
@@ -733,7 +733,7 @@ void L3DFile::AddSubmesh(const L3DSubmeshHeader& header) noexcept
 void L3DFile::AddPrimitives(const std::vector<L3DPrimitiveHeader>& headers) noexcept
 {
 	auto size = _primitiveHeaders.size();
-	for (auto& header : headers)
+	for (const auto& header : headers)
 	{
 		_primitiveHeaders.push_back(header);
 	}
@@ -743,7 +743,7 @@ void L3DFile::AddPrimitives(const std::vector<L3DPrimitiveHeader>& headers) noex
 void L3DFile::AddVertices(const std::vector<L3DVertex>& vertices) noexcept
 {
 	auto size = _vertices.size();
-	for (auto& vertex : vertices)
+	for (const auto& vertex : vertices)
 	{
 		_vertices.push_back(vertex);
 	}
@@ -753,7 +753,7 @@ void L3DFile::AddVertices(const std::vector<L3DVertex>& vertices) noexcept
 void L3DFile::AddIndices(const std::vector<uint16_t>& indices) noexcept
 {
 	auto size = _indices.size();
-	for (auto& index : indices)
+	for (const auto& index : indices)
 	{
 		_indices.push_back(index);
 	}
@@ -763,7 +763,7 @@ void L3DFile::AddIndices(const std::vector<uint16_t>& indices) noexcept
 void L3DFile::AddBones(const std::vector<L3DBone>& bones) noexcept
 {
 	auto size = _boneSpans.size();
-	for (auto& bone : bones)
+	for (const auto& bone : bones)
 	{
 		_bones.push_back(bone);
 	}

--- a/components/lnd/include/LNDFile.h
+++ b/components/lnd/include/LNDFile.h
@@ -96,10 +96,10 @@ struct LNDBlock
 	uint32_t nextSortingPtr;
 	float valueSorting;
 	float lowResTexture;
-	float fu_lrs; ///< (iu_lrs / 256)
-	float fv_lrs; ///< (iv_lrs / 256)
-	float iu_lrs; ///< lowrestex x
-	float iv_lrs; ///< lowrestex z
+	float fuLrs; ///< (iuLrs / 256)
+	float fvLrs; ///< (ivLrs / 256)
+	float iuLrs; ///< lowrestex x
+	float ivLrs; ///< lowrestex z
 	uint32_t smallTextUpdated;
 };
 static_assert(sizeof(LNDBlock) == 2520);
@@ -122,26 +122,26 @@ struct LNDMaterial
 {
 	struct R5G5B5A1
 	{
-		uint16_t B : 5;
-		uint16_t G : 5;
-		uint16_t R : 5;
-		uint16_t A : 1;
+		uint16_t b : 5;
+		uint16_t g : 5;
+		uint16_t r : 5;
+		uint16_t a : 1;
 	};
 	static_assert(sizeof(R5G5B5A1) == sizeof(uint16_t));
-	static constexpr uint16_t width = 256;
-	static constexpr uint16_t height = 256;
+	static constexpr uint16_t k_Width = 256;
+	static constexpr uint16_t k_Height = 256;
 
 	uint16_t type; ///< Terrain Type
-	std::array<R5G5B5A1, width * height> texels;
+	std::array<R5G5B5A1, k_Width * k_Height> texels;
 };
 static_assert(sizeof(LNDMaterial) == 0x20002);
 
 struct LNDBumpMap
 {
-	static constexpr uint16_t width = 256;
-	static constexpr uint16_t height = 256;
+	static constexpr uint16_t k_Width = 256;
+	static constexpr uint16_t k_Height = 256;
 
-	std::array<uint8_t, width * height> texels; ///< R8
+	std::array<uint8_t, k_Width * k_Height> texels; ///< R8
 };
 static_assert(sizeof(LNDBumpMap) == 0x10000);
 

--- a/components/lnd/src/LNDFile.cpp
+++ b/components/lnd/src/LNDFile.cpp
@@ -216,7 +216,7 @@ void LNDFile::WriteFile(std::ostream& stream) const
 	stream.write(reinterpret_cast<const char*>(&_header), sizeof(LNDHeader));
 
 	// Write low resolution textures
-	for (auto& texture : _lowResolutionTextures)
+	for (const auto& texture : _lowResolutionTextures)
 	{
 		stream.write(reinterpret_cast<const char*>(&texture.header), sizeof(texture.header));
 		stream.write(reinterpret_cast<const char*>(texture.texels.data()), texture.texels.size() * sizeof(texture.texels[0]));

--- a/components/morph/include/MorphFile.h
+++ b/components/morph/include/MorphFile.h
@@ -19,77 +19,77 @@ namespace openblack::morph
 
 struct MorphHeader
 {
-	uint32_t unknown_0x0; // TODO: is 0 for hands and 21 for creatures
-	uint32_t spec_file_version;
-	uint32_t binary_version;
-	std::array<char, 0x20> base_mesh_name;
-	std::array<std::array<char, 0x20>, 6> variant_mesh_names;
+	uint32_t unknown0x0; // TODO: is 0 for hands and 21 for creatures
+	uint32_t specFileVersion;
+	uint32_t binaryVersion;
+	std::array<char, 0x20> baseMeshName;
+	std::array<std::array<char, 0x20>, 6> variantMeshNames;
 };
 static_assert(sizeof(MorphHeader) == 0xec);
 
 struct AnimationHeader
 {
-	uint32_t unknown_0x0; // TODO: possibly duration or offset
-	uint32_t unknown_0x4; // TODO: either 0 or 1. Seem to be 1 when type C and 0 when not
-	float unknown_0x8;    // TODO:
-	float unknown_0xc;    // TODO:
-	float unknown_0x10;   // TODO:
-	float unknown_0x14;   // TODO:
-	float unknown_0x18;   // TODO:
-	uint32_t frame_count;
-	uint32_t mesh_bone_count;
-	uint32_t rotated_joint_count;
-	uint32_t translated_joint_count;
+	uint32_t unknown0x0; // TODO: possibly duration or offset
+	uint32_t unknown0x4; // TODO: either 0 or 1. Seem to be 1 when type C and 0 when not
+	float unknown0x8;    // TODO:
+	float unknown0xc;    // TODO:
+	float unknown0x10;   // TODO:
+	float unknown0x14;   // TODO:
+	float unknown0x18;   // TODO:
+	uint32_t frameCount;
+	uint32_t meshBoneCount;
+	uint32_t rotatedJointCount;
+	uint32_t translatedJointCount;
 };
 static_assert(sizeof(AnimationHeader) == 0x2c);
 
 struct HairHeader
 {
-	uint32_t unknown_0x0; // TODO:
-	uint32_t hair_group_count;
+	uint32_t unknown0x0; // TODO:
+	uint32_t hairGroupCount;
 };
 static_assert(sizeof(HairHeader) == 0x8);
 
 /// TODO: Function unknown
 struct HairGroupHeaderMember
 {
-	uint32_t unknown_0x0; // TODO
-	uint32_t unknown_0x4; // TODO
-	uint32_t unknown_0x8; // TODO
-	float unknown_0xc;    // TODO
-	float unknown_0x10;   // TODO
-	float unknown_0x14;   // TODO
-	float unknown_0x18;   // TODO
+	uint32_t unknown0x0; // TODO
+	uint32_t unknown0x4; // TODO
+	uint32_t unknown0x8; // TODO
+	float unknown0xc;    // TODO
+	float unknown0x10;   // TODO
+	float unknown0x14;   // TODO
+	float unknown0x18;   // TODO
 };
 static_assert(sizeof(HairGroupHeaderMember) == 0x1c);
 
 struct HairGroupHeader
 {
-	uint32_t unknown_0x0; // TODO
-	uint32_t hair_count;
-	uint32_t unknown_0x8; // TODO: some count
-	uint32_t unknown_0xc; // TODO
-	std::array<HairGroupHeaderMember, 3> unknown_0x10;
+	uint32_t unknown0x0; // TODO
+	uint32_t hairCount;
+	uint32_t unknown0x8; // TODO: some count
+	uint32_t unknown0xc; // TODO
+	std::array<HairGroupHeaderMember, 3> unknown0x10;
 };
 static_assert(sizeof(HairGroupHeader) == 0x64);
 
 struct HairIntersection
 {
-	uint32_t unknown_0x0;  // TODO
-	uint32_t unknown_0x4;  // TODO
-	uint32_t unknown_0x8;  // TODO
-	uint32_t unknown_0xc;  // TODO
-	uint32_t unknown_0x10; // TODO
-	uint32_t unknown_0x14; // TODO
-	uint32_t unknown_0x18; // TODO
-	float unknown_0x1c;    // TODO
-	float unknown_0x20;    // TODO
+	uint32_t unknown0x0;  // TODO
+	uint32_t unknown0x4;  // TODO
+	uint32_t unknown0x8;  // TODO
+	uint32_t unknown0xc;  // TODO
+	uint32_t unknown0x10; // TODO
+	uint32_t unknown0x14; // TODO
+	uint32_t unknown0x18; // TODO
+	float unknown0x1c;    // TODO
+	float unknown0x20;    // TODO
 };
 static_assert(sizeof(HairIntersection) == 0x24);
 
 struct Hair
 {
-	uint32_t unknown_0x0;          // TODO
+	uint32_t unknown0x0;           // TODO
 	HairIntersection intersection; // TODO
 	std::array<float, 3> xs;
 	std::array<float, 3> ys;
@@ -99,10 +99,10 @@ static_assert(sizeof(Hair) == 0x4c);
 
 struct ExtraData
 {
-	uint32_t unknown_0x0; // TODO
-	uint32_t unknown_0x4; // TODO
-	uint32_t unknown_0x8; // TODO
-	uint32_t unknown_0xc; // TODO
+	uint32_t unknown0x0; // TODO
+	uint32_t unknown0x4; // TODO
+	uint32_t unknown0x8; // TODO
+	uint32_t unknown0xc; // TODO
 };
 static_assert(sizeof(ExtraData) == 0x10);
 
@@ -127,20 +127,20 @@ struct AnimationSpecs
 {
 	std::filesystem::path path;
 	uint32_t version;
-	std::vector<AnimationSetDesc> animation_sets;
+	std::vector<AnimationSetDesc> animationSets;
 };
 
 struct AnimationFrame
 {
-	std::vector<std::array<float, 3>> euler_angles;
+	std::vector<std::array<float, 3>> eulerAngles;
 	std::vector<std::array<float, 3>> translations;
 };
 
 struct Animation
 {
 	AnimationHeader header;
-	std::vector<uint32_t> rotated_joint_indices;
-	std::vector<uint32_t> translated_joint_indices;
+	std::vector<uint32_t> rotatedJointIndices;
+	std::vector<uint32_t> translatedJointIndices;
 	std::vector<AnimationFrame> keyframes;
 };
 
@@ -162,19 +162,19 @@ protected:
 	std::filesystem::path _filename;
 
 	MorphHeader _header;
-	AnimationSpecs _animation_specs;
-	std::vector<Animation> _base_animation;
-	std::array<std::vector<Animation>, 4> _variant_animations; // last 2 mesh variants don't have animations
-	HairHeader _hair_header;
-	std::vector<HairGroup> _hair_groups;
-	std::vector<std::vector<ExtraData>> _extra_data; ///< related to \ref _base_animation
+	AnimationSpecs _animationSpecs;
+	std::vector<Animation> _baseAnimation;
+	std::array<std::vector<Animation>, 4> _variantAnimations; // last 2 mesh variants don't have animations
+	HairHeader _hairHeader;
+	std::vector<HairGroup> _hairGroups;
+	std::vector<std::vector<ExtraData>> _extraData; ///< related to \ref _base_animation
 
 	/// Error handling
 	void Fail(const std::string& msg);
 
 	/// Read file from the input source
-	virtual void ReadFile(std::istream& stream, const std::filesystem::path& specs_directory);
-	void ReadSpecFile(const std::filesystem::path& spec_file_path);
+	virtual void ReadFile(std::istream& stream, const std::filesystem::path& specsDirectory);
+	void ReadSpecFile(const std::filesystem::path& specFilePath);
 	std::vector<Animation> ReadAnimations(std::istream& stream, const std::vector<uint32_t>& offsets);
 	HairGroup ReadHairGroup(std::istream& stream);
 
@@ -183,21 +183,21 @@ public:
 	virtual ~MorphFile();
 
 	/// Read morph file from the filesystem
-	void Open(const std::filesystem::path& filepath, const std::filesystem::path& specs_directory);
+	void Open(const std::filesystem::path& filepath, const std::filesystem::path& specsDirectory);
 
 	/// Read morph file from a buffer
-	void Open(const std::vector<uint8_t>& buffer, const std::filesystem::path& specs_directory);
+	void Open(const std::vector<uint8_t>& buffer, const std::filesystem::path& specsDirectory);
 
 	[[nodiscard]] std::string GetFilename() const { return _filename.string(); }
 	[[nodiscard]] const MorphHeader& GetHeader() const { return _header; }
-	[[nodiscard]] const AnimationSpecs& GetAnimationSpecs() const { return _animation_specs; }
-	[[nodiscard]] const std::vector<Animation>& GetBaseAnimationSet() const { return _base_animation; }
+	[[nodiscard]] const AnimationSpecs& GetAnimationSpecs() const { return _animationSpecs; }
+	[[nodiscard]] const std::vector<Animation>& GetBaseAnimationSet() const { return _baseAnimation; }
 	[[nodiscard]] const std::vector<Animation>& GetVariantAnimationSet(uint32_t index) const
 	{
-		return _variant_animations.at(index);
+		return _variantAnimations.at(index);
 	}
-	[[nodiscard]] const std::vector<HairGroup>& GetHairGroups() const { return _hair_groups; }
-	[[nodiscard]] const std::vector<std::vector<ExtraData>>& GetExtraData() const { return _extra_data; }
+	[[nodiscard]] const std::vector<HairGroup>& GetHairGroups() const { return _hairGroups; }
+	[[nodiscard]] const std::vector<std::vector<ExtraData>>& GetExtraData() const { return _extraData; }
 };
 
 } // namespace openblack::morph

--- a/components/morph/src/MorphFile.cpp
+++ b/components/morph/src/MorphFile.cpp
@@ -153,12 +153,16 @@ std::istream& safe_getline(std::istream& is, std::string& t)
 			return is;
 		case '\r':
 			if (sb->sgetc() == '\n')
+			{
 				sb->sbumpc();
+			}
 			return is;
 		case std::streambuf::traits_type::eof():
 			// Also handle the case when the last line has no line ending
 			if (t.empty())
+			{
 				is.setstate(std::ios::eofbit);
+			}
 			return is;
 		default:
 			t += static_cast<char>(c);
@@ -303,7 +307,7 @@ void MorphFile::ReadFile(std::istream& stream, const std::filesystem::path& spec
 	std::string spec_name;
 	// this field is a good guess for hand or not, but a better choice might be
 	// getting the segment name from pack
-	if (_header.unknown_0x0)
+	if (_header.unknown_0x0 != 0u)
 	{
 		spec_name = "ctrspec" + std::to_string(_header.spec_file_version) + ".txt";
 	}
@@ -365,7 +369,7 @@ void MorphFile::ReadFile(std::istream& stream, const std::filesystem::path& spec
 			continue;
 		}
 		uint32_t has_data; // TODO: unknown if this serves another function
-		while (stream.read(reinterpret_cast<char*>(&has_data), sizeof(has_data)).good() && has_data)
+		while (stream.read(reinterpret_cast<char*>(&has_data), sizeof(has_data)).good() && has_data != 0u)
 		{
 			auto& data = _extra_data[i].emplace_back();
 			stream.read(reinterpret_cast<char*>(&data), sizeof(data));

--- a/components/pack/include/PackFile.h
+++ b/components/pack/include/PackFile.h
@@ -92,7 +92,7 @@ struct G3DTexture
 class PackFile
 {
 protected:
-	static constexpr const std::array<char, 8> kMagic = {'L', 'i', 'O', 'n', 'H', 'e', 'A', 'd'};
+	static constexpr const std::array<char, 8> k_Magic = {'L', 'i', 'O', 'n', 'H', 'e', 'A', 'd'};
 
 	/// True when a file has been loaded
 	bool _isLoaded {false};

--- a/components/pack/include/PackFile.h
+++ b/components/pack/include/PackFile.h
@@ -160,7 +160,7 @@ public:
 
 	[[nodiscard]] std::string GetFilename() const { return _filename.string(); }
 	[[nodiscard]] const std::map<std::string, std::vector<uint8_t>>& GetBlocks() const { return _blocks; }
-	[[nodiscard]] bool HasBlock(const std::string& name) const { return _blocks.count(name); }
+	[[nodiscard]] bool HasBlock(const std::string& name) const { return _blocks.count(name) != 0u; }
 	[[nodiscard]] const std::vector<uint8_t>& GetBlock(const std::string& name) const { return _blocks.at(name); }
 	[[nodiscard]] std::unique_ptr<std::istream> GetBlockAsStream(const std::string& name) const;
 	[[nodiscard]] const std::vector<InfoBlockLookup>& GetInfoBlockLookup() const { return _infoBlockLookup; }

--- a/components/pack/src/PackFile.cpp
+++ b/components/pack/src/PackFile.cpp
@@ -385,7 +385,7 @@ void PackFile::WriteBlocks(std::ostream& stream) const
 
 	PackBlockHeader header;
 
-	for (auto& [name, contents] : _blocks)
+	for (const auto& [name, contents] : _blocks)
 	{
 		std::snprintf(header.blockName.data(), header.blockName.size(), "%s", name.c_str());
 		header.blockSize = static_cast<uint32_t>(contents.size() * sizeof(contents[0]));
@@ -434,7 +434,7 @@ void PackFile::CreateMeshBlock()
 	contents.resize(offset + sizeof(uint32_t) * meshCount);
 	if (meshCount > 0)
 	{
-		auto meshOffsets = reinterpret_cast<uint32_t*>(&contents[offset]);
+		auto* meshOffsets = reinterpret_cast<uint32_t*>(&contents[offset]);
 		offset += sizeof(uint32_t) * meshCount;
 		for (size_t i = 0; i < _meshes.size(); ++i)
 		{
@@ -525,6 +525,6 @@ void PackFile::Write(const std::filesystem::path& file)
 
 std::unique_ptr<std::istream> PackFile::GetBlockAsStream(const std::string& name) const
 {
-	auto& data = GetBlock(name);
+	const auto& data = GetBlock(name);
 	return std::make_unique<imemstream>(reinterpret_cast<const char*>(data.data()), data.size());
 }

--- a/components/pack/src/PackFile.cpp
+++ b/components/pack/src/PackFile.cpp
@@ -132,13 +132,13 @@ struct imemstream: virtual membuf, public std::istream
 
 struct PackBlockHeader
 {
-	static constexpr uint32_t blockNameSize = 0x20;
-	std::array<char, blockNameSize> blockName;
+	static constexpr uint32_t k_BlockNameSize = 0x20;
+	std::array<char, k_BlockNameSize> blockName;
 	uint32_t blockSize;
 };
 
 /// Magic Key Jean-Claude Cottier
-constexpr const std::array<char, 4> kBlockMagic = {'M', 'K', 'J', 'C'};
+constexpr const std::array<char, 4> k_BlockMagic = {'M', 'K', 'J', 'C'};
 } // namespace
 
 /// Error handling
@@ -166,7 +166,7 @@ void PackFile::ReadBlocks()
 		input.seekg(0);
 	}
 
-	std::array<char, kMagic.size()> magic;
+	std::array<char, k_Magic.size()> magic;
 	if (fsize < magic.size() + sizeof(PackBlockHeader))
 	{
 		Fail("File too small to be a valid Pack file.");
@@ -174,7 +174,7 @@ void PackFile::ReadBlocks()
 
 	// First 8 bytes
 	input.read(magic.data(), magic.size());
-	if (std::memcmp(magic.data(), kMagic.data(), magic.size()) != 0)
+	if (std::memcmp(magic.data(), k_Magic.data(), magic.size()) != 0)
 	{
 		Fail("Unrecognized Pack header");
 	}
@@ -233,9 +233,9 @@ void PackFile::ResolveBodyBlock()
 	imemstream stream(reinterpret_cast<const char*>(data.data()), data.size());
 
 	// Greetings Jean-Claude Cottier
-	std::array<char, kBlockMagic.size()> magic;
+	std::array<char, k_BlockMagic.size()> magic;
 	stream.read(magic.data(), magic.size());
-	if (std::memcmp(magic.data(), kBlockMagic.data(), magic.size()) != 0)
+	if (std::memcmp(magic.data(), k_BlockMagic.data(), magic.size()) != 0)
 	{
 		Fail("Unrecognized Body Block header");
 	}
@@ -355,9 +355,9 @@ void PackFile::ResolveMeshBlock()
 
 	imemstream stream(reinterpret_cast<const char*>(data.data()), data.size());
 	// Greetings Jean-Claude Cottier
-	std::array<char, kBlockMagic.size()> magic;
+	std::array<char, k_BlockMagic.size()> magic;
 	stream.read(magic.data(), magic.size());
-	if (std::memcmp(magic.data(), kBlockMagic.data(), magic.size()) != 0)
+	if (std::memcmp(magic.data(), k_BlockMagic.data(), magic.size()) != 0)
 	{
 		Fail("Unrecognized Mesh Block header");
 	}
@@ -381,7 +381,7 @@ void PackFile::WriteBlocks(std::ostream& stream) const
 	assert(!_isLoaded);
 
 	// Magic number
-	stream.write(kMagic.data(), kMagic.size());
+	stream.write(k_Magic.data(), k_Magic.size());
 
 	PackBlockHeader header;
 
@@ -424,10 +424,10 @@ void PackFile::CreateMeshBlock()
 	std::vector<uint8_t> contents;
 
 	auto meshCount = static_cast<uint32_t>(_meshes.size());
-	contents.resize(kBlockMagic.size() + sizeof(meshCount));
+	contents.resize(k_BlockMagic.size() + sizeof(meshCount));
 
-	std::memcpy(contents.data() + offset, kBlockMagic.data(), kBlockMagic.size());
-	offset += kBlockMagic.size();
+	std::memcpy(contents.data() + offset, k_BlockMagic.data(), k_BlockMagic.size());
+	offset += k_BlockMagic.size();
 	std::memcpy(contents.data() + offset, &meshCount, sizeof(meshCount));
 	offset += sizeof(meshCount);
 

--- a/src/3D/AllMeshes.cpp
+++ b/src/3D/AllMeshes.cpp
@@ -12,7 +12,7 @@
 namespace openblack
 {
 
-std::array<std::string, static_cast<uint16_t>(MeshId::_COUNT)> MeshNames = {
+const std::array<std::string, static_cast<uint16_t>(MeshId::_COUNT)> k_MeshNames = {
     "Dummy",
     "AnimalBat1",
     "AnimalBat2",

--- a/src/3D/AllMeshes.h
+++ b/src/3D/AllMeshes.h
@@ -655,7 +655,7 @@ enum class MeshId : uint32_t
 };
 
 // just generated, mainly for debug
-extern std::array<std::string, static_cast<uint32_t>(MeshId::_COUNT)> MeshNames;
+extern const std::array<std::string, static_cast<uint32_t>(MeshId::_COUNT)> k_MeshNames;
 
 enum class AnimId : int
 {

--- a/src/3D/Camera.cpp
+++ b/src/3D/Camera.cpp
@@ -73,13 +73,13 @@ std::optional<ecs::components::Transform> Camera::RaycastMouseToLand()
 	float intersectDistance = 0.0f;
 	int sWidth;
 	int sHeight;
-	Game::instance()->GetWindow()->GetSize(sWidth, sHeight);
+	Game::Instance()->GetWindow()->GetSize(sWidth, sHeight);
 	glm::vec3 rayOrigin;
 	glm::vec3 rayDirection;
 	glm::ivec2 mouseVec;
 	SDL_GetMouseState(&mouseVec.x, &mouseVec.y);
 	DeprojectScreenToWorld(mouseVec, glm::vec2(sWidth, sHeight), rayOrigin, rayDirection);
-	const auto& dynamicsSystem = Game::instance()->GetDynamicsSystem();
+	const auto& dynamicsSystem = Game::Instance()->GetDynamicsSystem();
 	if (auto hit = dynamicsSystem.RayCastClosestHit(rayOrigin, rayDirection, 1e10f))
 	{
 		intersectionTransform = hit->first;
@@ -163,8 +163,8 @@ std::unique_ptr<Camera> Camera::Reflect(const glm::vec4& relectionPlane) const
 	return reflectionCamera;
 }
 
-void Camera::DeprojectScreenToWorld(glm::ivec2 screenPosition, glm::ivec2 screenSize, glm::vec3& out_worldOrigin,
-                                    glm::vec3& out_worldDirection)
+void Camera::DeprojectScreenToWorld(glm::ivec2 screenPosition, glm::ivec2 screenSize, glm::vec3& outWorldOrigin,
+                                    glm::vec3& outWorldDirection)
 {
 	const float normalizedX = static_cast<float>(screenPosition.x) / static_cast<float>(screenSize.x);
 	const float normalizedY = static_cast<float>(screenPosition.y) / static_cast<float>(screenSize.y);
@@ -203,23 +203,23 @@ void Camera::DeprojectScreenToWorld(glm::ivec2 screenPosition, glm::ivec2 screen
 	const glm::vec3 rayDirWorldSpace = glm::normalize(rayEndWorldSpace - rayStartWorldSpace);
 
 	// finally, store the results in the outputs
-	out_worldOrigin = rayStartWorldSpace;
-	out_worldDirection = rayDirWorldSpace;
+	outWorldOrigin = rayStartWorldSpace;
+	outWorldDirection = rayDirWorldSpace;
 }
 
-bool Camera::ProjectWorldToScreen(glm::vec3 worldPosition, glm::vec4 viewport, glm::vec3& out_screenPosition) const
+bool Camera::ProjectWorldToScreen(glm::vec3 worldPosition, glm::vec4 viewport, glm::vec3& outScreenPosition) const
 {
-	out_screenPosition = glm::project(worldPosition, GetViewMatrix(), GetProjectionMatrix(), viewport);
-	if (out_screenPosition.x < viewport.x || out_screenPosition.y < viewport.y || out_screenPosition.x > viewport.z ||
-	    out_screenPosition.y > viewport.w)
+	outScreenPosition = glm::project(worldPosition, GetViewMatrix(), GetProjectionMatrix(), viewport);
+	if (outScreenPosition.x < viewport.x || outScreenPosition.y < viewport.y || outScreenPosition.x > viewport.z ||
+	    outScreenPosition.y > viewport.w)
 	{
 		return false; // Outside viewport bounds
 	}
-	if (out_screenPosition.z > 1.0f)
+	if (outScreenPosition.z > 1.0f)
 	{
 		return false; // Behind Camera
 	}
-	if (out_screenPosition.z < 0.0f)
+	if (outScreenPosition.z < 0.0f)
 	{
 		return false; // Clipped
 	}
@@ -232,20 +232,20 @@ void Camera::ProcessSDLEvent(const SDL_Event& e)
 	{
 	case SDL_KEYDOWN:
 	case SDL_KEYUP:
-		handleKeyboardInput(e);
+		HandleKeyboardInput(e);
 		break;
 	case SDL_MOUSEMOTION:
 	case SDL_MOUSEBUTTONDOWN:
 	case SDL_MOUSEBUTTONUP:
 	case SDL_MOUSEWHEEL:
-		handleMouseInput(e);
+		HandleMouseInput(e);
 		break;
 	default:
 		break;
 	}
 }
 
-void Camera::handleKeyboardInput(const SDL_Event& e)
+void Camera::HandleKeyboardInput(const SDL_Event& e)
 {
 	if (e.key.repeat > 0) // ignore all repeated keys
 	{
@@ -378,7 +378,7 @@ void Camera::handleKeyboardInput(const SDL_Event& e)
 	}
 }
 
-void Camera::handleMouseInput(const SDL_Event& e)
+void Camera::HandleMouseInput(const SDL_Event& e)
 {
 	if (e.type == SDL_MOUSEMOTION && (e.motion.state & SDL_BUTTON(SDL_BUTTON_MIDDLE)) != 0u)
 	{
@@ -391,8 +391,8 @@ void Camera::handleMouseInput(const SDL_Event& e)
 		}
 		else // Holding down the middle mouse button without shift enables hand orbit camera rotation.
 		{
-			auto& entityReg = Game::instance()->GetEntityRegistry();
-			auto handEntity = Game::instance()->GetHand();
+			auto& entityReg = Game::Instance()->GetEntityRegistry();
+			auto handEntity = Game::Instance()->GetHand();
 			auto& handTransform = entityReg.Get<ecs::components::Transform>(handEntity);
 			auto handPos = handTransform.position;
 
@@ -403,7 +403,7 @@ void Camera::handleMouseInput(const SDL_Event& e)
 			}
 			int width;
 			int height;
-			Game::instance()->GetWindow()->GetSize(width, height);
+			Game::Instance()->GetWindow()->GetSize(width, height);
 			float yaw = e.motion.xrel * (glm::two_pi<float>() / width);
 			float pitch = e.motion.yrel * (glm::pi<float>() / height);
 
@@ -466,7 +466,7 @@ void Camera::handleMouseInput(const SDL_Event& e)
 		if (e.wheel.y != 0) // scroll up or down
 		{
 			float dist = 9999.0f;
-			const auto& dynamicsSystem = Game::instance()->GetDynamicsSystem();
+			const auto& dynamicsSystem = Game::Instance()->GetDynamicsSystem();
 			if (auto hit = dynamicsSystem.RayCastClosestHit(_position, GetForward(), 1e10f))
 			{
 				dist = glm::length(hit->first.position - _position);
@@ -552,12 +552,12 @@ void Camera::Update(std::chrono::microseconds dt)
 	float worldHandDist = 0.0f;
 	int sWidth;
 	int sHeight;
-	Game::instance()->GetWindow()->GetSize(sWidth, sHeight);
+	Game::Instance()->GetWindow()->GetSize(sWidth, sHeight);
 	if (_lmouseIsDown) // drag camera using hand
 	{
 		// get hand transform and project to screen coords
-		auto& entityReg = Game::instance()->GetEntityRegistry();
-		auto handEntity = Game::instance()->GetHand();
+		auto& entityReg = Game::Instance()->GetEntityRegistry();
+		auto handEntity = Game::Instance()->GetHand();
 		auto& handTransform = entityReg.Get<ecs::components::Transform>(handEntity);
 		const glm::vec3 handOffset(0, 1.5f, 0);
 		auto handPos = handTransform.position;
@@ -643,7 +643,7 @@ void Camera::Update(std::chrono::microseconds dt)
 		_position = glm::hermite(_flyFromPos, _flyFromTan, _flyToPos, _flyToTan, glm::smoothstep(0.0f, 1.0f, _flyProgress));
 
 		// check if there obstacles in the way, if there are fly over them
-		const auto& dynamicsSystem = Game::instance()->GetDynamicsSystem();
+		const auto& dynamicsSystem = Game::Instance()->GetDynamicsSystem();
 		if (auto obst = dynamicsSystem.RayCastClosestHit(_position - glm::vec3(0.0f, 20.0f, 0.0f),
 		                                                 glm::normalize((_flyToPos - glm::vec3(0.0f, 20.0f, 0.0f)) - _position),
 		                                                 glm::length(_flyToPos - _position) + 10.0f))
@@ -694,7 +694,7 @@ void Camera::Update(std::chrono::microseconds dt)
 		_hVelocity *= _handDragMult;
 		_position += rotation * (_velocity + _hVelocity) * fdt;
 	}
-	const auto& land = Game::instance()->GetLandIsland();
+	const auto& land = Game::Instance()->GetLandIsland();
 	auto height = land.GetHeightAt(glm::vec2(_position.x + 5, _position.z + 5));
 	_position.y =
 	    (_position.y < height + 13.0f) ? height + 13.0f : _position.y; // stop the camera from going below ground level.
@@ -716,7 +716,7 @@ glm::mat4 ReflectionCamera::GetViewMatrix() const
 
 	// M''camera = Mreflection * Mcamera * Mflip
 	glm::mat4x4 reflectionMatrix;
-	reflectMatrix(reflectionMatrix, _reflectionPlane);
+	ReflectMatrix(reflectionMatrix, _reflectionPlane);
 
 	return mView * reflectionMatrix;
 }
@@ -727,7 +727,7 @@ Mreflection = |  -2NxNy 1-2Ny2   -2NyNz  -2NyD |
               |  -2NxNz  -2NyNz 1-2Nz2   -2NzD |
               |    0       0       0       1   |
 */
-void ReflectionCamera::reflectMatrix(glm::mat4x4& m, const glm::vec4& plane) const
+void ReflectionCamera::ReflectMatrix(glm::mat4x4& m, const glm::vec4& plane) const
 {
 	m[0][0] = (1.0f - 2.0f * plane[0] * plane[0]);
 	m[1][0] = (-2.0f * plane[0] * plane[1]);

--- a/src/3D/Camera.h
+++ b/src/3D/Camera.h
@@ -62,15 +62,15 @@ public:
 
 	[[nodiscard]] std::unique_ptr<Camera> Reflect(const glm::vec4& relectionPlane) const;
 
-	void DeprojectScreenToWorld(glm::ivec2 screenPosition, glm::ivec2 screenSize, glm::vec3& out_worldOrigin,
-	                            glm::vec3& out_worldDirection);
-	bool ProjectWorldToScreen(glm::vec3 worldPosition, glm::vec4 viewport, glm::vec3& out_screenPosition) const;
+	void DeprojectScreenToWorld(glm::ivec2 screenPosition, glm::ivec2 screenSize, glm::vec3& outWorldOrigin,
+	                            glm::vec3& outWorldDirection);
+	bool ProjectWorldToScreen(glm::vec3 worldPosition, glm::vec4 viewport, glm::vec3& outScreenPosition) const;
 
 	void Update(std::chrono::microseconds dt);
 	void ProcessSDLEvent(const SDL_Event&);
 
-	void handleKeyboardInput(const SDL_Event&);
-	void handleMouseInput(const SDL_Event&);
+	void HandleKeyboardInput(const SDL_Event&);
+	void HandleMouseInput(const SDL_Event&);
 
 	[[nodiscard]] glm::mat4 GetRotationMatrix() const;
 
@@ -129,6 +129,6 @@ public:
 
 private:
 	glm::vec4 _reflectionPlane;
-	void reflectMatrix(glm::mat4x4& m, const glm::vec4& plane) const;
+	void ReflectMatrix(glm::mat4x4& m, const glm::vec4& plane) const;
 };
 } // namespace openblack

--- a/src/3D/Camera.h
+++ b/src/3D/Camera.h
@@ -62,9 +62,9 @@ public:
 
 	[[nodiscard]] std::unique_ptr<Camera> Reflect(const glm::vec4& relectionPlane) const;
 
-	void DeprojectScreenToWorld(const glm::ivec2 screenPosition, const glm::ivec2 screenSize, glm::vec3& out_worldOrigin,
+	void DeprojectScreenToWorld(glm::ivec2 screenPosition, glm::ivec2 screenSize, glm::vec3& out_worldOrigin,
 	                            glm::vec3& out_worldDirection);
-	bool ProjectWorldToScreen(const glm::vec3 worldPosition, const glm::vec4 viewport, glm::vec3& out_screenPosition) const;
+	bool ProjectWorldToScreen(glm::vec3 worldPosition, glm::vec4 viewport, glm::vec3& out_screenPosition) const;
 
 	void Update(std::chrono::microseconds dt);
 	void ProcessSDLEvent(const SDL_Event&);

--- a/src/3D/L3DAnim.cpp
+++ b/src/3D/L3DAnim.cpp
@@ -21,18 +21,18 @@ using namespace openblack;
 void L3DAnim::Load(const anm::ANMFile& anm)
 {
 	_name = std::string(anm.GetHeader().name.data(), anm.GetHeader().name.size());
-	_unknown_0x20 = anm.GetHeader().unknown_0x20;
-	_unknown_0x24 = anm.GetHeader().unknown_0x24;
-	_unknown_0x28 = anm.GetHeader().unknown_0x28;
-	_unknown_0x2C = anm.GetHeader().unknown_0x2C;
-	_unknown_0x30 = anm.GetHeader().unknown_0x30;
-	_unknown_0x34 = anm.GetHeader().unknown_0x34;
-	assert(anm.GetHeader().frame_count == anm.GetKeyframes().size());
-	_unknown_0x3C = anm.GetHeader().unknown_0x3C;
-	_duration = anm.GetHeader().animation_duration;
-	_unknown_0x44 = anm.GetHeader().unknown_0x44;
-	_unknown_0x48 = anm.GetHeader().unknown_0x48;
-	_unknown_0x50 = anm.GetHeader().unknown_0x50;
+	_unknown_0x20 = anm.GetHeader().unknown0x20;
+	_unknown_0x24 = anm.GetHeader().unknown0x24;
+	_unknown_0x28 = anm.GetHeader().unknown0x28;
+	_unknown_0x2C = anm.GetHeader().unknown0x2C;
+	_unknown_0x30 = anm.GetHeader().unknown0x30;
+	_unknown_0x34 = anm.GetHeader().unknown0x34;
+	assert(anm.GetHeader().frameCount == anm.GetKeyframes().size());
+	_unknown_0x3C = anm.GetHeader().unknown0x3C;
+	_duration = anm.GetHeader().animationDuration;
+	_unknown_0x44 = anm.GetHeader().unknown0x44;
+	_unknown_0x48 = anm.GetHeader().unknown0x48;
+	_unknown_0x50 = anm.GetHeader().unknown0x50;
 
 	_frames.reserve(anm.GetKeyframes().size());
 	for (const auto& keyframe : anm.GetKeyframes())
@@ -60,7 +60,7 @@ bool L3DAnim::LoadFromFile(const std::filesystem::path& path)
 
 	try
 	{
-		anm.Open(Game::instance()->GetFileSystem().FindPath(path));
+		anm.Open(Game::Instance()->GetFileSystem().FindPath(path));
 	}
 	catch (std::runtime_error& err)
 	{
@@ -101,14 +101,14 @@ std::vector<glm::mat4> L3DAnim::GetBoneMatrices(uint32_t time) const
 	{
 		return _frames[0].bones;
 	}
-	uint32_t animation_time = time % _duration;
+	uint32_t animationTime = time % _duration;
 	uint32_t index = 0;
-	uint32_t previous_time = 0;
+	uint32_t previousTime = 0;
 	for (const auto& frame : _frames)
 	{
-		if (frame.time < animation_time)
+		if (frame.time < animationTime)
 		{
-			previous_time = frame.time;
+			previousTime = frame.time;
 			index++;
 		}
 		else
@@ -125,7 +125,7 @@ std::vector<glm::mat4> L3DAnim::GetBoneMatrices(uint32_t time) const
 	{
 		return _frames[_frames.size() - 1].bones;
 	}
-	float t = static_cast<float>(animation_time - previous_time) / (_frames[index].time - previous_time);
+	float t = static_cast<float>(animationTime - previousTime) / (_frames[index].time - previousTime);
 
 	// Interpolate
 	std::vector<glm::mat4> bones;

--- a/src/3D/L3DAnim.cpp
+++ b/src/3D/L3DAnim.cpp
@@ -91,7 +91,7 @@ void L3DAnim::LoadFromBuffer(const std::vector<uint8_t>& data)
 	Load(anm);
 }
 
-const std::vector<glm::mat4> L3DAnim::GetBoneMatrices(uint32_t time) const
+std::vector<glm::mat4> L3DAnim::GetBoneMatrices(uint32_t time) const
 {
 	if (_frames.empty())
 	{
@@ -121,7 +121,7 @@ const std::vector<glm::mat4> L3DAnim::GetBoneMatrices(uint32_t time) const
 	{
 		return _frames[0].bones;
 	}
-	else if (index >= _frames.size())
+	if (index >= _frames.size())
 	{
 		return _frames[_frames.size() - 1].bones;
 	}

--- a/src/3D/L3DAnim.h
+++ b/src/3D/L3DAnim.h
@@ -47,7 +47,7 @@ public:
 	[[nodiscard]] const std::string& GetName() const { return _name; }
 	[[nodiscard]] uint32_t GetDuration() const { return _duration; }
 	[[nodiscard]] const std::vector<Frame>& GetFrames() const { return _frames; }
-	[[nodiscard]] const std::vector<glm::mat4> GetBoneMatrices(uint32_t time) const;
+	[[nodiscard]] std::vector<glm::mat4> GetBoneMatrices(uint32_t time) const;
 
 private:
 	std::string _name;

--- a/src/3D/L3DMesh.cpp
+++ b/src/3D/L3DMesh.cpp
@@ -38,7 +38,7 @@ void L3DMesh::Load(const l3d::L3DFile& l3d)
 	for (const auto& skin : l3d.GetSkins())
 	{
 		_skins[skin.id] = std::make_unique<Texture2D>(_debugName.c_str());
-		_skins[skin.id]->Create(l3d::L3DTexture::width, l3d::L3DTexture::height, 1, Format::RGBA4, Wrapping::Repeat,
+		_skins[skin.id]->Create(l3d::L3DTexture::k_Width, l3d::L3DTexture::k_Height, 1, Format::RGBA4, Wrapping::Repeat,
 		                        skin.texels.data(), static_cast<uint32_t>(skin.texels.size() * sizeof(skin.texels[0])));
 	}
 
@@ -107,7 +107,7 @@ bool L3DMesh::LoadFromFile(const std::filesystem::path& path)
 
 	try
 	{
-		l3d.Open(Game::instance()->GetFileSystem().FindPath(path));
+		l3d.Open(Game::Instance()->GetFileSystem().FindPath(path));
 	}
 	catch (std::runtime_error& err)
 	{

--- a/src/3D/L3DMesh.cpp
+++ b/src/3D/L3DMesh.cpp
@@ -35,25 +35,25 @@ L3DMesh::~L3DMesh() = default;
 void L3DMesh::Load(const l3d::L3DFile& l3d)
 {
 	_flags = static_cast<l3d::L3DMeshFlags>(l3d.GetHeader().flags);
-	for (auto& skin : l3d.GetSkins())
+	for (const auto& skin : l3d.GetSkins())
 	{
 		_skins[skin.id] = std::make_unique<Texture2D>(_debugName.c_str());
-		_skins[skin.id]->Create(skin.width, skin.height, 1, Format::RGBA4, Wrapping::Repeat, skin.texels.data(),
-		                        static_cast<uint32_t>(skin.texels.size() * sizeof(skin.texels[0])));
+		_skins[skin.id]->Create(l3d::L3DTexture::width, l3d::L3DTexture::height, 1, Format::RGBA4, Wrapping::Repeat,
+		                        skin.texels.data(), static_cast<uint32_t>(skin.texels.size() * sizeof(skin.texels[0])));
 	}
 
-	if (static_cast<uint32_t>(_flags) & static_cast<uint32_t>(l3d::L3DMeshFlags::HasDoorPosition) &&
-	    l3d.GetExtraPoints().size() > 0)
+	if ((static_cast<uint32_t>(_flags) & static_cast<uint32_t>(l3d::L3DMeshFlags::HasDoorPosition)) != 0u &&
+	    !l3d.GetExtraPoints().empty())
 	{
 		_doorPos = glm::vec3(l3d.GetExtraPoints()[0].x, l3d.GetExtraPoints()[0].y, l3d.GetExtraPoints()[0].z);
 	}
 
 	std::map<uint32_t, glm::mat4> matrices;
-	auto& bones = l3d.GetBones();
+	const auto& bones = l3d.GetBones();
 	_bonesParents.resize(bones.size());
 	for (uint32_t i = 0; i < bones.size(); ++i)
 	{
-		auto& bone = bones[i];
+		const auto& bone = bones[i];
 		// clang-format off
 		auto matrix = glm::mat4(bone.orientation[0], bone.orientation[1], bone.orientation[2], 0.0f,
 		                        bone.orientation[3], bone.orientation[4], bone.orientation[5], 0.0f,
@@ -80,8 +80,8 @@ void L3DMesh::Load(const l3d::L3DFile& l3d)
 		}
 		if (subMesh->GetFlags().isPhysics)
 		{
-			auto& verticesSpan = l3d.GetVertexSpan(i);
-			auto physicsMesh =
+			const auto& verticesSpan = l3d.GetVertexSpan(i);
+			auto* physicsMesh =
 			    new btConvexHullShape(reinterpret_cast<const btScalar*>(verticesSpan.data()),
 			                          static_cast<int>(verticesSpan.size()), static_cast<int>(sizeof(verticesSpan[0])));
 			physicsMesh->optimizeConvexHull();

--- a/src/3D/L3DMesh.h
+++ b/src/3D/L3DMesh.h
@@ -32,7 +32,7 @@ class L3DFile;
 
 typedef uint32_t SkinId;
 
-constexpr std::array<std::string_view, 32> L3DMeshFlagNames {
+constexpr std::array<std::string_view, 32> k_L3DMeshFlagNames {
     "Unknown1",
     "Unknown2",
     "Unknown3",

--- a/src/3D/L3DSubMesh.cpp
+++ b/src/3D/L3DSubMesh.cpp
@@ -43,12 +43,12 @@ L3DSubMesh::~L3DSubMesh() = default;
 
 bool L3DSubMesh::Load(const l3d::L3DFile& l3d, uint32_t meshIndex)
 {
-	auto& header = l3d.GetSubmeshHeaders()[meshIndex];
-	auto primitiveSpan = l3d.GetPrimitiveSpan(meshIndex);
-	auto& verticesSpan = l3d.GetVertexSpan(meshIndex);
-	auto& indexSpan = l3d.GetIndexSpan(meshIndex);
-	auto& vertexGroupSpans = l3d.GetVertexGroupSpan(meshIndex);
-	auto& boneSpans = l3d.GetBoneSpan(meshIndex);
+	const auto& header = l3d.GetSubmeshHeaders()[meshIndex];
+	const auto primitiveSpan = l3d.GetPrimitiveSpan(meshIndex);
+	const auto& verticesSpan = l3d.GetVertexSpan(meshIndex);
+	const auto& indexSpan = l3d.GetIndexSpan(meshIndex);
+	const auto& vertexGroupSpans = l3d.GetVertexGroupSpan(meshIndex);
+	const auto& boneSpans = l3d.GetBoneSpan(meshIndex);
 
 	_flags = header.flags;
 
@@ -128,7 +128,7 @@ bool L3DSubMesh::Load(const l3d::L3DFile& l3d, uint32_t meshIndex)
 
 	// Get Indices
 	const bgfx::Memory* indicesMem = bgfx::alloc(sizeof(uint16_t) * nIndices);
-	auto indices = (uint16_t*)indicesMem->data;
+	auto* indices = reinterpret_cast<uint16_t*>(indicesMem->data);
 
 	// Fill bone index
 	uint32_t vertexIndex = 0;
@@ -148,7 +148,9 @@ bool L3DSubMesh::Load(const l3d::L3DFile& l3d, uint32_t meshIndex)
 	{
 		// Fix indices for merged vertex buffer
 		for (uint32_t j = 0; j < primitive.numTriangles * 3; j++)
+		{
 			indices[startIndex + j] = indexSpan[startIndex + j] + startVertex;
+		}
 
 		struct MaterialTypeLutEntry
 		{
@@ -210,8 +212,8 @@ bool L3DSubMesh::Load(const l3d::L3DFile& l3d, uint32_t meshIndex)
 	decl.emplace_back(VertexAttrib::Attribute::Indices, static_cast<uint8_t>(2), VertexAttrib::Type::Int16);
 
 	// build our buffers
-	auto vertexBuffer = new VertexBuffer(_l3dMesh.GetDebugName(), verticesMem, decl);
-	auto indexBuffer = new IndexBuffer(_l3dMesh.GetDebugName(), indicesMem, IndexBuffer::Type::Uint16);
+	auto* vertexBuffer = new VertexBuffer(_l3dMesh.GetDebugName(), verticesMem, decl);
+	auto* indexBuffer = new IndexBuffer(_l3dMesh.GetDebugName(), indicesMem, IndexBuffer::Type::Uint16);
 	_mesh = std::make_unique<graphics::Mesh>(vertexBuffer, indexBuffer);
 
 	SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "{} submesh {} with {} verts and {} indices", _l3dMesh.GetDebugName(), meshIndex,

--- a/src/3D/L3DSubMesh.h
+++ b/src/3D/L3DSubMesh.h
@@ -62,7 +62,7 @@ public:
 	bool Load(const l3d::L3DFile& l3d, uint32_t meshIndex);
 
 	[[nodiscard]] openblack::l3d::L3DSubmeshHeader::Flags GetFlags() const { return _flags; }
-	[[nodiscard]] bool isPhysics() const { return _flags.isPhysics; }
+	[[nodiscard]] bool IsPhysics() const { return _flags.isPhysics; }
 	[[nodiscard]] graphics::Mesh& GetMesh() const;
 	[[nodiscard]] const AxisAlignedBoundingBox& GetBoundingBox() const { return _boundingBox; }
 	[[nodiscard]] const std::vector<Primitive>& GetPrimitives() const { return _primitives; }

--- a/src/3D/LandBlock.cpp
+++ b/src/3D/LandBlock.cpp
@@ -59,7 +59,7 @@ void LandBlock::BuildMesh(LandIsland& island)
 	// water alpha
 	decl.emplace_back(VertexAttrib::Attribute::Color3, static_cast<uint8_t>(1), VertexAttrib::Type::Float, true);
 
-	const auto* verts = buildVertexList(island);
+	const auto* verts = BuildVertexList(island);
 
 	auto* vertexBuffer = new VertexBuffer("LandBlock", verts, decl);
 	_mesh = std::make_unique<Mesh>(vertexBuffer);
@@ -77,7 +77,7 @@ void LandBlock::BuildMesh(LandIsland& island)
 	_rigidBody->setUserIndex(-1);
 }
 
-const bgfx::Memory* LandBlock::buildVertexList(LandIsland& island)
+const bgfx::Memory* LandBlock::BuildVertexList(LandIsland& island)
 {
 	// reserve 16*16 quads of 2 tris with 3 verts = 1536
 	const bgfx::Memory* verticesMem = bgfx::alloc(sizeof(LandVertex) * 1536);
@@ -109,14 +109,14 @@ const bgfx::Memory* LandBlock::buildVertexList(LandIsland& island)
 			auto br = island.GetCell(glm::u16vec2(bx + x + 1, bz + z + 1));
 
 			// construct positions from cell altitudes
-			glm::vec3 pTL((x + 0) * LandIsland::CellSize, tl.altitude * LandIsland::HeightUnit,
-			              ((z + 0) * LandIsland::CellSize));
-			glm::vec3 pTR((x + 1) * LandIsland::CellSize, tr.altitude * LandIsland::HeightUnit,
-			              ((z + 0) * LandIsland::CellSize));
-			glm::vec3 pBL((x + 0) * LandIsland::CellSize, bl.altitude * LandIsland::HeightUnit,
-			              ((z + 1) * LandIsland::CellSize));
-			glm::vec3 pBR((x + 1) * LandIsland::CellSize, br.altitude * LandIsland::HeightUnit,
-			              ((z + 1) * LandIsland::CellSize));
+			glm::vec3 pTL((x + 0) * LandIsland::k_CellSize, tl.altitude * LandIsland::k_HeightUnit,
+			              ((z + 0) * LandIsland::k_CellSize));
+			glm::vec3 pTR((x + 1) * LandIsland::k_CellSize, tr.altitude * LandIsland::k_HeightUnit,
+			              ((z + 0) * LandIsland::k_CellSize));
+			glm::vec3 pBL((x + 0) * LandIsland::k_CellSize, bl.altitude * LandIsland::k_HeightUnit,
+			              ((z + 1) * LandIsland::k_CellSize));
+			glm::vec3 pBR((x + 1) * LandIsland::k_CellSize, br.altitude * LandIsland::k_HeightUnit,
+			              ((z + 1) * LandIsland::k_CellSize));
 
 			auto getMat = [&countries, &island](const lnd::LNDCell& cell, int x, int z) {
 				const auto& country = countries.at(cell.properties.country);
@@ -143,8 +143,8 @@ const bgfx::Memory* LandBlock::buildVertexList(LandIsland& island)
 				}
 				return 1.0f;
 			};
-			auto make_vert = [&getAlpha](const glm::vec3& height, const glm::vec3& weight,
-			                             const std::array<lnd::LNDMapMaterial, 3>& m, const lnd::LNDCell& cell) -> LandVertex {
+			auto makeVert = [&getAlpha](const glm::vec3& height, const glm::vec3& weight,
+			                            const std::array<lnd::LNDMapMaterial, 3>& m, const lnd::LNDCell& cell) -> LandVertex {
 				std::array<uint32_t, 6> mat = {m[0].indices[0], m[1].indices[0], m[2].indices[0],
 				                               m[0].indices[1], m[1].indices[1], m[2].indices[1]};
 				glm::u32vec3 blend = {m[0].coefficient, m[1].coefficient, m[2].coefficient};
@@ -158,32 +158,32 @@ const bgfx::Memory* LandBlock::buildVertexList(LandIsland& island)
 				// TR/BR/TL  # #
 				//             #
 				std::array<lnd::LNDMapMaterial, 3> trbrtl = {tlMat, trMat, brMat};
-				vertices[i++] = make_vert(pTR, glm::vec3(0, 1, 0), trbrtl, tr);
-				vertices[i++] = make_vert(pBR, glm::vec3(0, 0, 1), trbrtl, br);
-				vertices[i++] = make_vert(pTL, glm::vec3(1, 0, 0), trbrtl, tl);
+				vertices[i++] = makeVert(pTR, glm::vec3(0, 1, 0), trbrtl, tr);
+				vertices[i++] = makeVert(pBR, glm::vec3(0, 0, 1), trbrtl, br);
+				vertices[i++] = makeVert(pTL, glm::vec3(1, 0, 0), trbrtl, tl);
 
 				// BR/BL/TL  #
 				//           # #
 				std::array<lnd::LNDMapMaterial, 3> brbltl = {tlMat, blMat, brMat};
-				vertices[i++] = make_vert(pBR, glm::vec3(0, 0, 1), brbltl, br);
-				vertices[i++] = make_vert(pBL, glm::vec3(0, 1, 0), brbltl, bl);
-				vertices[i++] = make_vert(pTL, glm::vec3(1, 0, 0), brbltl, tl);
+				vertices[i++] = makeVert(pBR, glm::vec3(0, 0, 1), brbltl, br);
+				vertices[i++] = makeVert(pBL, glm::vec3(0, 1, 0), brbltl, bl);
+				vertices[i++] = makeVert(pTL, glm::vec3(1, 0, 0), brbltl, tl);
 			}
 			else
 			{
 				// BL/TL/TR  # #
 				//           #
 				std::array<lnd::LNDMapMaterial, 3> bltltr = {blMat, tlMat, trMat};
-				vertices[i++] = make_vert(pBL, glm::vec3(1, 0, 0), bltltr, bl);
-				vertices[i++] = make_vert(pTL, glm::vec3(0, 1, 0), bltltr, tl);
-				vertices[i++] = make_vert(pTR, glm::vec3(0, 0, 1), bltltr, tr);
+				vertices[i++] = makeVert(pBL, glm::vec3(1, 0, 0), bltltr, bl);
+				vertices[i++] = makeVert(pTL, glm::vec3(0, 1, 0), bltltr, tl);
+				vertices[i++] = makeVert(pTR, glm::vec3(0, 0, 1), bltltr, tr);
 
 				// TR/BR/BL    #
 				//           # #
 				std::array<lnd::LNDMapMaterial, 3> trbrbl = {blMat, brMat, trMat};
-				vertices[i++] = make_vert(pTR, glm::vec3(0, 0, 1), trbrbl, tr);
-				vertices[i++] = make_vert(pBR, glm::vec3(0, 1, 0), trbrbl, br);
-				vertices[i++] = make_vert(pBL, glm::vec3(1, 0, 0), trbrbl, bl);
+				vertices[i++] = makeVert(pTR, glm::vec3(0, 0, 1), trbrbl, tr);
+				vertices[i++] = makeVert(pBR, glm::vec3(0, 1, 0), trbrbl, br);
+				vertices[i++] = makeVert(pBL, glm::vec3(1, 0, 0), trbrbl, bl);
 			}
 		}
 	}

--- a/src/3D/LandBlock.cpp
+++ b/src/3D/LandBlock.cpp
@@ -39,7 +39,9 @@ LandVertex::LandVertex(const glm::vec3& position, const glm::vec3& weight, const
 void LandBlock::BuildMesh(LandIsland& island)
 {
 	if (_mesh != nullptr)
+	{
 		_mesh.reset();
+	}
 
 	VertexDecl decl;
 	decl.reserve(7);
@@ -57,9 +59,9 @@ void LandBlock::BuildMesh(LandIsland& island)
 	// water alpha
 	decl.emplace_back(VertexAttrib::Attribute::Color3, static_cast<uint8_t>(1), VertexAttrib::Type::Float, true);
 
-	auto verts = buildVertexList(island);
+	const auto* verts = buildVertexList(island);
 
-	auto vertexBuffer = new VertexBuffer("LandBlock", verts, decl);
+	auto* vertexBuffer = new VertexBuffer("LandBlock", verts, decl);
 	_mesh = std::make_unique<Mesh>(vertexBuffer);
 
 	_dynamicsMeshInterface =
@@ -79,7 +81,7 @@ const bgfx::Memory* LandBlock::buildVertexList(LandIsland& island)
 {
 	// reserve 16*16 quads of 2 tris with 3 verts = 1536
 	const bgfx::Memory* verticesMem = bgfx::alloc(sizeof(LandVertex) * 1536);
-	auto vertices = (LandVertex*)verticesMem->data;
+	auto* vertices = reinterpret_cast<LandVertex*>(verticesMem->data);
 
 	auto countries = island.GetCountries();
 
@@ -132,9 +134,13 @@ const bgfx::Memory* LandBlock::buildVertexList(LandIsland& island)
 			// use a lambda so we're not repeating ourselves
 			auto getAlpha = [](lnd::LNDCell::Properties properties) {
 				if (properties.hasWater || properties.fullWater)
+				{
 					return 0.0f;
+				}
 				if (properties.coastLine)
+				{
 					return 0.5f;
+				}
 				return 1.0f;
 			};
 			auto make_vert = [&getAlpha](const glm::vec3& height, const glm::vec3& weight,

--- a/src/3D/LandBlock.h
+++ b/src/3D/LandBlock.h
@@ -73,7 +73,7 @@ private:
 	std::unique_ptr<btBvhTriangleMeshShape> _physicsMesh;
 	std::unique_ptr<btRigidBody> _rigidBody;
 
-	const bgfx::Memory* buildVertexList(LandIsland& island);
+	const bgfx::Memory* BuildVertexList(LandIsland& island);
 
 	friend LandIsland;
 };

--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -24,8 +24,8 @@
 using namespace openblack;
 using namespace openblack::graphics;
 
-const float LandIsland::HeightUnit = 0.67f;
-const float LandIsland::CellSize = 10.0f;
+const float LandIsland::k_HeightUnit = 0.67f;
+const float LandIsland::k_CellSize = 10.0f;
 
 LandIsland::LandIsland() = default;
 
@@ -62,27 +62,27 @@ void LandIsland::LoadFromFile(const std::filesystem::path& path)
 	auto materialCount = static_cast<uint16_t>(lnd.GetMaterials().size());
 	SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "[LandIsland] loading {} textures", materialCount);
 	std::vector<uint16_t> rgba5TextureData;
-	rgba5TextureData.resize(lnd::LNDMaterial::width * lnd::LNDMaterial::height * lnd.GetMaterials().size());
+	rgba5TextureData.resize(lnd::LNDMaterial::k_Width * lnd::LNDMaterial::k_Height * lnd.GetMaterials().size());
 	for (size_t i = 0; i < lnd.GetMaterials().size(); i++)
 	{
-		std::memcpy(&rgba5TextureData[lnd::LNDMaterial::width * lnd::LNDMaterial::height * i],
+		std::memcpy(&rgba5TextureData[lnd::LNDMaterial::k_Width * lnd::LNDMaterial::k_Height * i],
 		            lnd.GetMaterials()[i].texels.data(),
 		            sizeof(lnd.GetMaterials()[i].texels[0]) * lnd.GetMaterials()[i].texels.size());
 	}
 	_materialArray = std::make_unique<Texture2D>("LandIslandMaterialArray");
-	_materialArray->Create(lnd::LNDMaterial::width, lnd::LNDMaterial::height, materialCount, Format::RGB5A1,
+	_materialArray->Create(lnd::LNDMaterial::k_Width, lnd::LNDMaterial::k_Height, materialCount, Format::RGB5A1,
 	                       Wrapping::ClampEdge, rgba5TextureData.data(),
 	                       static_cast<uint32_t>(rgba5TextureData.size() * sizeof(rgba5TextureData[0])));
 
 	// read noise map into Texture2D
 	_noiseMap = lnd.GetExtra().noise.texels;
 	_textureNoiseMap = std::make_unique<Texture2D>("LandIslandNoiseMap");
-	_textureNoiseMap->Create(lnd::LNDBumpMap::width, lnd::LNDBumpMap::height, 1, Format::R8, Wrapping::ClampEdge,
+	_textureNoiseMap->Create(lnd::LNDBumpMap::k_Width, lnd::LNDBumpMap::k_Height, 1, Format::R8, Wrapping::ClampEdge,
 	                         _noiseMap.data(), static_cast<uint32_t>(_noiseMap.size() * sizeof(_noiseMap[0])));
 
 	// read bump map into Texture2D
 	_textureBumpMap = std::make_unique<Texture2D>("LandIslandBumpMap");
-	_textureBumpMap->Create(lnd::LNDBumpMap::width, lnd::LNDBumpMap::height, 1, Format::R8, Wrapping::Repeat,
+	_textureBumpMap->Create(lnd::LNDBumpMap::k_Width, lnd::LNDBumpMap::k_Height, 1, Format::R8, Wrapping::Repeat,
 	                        lnd.GetExtra().bump.texels.data(),
 	                        static_cast<uint32_t>(sizeof(lnd.GetExtra().bump.texels[0]) * lnd.GetExtra().bump.texels.size()));
 
@@ -96,7 +96,7 @@ void LandIsland::LoadFromFile(const std::filesystem::path& path)
 
 float LandIsland::GetHeightAt(glm::vec2 vec) const
 {
-	return GetCell(vec * 0.1f).altitude * LandIsland::HeightUnit;
+	return GetCell(vec * 0.1f).altitude * LandIsland::k_HeightUnit;
 }
 
 uint8_t LandIsland::GetNoise(int x, int y)
@@ -128,13 +128,13 @@ constexpr lnd::LNDCell EmptyCell() noexcept
 	return cell;
 }
 
-constexpr lnd::LNDCell s_EmptyCell = EmptyCell();
+constexpr lnd::LNDCell k_EmptyCell = EmptyCell();
 
 const lnd::LNDCell& LandIsland::GetCell(const glm::u16vec2& coordinates) const
 {
 	if (coordinates.x > 511 || coordinates.y > 511)
 	{
-		return s_EmptyCell;
+		return k_EmptyCell;
 	}
 
 	const uint16_t lookupIndex = ((coordinates.x & ~0xFU) << 1U) | (coordinates.y >> 4U);
@@ -144,7 +144,7 @@ const lnd::LNDCell& LandIsland::GetCell(const glm::u16vec2& coordinates) const
 
 	if (blockIndex == 0)
 	{
-		return s_EmptyCell;
+		return k_EmptyCell;
 	}
 	assert(_landBlocks.size() >= blockIndex);
 	return _landBlocks[blockIndex - 1].GetCells()[cellIndex];

--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -48,7 +48,7 @@ void LandIsland::LoadFromFile(const std::filesystem::path& path)
 
 	_blockIndexLookup = lnd.GetHeader().lookUpTable;
 
-	auto& lndBlocks = lnd.GetBlocks();
+	const auto& lndBlocks = lnd.GetBlocks();
 	SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "[LandIsland] loading {} blocks", lndBlocks.size());
 	_landBlocks.resize(lndBlocks.size());
 	for (size_t i = 0; i < _landBlocks.size(); i++)
@@ -87,7 +87,10 @@ void LandIsland::LoadFromFile(const std::filesystem::path& path)
 	                        static_cast<uint32_t>(sizeof(lnd.GetExtra().bump.texels[0]) * lnd.GetExtra().bump.texels.size()));
 
 	// build the meshes (we could move this elsewhere)
-	for (auto& block : _landBlocks) block.BuildMesh(*this);
+	for (auto& block : _landBlocks)
+	{
+		block.BuildMesh(*this);
+	}
 	bgfx::frame();
 }
 
@@ -105,11 +108,15 @@ const LandBlock* LandIsland::GetBlock(const glm::u8vec2& coordinates) const
 {
 	// our blocks can only be between [0-31, 0-31]
 	if (coordinates.x > 32 || coordinates.y > 32)
+	{
 		return nullptr;
+	}
 
 	const uint8_t blockIndex = _blockIndexLookup.at(coordinates.x * 32 + coordinates.y);
 	if (blockIndex == 0)
+	{
 		return nullptr;
+	}
 
 	return &_landBlocks[blockIndex - 1];
 }

--- a/src/3D/LandIsland.h
+++ b/src/3D/LandIsland.h
@@ -44,7 +44,7 @@ public:
 	LandIsland();
 	~LandIsland();
 
-	void LoadFromFile(const std::filesystem::path& filename);
+	void LoadFromFile(const std::filesystem::path& path);
 
 	[[nodiscard]] float GetHeightAt(glm::vec2) const;
 	[[nodiscard]] const LandBlock* GetBlock(const glm::u8vec2& coordinates) const;

--- a/src/3D/LandIsland.h
+++ b/src/3D/LandIsland.h
@@ -37,9 +37,9 @@ struct LNDCountry;
 class LandIsland
 {
 public:
-	static const float HeightUnit;
-	static const float CellSize;
-	static constexpr entt::hashed_string SmallBumpTextureId = entt::hashed_string("raw/smallbumpa");
+	static const float k_HeightUnit;
+	static const float k_CellSize;
+	static constexpr entt::hashed_string k_SmallBumpTextureId = entt::hashed_string("raw/smallbumpa");
 
 	LandIsland();
 	~LandIsland();

--- a/src/3D/Sky.cpp
+++ b/src/3D/Sky.cpp
@@ -17,7 +17,6 @@
 #include "Common/Bitmap16B.h"
 #include "Common/FileSystem.h"
 #include "Common/StringUtils.h"
-#include "Game.h"
 
 using namespace openblack::graphics;
 
@@ -29,17 +28,16 @@ Sky::Sky()
 	SetDayNightTimes(4.5, 7.0, 7.5, 8.25);
 
 	// load in the mesh
-	auto& filesystem = Game::instance()->GetFileSystem();
 	_model = std::make_unique<L3DMesh>("Sky");
 	_model->LoadFromFile(FileSystem::WeatherSystemPath() / "sky.l3d");
 
-	for (uint32_t idx = 0; const auto& alignment : _alignments)
+	for (uint32_t idx = 0; const auto& alignment : k_Alignments)
 	{
-		for (const auto& timeView : _times)
+		for (const auto& timeView : k_Times)
 		{
 			auto time = std::string(timeView);
 			auto prefix = std::string("sky");
-			if (idx >= _times.size() && idx < 2 * _times.size())
+			if (idx >= k_Times.size() && idx < 2 * k_Times.size())
 			{
 				time = string_utils::Capitalise(time);
 				prefix = string_utils::Capitalise(prefix);
@@ -49,7 +47,7 @@ Sky::Sky()
 			SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "Loading sky texture: {}", path.generic_string());
 
 			Bitmap16B* bitmap = Bitmap16B::LoadFromFile(path);
-			memcpy(&_bitmaps.at(idx * _textureResolution[0] * _textureResolution[1]), bitmap->Data(), bitmap->Size());
+			memcpy(&_bitmaps.at(idx * k_TextureResolution[0] * k_TextureResolution[1]), bitmap->Data(), bitmap->Size());
 			delete bitmap;
 			++idx;
 		}
@@ -58,8 +56,8 @@ Sky::Sky()
 	_texture = std::make_unique<Texture2D>("Sky");
 	_timeOfDay = 1.0f;
 
-	_texture->Create(_textureResolution[0], _textureResolution[1], _textureResolution[2], Format::RGB5A1, Wrapping::ClampEdge,
-	                 _bitmaps.data(), static_cast<uint32_t>(_bitmaps.size() * sizeof(_bitmaps[0])));
+	_texture->Create(k_TextureResolution[0], k_TextureResolution[1], k_TextureResolution[2], Format::RGB5A1,
+	                 Wrapping::ClampEdge, _bitmaps.data(), static_cast<uint32_t>(_bitmaps.size() * sizeof(_bitmaps[0])));
 }
 
 void Sky::SetDayNightTimes(float nightFull, float duskStart, float duskEnd, float dayFull)

--- a/src/3D/Sky.cpp
+++ b/src/3D/Sky.cpp
@@ -31,7 +31,7 @@ Sky::Sky()
 	// load in the mesh
 	auto& filesystem = Game::instance()->GetFileSystem();
 	_model = std::make_unique<L3DMesh>("Sky");
-	_model->LoadFromFile(filesystem.WeatherSystemPath() / "sky.l3d");
+	_model->LoadFromFile(FileSystem::WeatherSystemPath() / "sky.l3d");
 
 	for (uint32_t idx = 0; const auto& alignment : _alignments)
 	{
@@ -45,7 +45,7 @@ Sky::Sky()
 				prefix = string_utils::Capitalise(prefix);
 			}
 			const auto filename = fmt::format("{}_{}_{}.555", prefix, alignment, time);
-			const auto path = filesystem.WeatherSystemPath() / filename;
+			const auto path = FileSystem::WeatherSystemPath() / filename;
 			SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "Loading sky texture: {}", path.generic_string());
 
 			Bitmap16B* bitmap = Bitmap16B::LoadFromFile(path);
@@ -87,22 +87,20 @@ float Sky::GetCurrentSkyType() const
 	{
 		return 0.0f; // Index for night texture
 	}
-	else if (time < _duskStartTime) // Between night and dusk
+	if (time < _duskStartTime) // Between night and dusk
 	{
 		return (time - _nightFullTime) / (_duskStartTime - _nightFullTime); // 0 - 1 lerp between night and dusk
 	}
-	else if (time <= _duskEndTime) // In full dusk
+	if (time <= _duskEndTime) // In full dusk
 	{
 		return 1.0f; // Index for dusk texture
 	}
-	else if (time < _dayFullTime) // Between dusk and day
+	if (time < _dayFullTime) // Between dusk and day
 	{
 		return 1.0f + (time - _duskEndTime) / (_dayFullTime - _duskEndTime); // 1 - 2 lerp between dusk and day
 	}
-	else // In full day
-	{
-		return 2.0f; // Index for day texture
-	}
+	// In full day
+	return 2.0f; // Index for day texture
 }
 
 } // namespace openblack

--- a/src/3D/Sky.h
+++ b/src/3D/Sky.h
@@ -46,26 +46,26 @@ public:
 private:
 	friend class Renderer;
 
-	static constexpr std::array<std::string_view, 3> _alignments = {
+	static constexpr std::array<std::string_view, 3> k_Alignments = {
 	    "evil",
 	    "Ntrl",
 	    "good",
 	};
-	static constexpr std::array<std::string_view, 3> _times = {
+	static constexpr std::array<std::string_view, 3> k_Times = {
 	    "night",
 	    "dusk",
 	    "day",
 	};
-	static constexpr std::array<uint16_t, 3> _textureResolution = {
+	static constexpr std::array<uint16_t, 3> k_TextureResolution = {
 	    256,
 	    256,
-	    static_cast<uint16_t>(_alignments.size() * _times.size()),
+	    static_cast<uint16_t>(k_Alignments.size() * k_Times.size()),
 	};
 
 	std::unique_ptr<L3DMesh> _model;
 	std::unique_ptr<graphics::Texture2D> _texture; // TODO(bwrsandman): put in a resource manager and store look-up
 
-	std::array<uint16_t, _textureResolution[0] * _textureResolution[1] * _textureResolution[2]> _bitmaps;
+	std::array<uint16_t, k_TextureResolution[0] * k_TextureResolution[1] * k_TextureResolution[2]> _bitmaps;
 
 	float _timeOfDay;
 	float _nightFullTime;

--- a/src/3D/Water.cpp
+++ b/src/3D/Water.cpp
@@ -28,10 +28,11 @@ Water::Water()
 	_reflectionFrameBuffer =
 	    std::make_unique<FrameBuffer>("Reflection", static_cast<uint16_t>(1024), static_cast<uint16_t>(1024),
 	                                  graphics::Format::RGBA8, graphics::Format::Depth24Stencil8);
-	createMesh();
+	CreateMesh();
 }
+Water::~Water() = default;
 
-void Water::createMesh()
+void Water::CreateMesh()
 {
 	VertexDecl decl;
 	decl.reserve(1);

--- a/src/3D/Water.cpp
+++ b/src/3D/Water.cpp
@@ -46,8 +46,8 @@ void Water::createMesh()
 
 	static constexpr std::array<uint16_t, 6> indices = {2, 1, 0, 0, 3, 2};
 
-	auto vertexBuffer = new VertexBuffer("Water", points.data(), static_cast<uint32_t>(points.size()), decl);
-	auto indexBuffer =
+	auto* vertexBuffer = new VertexBuffer("Water", points.data(), static_cast<uint32_t>(points.size()), decl);
+	auto* indexBuffer =
 	    new IndexBuffer("Water", indices.data(), static_cast<uint32_t>(indices.size()), IndexBuffer::Type::Uint16);
 
 	_mesh = std::make_unique<Mesh>(vertexBuffer, indexBuffer, graphics::Mesh::Topology::TriangleList);

--- a/src/3D/Water.h
+++ b/src/3D/Water.h
@@ -29,11 +29,11 @@ class Water
 {
 public:
 	// Oddly enough the water texture is labeled Sky
-	static constexpr entt::hashed_string DiffuseTextureId = entt::hashed_string("raw/Sky");
-	static constexpr entt::hashed_string AlphaTextureId = entt::hashed_string("raw/Skya");
+	static constexpr entt::hashed_string k_DiffuseTextureId = entt::hashed_string("raw/Sky");
+	static constexpr entt::hashed_string k_AlphaTextureId = entt::hashed_string("raw/Skya");
 
 	Water();
-	~Water() = default;
+	~Water();
 
 	[[nodiscard]] glm::vec4 GetReflectionPlane() const { return {0.0f, 1.0f, 0.0f, 0.0f}; };
 	[[nodiscard]] graphics::FrameBuffer& GetFrameBuffer() const;
@@ -41,7 +41,7 @@ public:
 private:
 	friend class Renderer;
 
-	void createMesh();
+	void CreateMesh();
 
 	std::unique_ptr<graphics::Mesh> _mesh;
 	std::unique_ptr<graphics::FrameBuffer> _reflectionFrameBuffer;

--- a/src/Common/Bitmap16B.cpp
+++ b/src/Common/Bitmap16B.cpp
@@ -33,7 +33,7 @@ Bitmap16B::~Bitmap16B()
 
 Bitmap16B* Bitmap16B::LoadFromFile(const std::filesystem::path& path)
 {
-	auto const& data = Game::instance()->GetFileSystem().ReadAll(path);
+	auto const& data = Game::Instance()->GetFileSystem().ReadAll(path);
 	auto* bitmap = new Bitmap16B(data.data());
 
 	return bitmap;

--- a/src/Common/EventManager.h
+++ b/src/Common/EventManager.h
@@ -45,14 +45,14 @@ private:
 
 	public:
 		template <typename... T>
-		inline static const int Type = identifier++;
+		inline static const int k_Type = identifier++;
 	};
-	mutable std::unordered_map<int, std::unique_ptr<IEventQueue>> queues {};
+	mutable std::unordered_map<int, std::unique_ptr<IEventQueue>> _queues {};
 	template <typename Event>
 	EventQueue<Event>* Insist()
 	{
-		const auto eventType = EventManager::_EventFamily::Type<Event>;
-		std::unique_ptr<IEventQueue>& p = queues[eventType];
+		const auto eventType = EventManager::_EventFamily::k_Type<Event>;
+		std::unique_ptr<IEventQueue>& p = _queues[eventType];
 
 		if (!p)
 		{

--- a/src/Common/FileStream.cpp
+++ b/src/Common/FileStream.cpp
@@ -42,7 +42,9 @@ FileStream::FileStream(const std::filesystem::path& path, FileMode mode)
 #endif
 
 	if (_file == nullptr)
+	{
 		throw std::runtime_error(fmt::format("Failed to open file '{}'", path.string()));
+	}
 
 	Seek(0, SeekMode::End);
 	_fileSize = Position();
@@ -52,7 +54,9 @@ FileStream::FileStream(const std::filesystem::path& path, FileMode mode)
 FileStream::~FileStream()
 {
 	if (_file != nullptr)
+	{
 		std::fclose(_file);
+	}
 }
 
 std::size_t FileStream::Position() const

--- a/src/Common/FileStream.h
+++ b/src/Common/FileStream.h
@@ -26,7 +26,7 @@ enum class FileMode
 class FileStream final: public IStream
 {
 public:
-	FileStream(const std::filesystem::path& filename, FileMode mode);
+	FileStream(const std::filesystem::path& path, FileMode mode);
 	virtual ~FileStream();
 
 	[[nodiscard]] std::size_t Position() const override;

--- a/src/Common/FileSystem.cpp
+++ b/src/Common/FileSystem.cpp
@@ -27,7 +27,7 @@ std::filesystem::path FileSystem::FixPath(const std::filesystem::path& path)
 	    "\\Landscape\\",
 	    "\\Multi_Player\\",
 	};
-	for (auto& pattern : caseFixTable)
+	for (const auto& pattern : caseFixTable)
 	{
 		auto foundIter = std::search(result.cbegin(), result.cend(), pattern.cbegin(), pattern.cend(),
 		                             [](char left, char right) { return std::toupper(left) == std::toupper(right); });
@@ -50,19 +50,27 @@ std::filesystem::path FileSystem::FixPath(const std::filesystem::path& path)
 std::filesystem::path FileSystem::FindPath(const std::filesystem::path& path) const
 {
 	if (path.empty())
+	{
 		throw std::invalid_argument("empty path");
+	}
 
 	// try absolute first
 	if (path.is_absolute() && std::filesystem::exists(path))
+	{
 		return path;
+	}
 
 	// try relative to current directory
 	if (path.is_relative() && std::filesystem::exists(path))
+	{
 		return path;
+	}
 
 	// try relative to game directory
 	if (path.is_relative() && std::filesystem::exists(_gamePath / path))
+	{
 		return _gamePath / path;
+	}
 
 	throw std::runtime_error("File " + path.string() + " not found");
 }

--- a/src/Common/Zip.cpp
+++ b/src/Common/Zip.cpp
@@ -17,7 +17,7 @@
 #include <fmt/format.h>
 #include <zlib.h>
 
-constexpr auto MAX_BUFFER_SIZE = std::numeric_limits<decltype(z_stream::avail_out)>::max();
+constexpr auto k_MaxBufferSize = std::numeric_limits<decltype(z_stream::avail_out)>::max();
 
 std::string GetZlibError(int statusCode)
 {
@@ -51,7 +51,7 @@ std::vector<uint8_t> openblack::zip::Inflate(const std::vector<uint8_t>& deflate
 	auto inflatedData = std::vector<uint8_t>(inflatedSize);
 	int returnStatus;
 
-	if (deflatedSize > MAX_BUFFER_SIZE || inflatedSize > MAX_BUFFER_SIZE)
+	if (deflatedSize > k_MaxBufferSize || inflatedSize > k_MaxBufferSize)
 	{
 		throw std::runtime_error("Data is too large to inflate");
 	}

--- a/src/Common/Zip.cpp
+++ b/src/Common/Zip.cpp
@@ -19,7 +19,7 @@
 
 constexpr auto MAX_BUFFER_SIZE = std::numeric_limits<decltype(z_stream::avail_out)>::max();
 
-const std::string GetZlibError(int statusCode)
+std::string GetZlibError(int statusCode)
 {
 	switch (statusCode)
 	{

--- a/src/Dynamics/LandBlockBulletMeshInterface.h
+++ b/src/Dynamics/LandBlockBulletMeshInterface.h
@@ -33,16 +33,16 @@ class LandBlockBulletMeshInterface: public btStridingMeshInterface
 	std::vector<uint16_t> _indices;
 
 public:
-	explicit LandBlockBulletMeshInterface(const uint8_t* vertex_data, uint32_t vertex_count, size_t stride)
-	    : _vertices(vertex_count / stride)
-	    , _indices(vertex_count / stride)
+	explicit LandBlockBulletMeshInterface(const uint8_t* vertexData, uint32_t vertexCount, size_t stride)
+	    : _vertices(vertexCount / stride)
+	    , _indices(vertexCount / stride)
 	{
 		for (uint16_t i = 0; auto& v : _vertices)
 		{
-			const auto* vertex_base = reinterpret_cast<const float*>(&vertex_data[i * stride]);
-			v[0] = vertex_base[0];
-			v[1] = vertex_base[1];
-			v[2] = vertex_base[2];
+			const auto* vertexBase = reinterpret_cast<const float*>(&vertexData[i * stride]);
+			v[0] = vertexBase[0];
+			v[1] = vertexBase[1];
+			v[2] = vertexBase[2];
 			_indices[i] = i;
 			++i;
 		}

--- a/src/Dynamics/LandBlockBulletMeshInterface.h
+++ b/src/Dynamics/LandBlockBulletMeshInterface.h
@@ -39,7 +39,7 @@ public:
 	{
 		for (uint16_t i = 0; auto& v : _vertices)
 		{
-			auto vertex_base = reinterpret_cast<const float*>(&vertex_data[i * stride]);
+			const auto* vertex_base = reinterpret_cast<const float*>(&vertex_data[i * stride]);
 			v[0] = vertex_base[0];
 			v[1] = vertex_base[1];
 			v[2] = vertex_base[2];
@@ -59,7 +59,6 @@ public:
 	                              [[maybe_unused]] int& numfaces, [[maybe_unused]] PHY_ScalarType& indicestype,
 	                              [[maybe_unused]] int subpart) override
 	{
-		return;
 	}
 
 	void getLockedReadOnlyVertexIndexBase(const unsigned char** vertexbase, int& numverts, PHY_ScalarType& type, int& stride,
@@ -79,16 +78,16 @@ public:
 
 	/// unLockVertexBase finishes the access to a subpart of the triangle mesh
 	/// make a call to unLockVertexBase when the read and write access (using getLockedVertexIndexBase) is finished
-	void unLockVertexBase([[maybe_unused]] int subpart) override { return; }
+	void unLockVertexBase([[maybe_unused]] int subpart) override {}
 
-	void unLockReadOnlyVertexBase([[maybe_unused]] int subpart) const override { return; }
+	void unLockReadOnlyVertexBase([[maybe_unused]] int subpart) const override {}
 
 	/// getNumSubParts returns the number of separate subparts
 	/// each subpart has a continuous array of vertices and indices
 	[[nodiscard]] int getNumSubParts() const override { return 1; }
 
-	void preallocateVertices([[maybe_unused]] int numverts) override { return; }
+	void preallocateVertices([[maybe_unused]] int numverts) override {}
 
-	void preallocateIndices([[maybe_unused]] int numindices) override { return; }
+	void preallocateIndices([[maybe_unused]] int numindices) override {}
 };
 } // namespace openblack::dynamics

--- a/src/ECS/Archetypes/AbodeArchetype.cpp
+++ b/src/ECS/Archetypes/AbodeArchetype.cpp
@@ -31,14 +31,14 @@ using namespace openblack::ecs::systems;
 entt::entity AbodeArchetype::Create(uint32_t townId, const glm::vec3& position, AbodeInfo type, float yAngleRadians,
                                     float scale, uint32_t foodAmount, uint32_t woodAmount)
 {
-	auto* game = Game::instance();
+	auto* game = Game::Instance();
 	auto& registry = game->GetEntityRegistry();
 
 	// If there is no town, assign to closest
 	if (registry.Context().towns.find(townId) == registry.Context().towns.end())
 	{
 		SPDLOG_LOGGER_WARN(spdlog::get("scripting"), "Function {} has invalid Town ({}).", __func__, townId);
-		const auto town = TownSystem::instance().FindClosestTown(position);
+		const auto town = TownSystem::Instance().FindClosestTown(position);
 		if (town != entt::null)
 		{
 			townId = registry.Get<Town>(town).id;

--- a/src/ECS/Archetypes/AnimatedStaticArchetype.cpp
+++ b/src/ECS/Archetypes/AnimatedStaticArchetype.cpp
@@ -28,10 +28,10 @@ using namespace openblack::ecs::components;
 entt::entity AnimatedStaticArchetype::Create(const glm::vec3& position, AnimatedStaticInfo type, float yAngleRadians,
                                              float scale)
 {
-	auto& registry = Game::instance()->GetEntityRegistry();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 	const auto entity = registry.Create();
 
-	const auto& info = Game::instance()->GetInfoConstants().animatedStatic.at(static_cast<size_t>(type));
+	const auto& info = Game::Instance()->GetInfoConstants().animatedStatic.at(static_cast<size_t>(type));
 
 	// The exact same as Feature but info is different and type is a different enum
 	const auto& transform = registry.Assign<Transform>(entity, position, glm::eulerAngleY(-yAngleRadians), glm::vec3(scale));

--- a/src/ECS/Archetypes/BigForestArchetype.cpp
+++ b/src/ECS/Archetypes/BigForestArchetype.cpp
@@ -27,10 +27,10 @@ using namespace openblack::ecs::components;
 entt::entity BigForestArchetype::Create(const glm::vec3& position, BigForestInfo type, [[maybe_unused]] uint32_t unknown,
                                         float yAngleRadians, float scale)
 {
-	auto& registry = Game::instance()->GetEntityRegistry();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 	const auto entity = registry.Create();
 
-	const auto& info = Game::instance()->GetInfoConstants().bigForest.at(static_cast<size_t>(type));
+	const auto& info = Game::Instance()->GetInfoConstants().bigForest.at(static_cast<size_t>(type));
 
 	const auto& transform = registry.Assign<Transform>(entity, position, glm::eulerAngleY(-yAngleRadians), glm::vec3(scale));
 	const auto [point, radius] = GetFixedObstacleBoundingCircle(info.meshId, transform);

--- a/src/ECS/Archetypes/BonfireArchetype.cpp
+++ b/src/ECS/Archetypes/BonfireArchetype.cpp
@@ -23,7 +23,7 @@ using namespace openblack::ecs::components;
 
 entt::entity BonfireArchetype::Create(const glm::vec3& position)
 {
-	auto& registry = Game::instance()->GetEntityRegistry();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 	const auto entity = registry.Create();
 	registry.Assign<Transform>(entity, position, glm::eulerAngleY(glm::radians(180.0f)), glm::vec3(1.0f));
 	const auto resourceId = resources::MeshIdToResourceId(MeshId::BuildingCampfire);

--- a/src/ECS/Archetypes/CameraBookmarkArchetype.cpp
+++ b/src/ECS/Archetypes/CameraBookmarkArchetype.cpp
@@ -22,7 +22,7 @@ using namespace openblack::ecs::components;
 
 std::array<entt::entity, 8> CameraBookmarkArchetype::CreateAll()
 {
-	auto& registry = Game::instance()->GetEntityRegistry();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 	auto texture = Locator::resources::ref().GetTextures().Handle(entt::hashed_string("raw/misc0a"));
 	if (!texture)
 	{

--- a/src/ECS/Archetypes/FeatureArchetype.cpp
+++ b/src/ECS/Archetypes/FeatureArchetype.cpp
@@ -30,10 +30,10 @@ using namespace openblack::ecs::components;
 
 entt::entity FeatureArchetype::Create(const glm::vec3& position, FeatureInfo type, float yAngleRadians, float scale)
 {
-	auto& registry = Game::instance()->GetEntityRegistry();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 	const auto entity = registry.Create();
 
-	const auto& info = Game::instance()->GetInfoConstants().feature.at(static_cast<size_t>(type));
+	const auto& info = Game::Instance()->GetInfoConstants().feature.at(static_cast<size_t>(type));
 
 	const auto& transform = registry.Assign<Transform>(entity, position, glm::eulerAngleY(-yAngleRadians), glm::vec3(scale));
 	const auto [point, radius] = GetFixedObstacleBoundingCircle(info.meshId, transform);

--- a/src/ECS/Archetypes/FieldArchetype.cpp
+++ b/src/ECS/Archetypes/FieldArchetype.cpp
@@ -23,9 +23,9 @@ using namespace openblack::ecs::components;
 
 entt::entity FieldArchetype::Create(int townId, const glm::vec3& position, FieldTypeInfo type, float yAngleRadians)
 {
-	auto& registry = Game::instance()->GetEntityRegistry();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 
-	[[maybe_unused]] const auto& info = Game::instance()->GetInfoConstants().fieldType.at(static_cast<size_t>(type));
+	[[maybe_unused]] const auto& info = Game::Instance()->GetInfoConstants().fieldType.at(static_cast<size_t>(type));
 
 	auto townTribe = registry.Get<Tribe>(registry.Context().towns[townId]);
 	auto abodeInfo = GAbodeInfo::Find(townTribe, AbodeNumber::Field);

--- a/src/ECS/Archetypes/HandArchetype.cpp
+++ b/src/ECS/Archetypes/HandArchetype.cpp
@@ -25,13 +25,13 @@ using namespace openblack::ecs::components;
 entt::entity HandArchetype::Create(const glm::vec3& position, float xAngleRadians, float yAngleRadians, float zAngleRadians,
                                    float scale, bool rightHanded)
 {
-	auto& registry = Game::instance()->GetEntityRegistry();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 	const auto entity = registry.Create();
 
 	const auto rotation = glm::mat3(glm::eulerAngleXYZ(xAngleRadians, yAngleRadians, zAngleRadians));
 	registry.Assign<Hand>(entity, rightHanded);
 	registry.Assign<Transform>(entity, position, rotation, glm::vec3(scale));
-	registry.Assign<Mesh>(entity, Hand::meshId, static_cast<int8_t>(0), static_cast<int8_t>(0));
+	registry.Assign<Mesh>(entity, Hand::k_MeshId, static_cast<int8_t>(0), static_cast<int8_t>(0));
 
 	// Data/CreatureMesh/Hand_Boned_Base2.l3d
 	// Data/CreatureMesh/Hand_Boned_Good2.l3d

--- a/src/ECS/Archetypes/MobileObjectArchetype.cpp
+++ b/src/ECS/Archetypes/MobileObjectArchetype.cpp
@@ -26,10 +26,10 @@ using namespace openblack::ecs::components;
 
 entt::entity MobileObjectArchetype::Create(const glm::vec3& position, MobileObjectInfo type, float yAngleRadians, float scale)
 {
-	auto& registry = Game::instance()->GetEntityRegistry();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 	const auto entity = registry.Create();
 
-	const auto& info = Game::instance()->GetInfoConstants().mobileObject.at(static_cast<size_t>(type));
+	const auto& info = Game::Instance()->GetInfoConstants().mobileObject.at(static_cast<size_t>(type));
 
 	registry.Assign<Transform>(entity, position, glm::eulerAngleY(-yAngleRadians), glm::vec3(scale));
 	registry.Assign<Mobile>(entity);

--- a/src/ECS/Archetypes/MobileStaticArchetype.cpp
+++ b/src/ECS/Archetypes/MobileStaticArchetype.cpp
@@ -27,10 +27,10 @@ using namespace openblack::ecs::components;
 entt::entity MobileStaticArchetype::Create(const glm::vec3& position, MobileStaticInfo type, float altitude,
                                            float xAngleRadians, float yAngleRadians, float zAngleRadians, float scale)
 {
-	auto& registry = Game::instance()->GetEntityRegistry();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 	const auto entity = registry.Create();
 
-	const auto& info = Game::instance()->GetInfoConstants().mobileStatic.at(static_cast<size_t>(type));
+	const auto& info = Game::Instance()->GetInfoConstants().mobileStatic.at(static_cast<size_t>(type));
 
 	glm::vec3 offset(0.0f, altitude, 0.0f);
 

--- a/src/ECS/Archetypes/StreetLanternArchetype.cpp
+++ b/src/ECS/Archetypes/StreetLanternArchetype.cpp
@@ -24,7 +24,7 @@ using namespace openblack::ecs::components;
 
 entt::entity StreetLanternArchetype::Create(const glm::vec3& position)
 {
-	auto& registry = Game::instance()->GetEntityRegistry();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 	const auto entity = registry.Create();
 	registry.Assign<Transform>(entity, position, glm::eulerAngleY(glm::radians(180.0f)), glm::vec3(1.0f));
 	const auto resourceId = resources::MeshIdToResourceId(MeshId::ObjectTownLight);

--- a/src/ECS/Archetypes/TownArchetype.cpp
+++ b/src/ECS/Archetypes/TownArchetype.cpp
@@ -20,10 +20,10 @@ using namespace openblack::ecs::components;
 
 entt::entity TownArchetype::Create(int id, const glm::vec3& position, [[maybe_unused]] PlayerNames playerOwner, Tribe tribe)
 {
-	auto& registry = Game::instance()->GetEntityRegistry();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 	const auto entity = registry.Create();
 
-	// const auto& info = Game::instance()->GetInfoConstants().town;
+	// const auto& info = Game::Instance()->GetInfoConstants().town;
 
 	registry.Assign<Town>(entity, static_cast<uint32_t>(id));
 	registry.Assign<Tribe>(entity, tribe);

--- a/src/ECS/Archetypes/TreeArchetype.cpp
+++ b/src/ECS/Archetypes/TreeArchetype.cpp
@@ -27,10 +27,10 @@ using namespace openblack::ecs::components;
 entt::entity TreeArchetype::Create([[maybe_unused]] uint32_t forestId, const glm::vec3& position, TreeInfo type,
                                    [[maybe_unused]] bool isNonScenic, float yAngleRadians, float maxSize, float scale)
 {
-	auto& registry = Game::instance()->GetEntityRegistry();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 	const auto entity = registry.Create();
 
-	const auto& info = Game::instance()->GetInfoConstants().tree.at(static_cast<size_t>(type));
+	const auto& info = Game::Instance()->GetInfoConstants().tree.at(static_cast<size_t>(type));
 
 	const auto& transform = registry.Assign<Transform>(entity, position, glm::eulerAngleY(-yAngleRadians), glm::vec3(scale));
 	const auto [point, radius] = GetFixedObstacleBoundingCircle(info.normal, transform);

--- a/src/ECS/Archetypes/VillagerArchetype.cpp
+++ b/src/ECS/Archetypes/VillagerArchetype.cpp
@@ -32,10 +32,10 @@ using namespace openblack::ecs::systems;
 entt::entity VillagerArchetype::Create([[maybe_unused]] const glm::vec3& abodePosition, const glm::vec3& position,
                                        VillagerInfo type, uint32_t age)
 {
-	auto& registry = Game::instance()->GetEntityRegistry();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 	const auto entity = registry.Create();
 
-	const auto& info = Game::instance()->GetInfoConstants().villager.at(static_cast<size_t>(type));
+	const auto& info = Game::Instance()->GetInfoConstants().villager.at(static_cast<size_t>(type));
 
 	registry.Assign<Transform>(entity, position, glm::eulerAngleY(glm::radians(180.0f)), glm::vec3(1.0));
 	registry.Assign<Mobile>(entity);
@@ -47,11 +47,11 @@ entt::entity VillagerArchetype::Create([[maybe_unused]] const glm::vec3& abodePo
 	const auto task = Villager::Task::IDLE;
 
 	// TODO(bwrsandman): Might be better to make a FindClosestAbode
-	const entt::entity town = TownSystem::instance().FindClosestTown(abodePosition);
+	const entt::entity town = TownSystem::Instance().FindClosestTown(abodePosition);
 	entt::entity abode = entt::null;
 	if (town != entt::null)
 	{
-		abode = TownSystem::instance().FindAbodeWithSpace(town);
+		abode = TownSystem::Instance().FindAbodeWithSpace(town);
 	}
 
 	registry.Assign<Villager>(entity, health, static_cast<uint32_t>(age), hunger, lifeStage, sex, info.tribeType,

--- a/src/ECS/Components/Hand.h
+++ b/src/ECS/Components/Hand.h
@@ -28,7 +28,7 @@ struct Hand
 		Symbol
 	};
 
-	static constexpr entt::id_type meshId = entt::hashed_string("hand");
+	static constexpr entt::id_type k_MeshId = entt::hashed_string("hand");
 
 	bool rightHanded;
 	RenderType renderType;

--- a/src/ECS/Components/LivingAction.h
+++ b/src/ECS/Components/LivingAction.h
@@ -26,7 +26,7 @@ struct LivingAction
 
 		_Count,
 	};
-	static constexpr std::array<std::string_view, static_cast<size_t>(Index::_Count)> IndexStrings = {
+	static constexpr std::array<std::string_view, static_cast<size_t>(Index::_Count)> k_IndexStrings = {
 	    "Top",
 	    "Final",
 	    "Previous",

--- a/src/ECS/Components/Stream.h
+++ b/src/ECS/Components/Stream.h
@@ -47,14 +47,14 @@ struct Stream
 				    return firstDistance < secondDistance;
 			    });
 
-			if (glm::distance(position, element->position) < maxNodeDistance)
+			if (glm::distance(position, element->position) < k_MaxNodeDistance)
 			{
 				edges.push_back(*element);
 			}
 		}
 
 	private:
-		const static auto maxNodeDistance = 100;
+		const static auto k_MaxNodeDistance = 100;
 	};
 
 	Stream::Id id;

--- a/src/ECS/Components/Villager.h
+++ b/src/ECS/Components/Villager.h
@@ -32,7 +32,7 @@ struct Villager
 
 		_COUNT
 	};
-	static constexpr std::array<std::string_view, static_cast<uint8_t>(Task::_COUNT)> TaskStrs = {
+	static constexpr std::array<std::string_view, static_cast<uint8_t>(Task::_COUNT)> k_TaskStrs = {
 	    "IDLE", //
 	};
 
@@ -44,7 +44,7 @@ struct Villager
 
 		_COUNT
 	};
-	static constexpr std::array<std::string_view, static_cast<uint8_t>(Sex::_COUNT)> SexStrs = {
+	static constexpr std::array<std::string_view, static_cast<uint8_t>(Sex::_COUNT)> k_SexStrs = {
 	    "MALE",   //
 	    "FEMALE", //
 	};
@@ -57,7 +57,7 @@ struct Villager
 
 		_COUNT
 	};
-	static constexpr std::array<std::string_view, static_cast<uint8_t>(LifeStage::_COUNT)> LifeStageStrs = {
+	static constexpr std::array<std::string_view, static_cast<uint8_t>(LifeStage::_COUNT)> k_LifeStageStrs = {
 	    "Child", //
 	    "Adult", //
 	};

--- a/src/ECS/Components/WallHug.h
+++ b/src/ECS/Components/WallHug.h
@@ -36,7 +36,7 @@ enum class MoveState
 template <MoveState S>
 struct MoveStateTagComponent
 {
-	static constexpr MoveState value = S;
+	static constexpr MoveState k_Value = S;
 	MoveStateClockwise clockwise;
 	glm::vec2 stepGoal;
 };
@@ -58,7 +58,7 @@ struct WallHug
 {
 	glm::vec2 goal;
 	glm::vec2 step;
-	float y_angle; // FIXME(bwrsandman): member is a little redundant with transform or atan on step could keep or not
+	float yAngle; // FIXME(bwrsandman): member is a little redundant with transform or atan on step could keep or not
 	float speed;
 };
 

--- a/src/ECS/Map.cpp
+++ b/src/ECS/Map.cpp
@@ -27,9 +27,9 @@ using namespace openblack::ecs::components;
 Map::CellId Map::GetGridCell(const glm::vec2& pos)
 {
 	assert(glm::compMin(pos) >= 0);
-	const glm::u32vec2 coords = pos * _positionToGridFactor;
+	const glm::u32vec2 coords = pos * k_PositionToGridFactor;
 	const Map::CellId result(coords.x >> 0x10, coords.y >> 0x10);
-	assert(glm::all(glm::lessThan(result, _gridSize))); // If not, clamp to 0, _gridSize
+	assert(glm::all(glm::lessThan(result, k_GridSize))); // If not, clamp to 0, _gridSize
 	return result;
 }
 
@@ -40,12 +40,12 @@ Map::CellId Map::GetGridCell(const glm::vec3& pos)
 
 glm::vec2 Map::GetCellCenter(const Map::CellId& cellId)
 {
-	return glm::vec2(cellId.x << 0x10, cellId.y << 0x10) / _positionToGridFactor + 5.0f;
+	return glm::vec2(cellId.x << 0x10, cellId.y << 0x10) / k_PositionToGridFactor + 5.0f;
 }
 
 const std::unordered_set<entt::entity>& Map::GetFixedInGridCell(const CellId& cellId) const
 {
-	return _fixedGrid.at(cellId.x + cellId.y * _gridSize.x);
+	return _fixedGrid.at(cellId.x + cellId.y * k_GridSize.x);
 }
 
 const std::unordered_set<entt::entity>& Map::GetFixedInGridCell(const glm::vec3& pos) const
@@ -56,7 +56,7 @@ const std::unordered_set<entt::entity>& Map::GetFixedInGridCell(const glm::vec3&
 
 const std::unordered_set<entt::entity>& Map::GetMobileInGridCell(const CellId& cellId) const
 {
-	return _mobileGrid.at(cellId.x + cellId.y * _gridSize.x);
+	return _mobileGrid.at(cellId.x + cellId.y * k_GridSize.x);
 }
 
 const std::unordered_set<entt::entity>& Map::GetMobileInGridCell(const glm::vec3& pos) const
@@ -85,7 +85,7 @@ void Map::Clear()
 
 void Map::Build()
 {
-	auto& registry = Game::instance()->GetEntityRegistry();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 	registry.Each<const Fixed, const Transform>([this](entt::entity entity, const Fixed& fixed, const Transform& transform) {
 		// TODO(bwrsandman): This is only in the case of a square bb underling the bounding circle (x/z) <= 1.4
 		const float radius = fixed.boundingRadius * glm::compMax(transform.scale) + 1.0f;
@@ -99,7 +99,7 @@ void Map::Build()
 				const auto cellId = Map::CellId(x, y);
 				if (glm::distance2(GetCellCenter(cellId), fixed.boundingCenter) < radius * radius)
 				{
-					auto& cell = _fixedGrid.at(cellId.x + cellId.y * _gridSize.x);
+					auto& cell = _fixedGrid.at(cellId.x + cellId.y * k_GridSize.x);
 					cell.insert(entity);
 				}
 			}
@@ -108,7 +108,7 @@ void Map::Build()
 	registry.Each<const Mobile, const Transform>(
 	    [this](entt::entity entity, [[maybe_unused]] const Mobile& mobile, const Transform& transform) {
 		    const auto cellId = GetGridCell(transform.position);
-		    auto& cell = _mobileGrid.at(cellId.x + cellId.y * _gridSize.x);
+		    auto& cell = _mobileGrid.at(cellId.x + cellId.y * k_GridSize.x);
 		    cell.insert(entity);
 	    });
 }

--- a/src/ECS/Map.h
+++ b/src/ECS/Map.h
@@ -26,8 +26,8 @@ class Map
 public:
 	using CellId = glm::u16vec2;
 
-	static constexpr float _positionToGridFactor = static_cast<float>(0x10000) * 0.1f;
-	static constexpr glm::u16vec2 _gridSize = {0x200, 0x200};
+	static constexpr float k_PositionToGridFactor = static_cast<float>(0x10000) * 0.1f;
+	static constexpr glm::u16vec2 k_GridSize = {0x200, 0x200};
 
 	static CellId GetGridCell(const glm::vec2& pos);
 	static CellId GetGridCell(const glm::vec3& pos);
@@ -44,8 +44,8 @@ private:
 	void Clear();
 	void Build();
 
-	std::array<std::unordered_set<entt::entity>, _gridSize.x * _gridSize.y> _fixedGrid;
-	std::array<std::unordered_set<entt::entity>, _gridSize.x * _gridSize.y> _mobileGrid;
+	std::array<std::unordered_set<entt::entity>, k_GridSize.x * k_GridSize.y> _fixedGrid;
+	std::array<std::unordered_set<entt::entity>, k_GridSize.x * k_GridSize.y> _mobileGrid;
 };
 
 } // namespace openblack::ecs

--- a/src/ECS/Registry.cpp
+++ b/src/ECS/Registry.cpp
@@ -31,6 +31,6 @@ const RegistryContext& Registry::Context() const
 
 void Registry::SetDirty()
 {
-	systems::RenderingSystem::instance().SetDirty();
+	systems::RenderingSystem::Instance().SetDirty();
 }
 } // namespace openblack::ecs

--- a/src/ECS/Systems/CameraBookmarkSystem.cpp
+++ b/src/ECS/Systems/CameraBookmarkSystem.cpp
@@ -19,7 +19,7 @@
 using namespace openblack::ecs::systems;
 using namespace openblack::ecs::components;
 
-CameraBookmarkSystem& CameraBookmarkSystem::instance()
+CameraBookmarkSystem& CameraBookmarkSystem::Instance()
 {
 	static CameraBookmarkSystem* instance = nullptr;
 	if (instance == nullptr)
@@ -39,7 +39,7 @@ bool CameraBookmarkSystem::Initialize()
 
 void CameraBookmarkSystem::Update(const std::chrono::microseconds& dt) const
 {
-	Game::instance()->GetEntityRegistry().Each<CameraBookmark, Transform>(
+	Game::Instance()->GetEntityRegistry().Each<CameraBookmark, Transform>(
 	    [&dt](CameraBookmark& bookmark, Transform& transform) {
 		    std::chrono::duration<float> seconds = dt;
 		    auto t = bookmark.animationTime * 5.0f;
@@ -52,7 +52,7 @@ void CameraBookmarkSystem::SetBookmark(uint8_t index, const glm::vec3& position)
 {
 	if (index < _bookmarks.size())
 	{
-		auto& registry = Game::instance()->GetEntityRegistry();
+		auto& registry = Game::Instance()->GetEntityRegistry();
 		auto entity = _bookmarks.at(index);
 		registry.AssignOrReplace<Transform>(entity, position + glm::vec3(0.0f, 1.0f, 0.0f), glm::mat3(1.0f), glm::vec3(1.0f));
 		auto& bookmark = registry.Get<CameraBookmark>(entity);
@@ -68,7 +68,7 @@ void CameraBookmarkSystem::ClearBookmark(uint8_t index) const
 {
 	if (index < _bookmarks.size())
 	{
-		Game::instance()->GetEntityRegistry().Remove<Transform>(_bookmarks.at(index));
+		Game::Instance()->GetEntityRegistry().Remove<Transform>(_bookmarks.at(index));
 	}
 	else
 	{

--- a/src/ECS/Systems/CameraBookmarkSystem.cpp
+++ b/src/ECS/Systems/CameraBookmarkSystem.cpp
@@ -21,10 +21,10 @@ using namespace openblack::ecs::components;
 
 CameraBookmarkSystem& CameraBookmarkSystem::Instance()
 {
-	static CameraBookmarkSystem* instance = nullptr;
+	static std::unique_ptr<CameraBookmarkSystem> instance = nullptr;
 	if (instance == nullptr)
 	{
-		instance = new CameraBookmarkSystem();
+		instance.reset(new CameraBookmarkSystem());
 	}
 	return *instance;
 }

--- a/src/ECS/Systems/CameraBookmarkSystem.h
+++ b/src/ECS/Systems/CameraBookmarkSystem.h
@@ -21,7 +21,7 @@ namespace openblack::ecs::systems
 class CameraBookmarkSystem
 {
 public:
-	static CameraBookmarkSystem& instance();
+	static CameraBookmarkSystem& Instance();
 	bool Initialize();
 	void Update(const std::chrono::microseconds& dt) const;
 

--- a/src/ECS/Systems/DynamicsSystem.cpp
+++ b/src/ECS/Systems/DynamicsSystem.cpp
@@ -47,9 +47,9 @@ void DynamicsSystem::Reset()
 	std::vector<btRigidBody*> to_remove;
 	for (int i = 0; i < _world->getNumCollisionObjects(); ++i)
 	{
-		auto obj = _world->getCollisionObjectArray()[i];
+		auto* obj = _world->getCollisionObjectArray()[i];
 		btRigidBody* body = btRigidBody::upcast(obj);
-		if (body)
+		if (body != nullptr)
 		{
 			to_remove.push_back(body);
 		}
@@ -117,7 +117,7 @@ void DynamicsSystem::UpdatePhysicsTransforms()
 	});
 }
 
-const std::optional<std::pair<Transform, RigidBodyDetails>>
+std::optional<std::pair<Transform, RigidBodyDetails>>
 DynamicsSystem::RayCastClosestHit(const glm::vec3& origin, const glm::vec3& direction, float t_max) const
 {
 	auto from = btVector3(origin.x, origin.y, origin.z);

--- a/src/ECS/Systems/DynamicsSystem.cpp
+++ b/src/ECS/Systems/DynamicsSystem.cpp
@@ -44,17 +44,17 @@ DynamicsSystem::DynamicsSystem()
 
 void DynamicsSystem::Reset()
 {
-	std::vector<btRigidBody*> to_remove;
+	std::vector<btRigidBody*> toRemove;
 	for (int i = 0; i < _world->getNumCollisionObjects(); ++i)
 	{
 		auto* obj = _world->getCollisionObjectArray()[i];
 		btRigidBody* body = btRigidBody::upcast(obj);
 		if (body != nullptr)
 		{
-			to_remove.push_back(body);
+			toRemove.push_back(body);
 		}
 	}
-	for (auto& obj : to_remove)
+	for (auto& obj : toRemove)
 	{
 		_world->removeRigidBody(obj);
 	}
@@ -75,7 +75,7 @@ void DynamicsSystem::AddRigidBody(btRigidBody* object)
 
 void DynamicsSystem::RegisterRigidBodies()
 {
-	auto& registry = Game::instance()->GetEntityRegistry();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 	registry.Each<RigidBody>([this](RigidBody& body) {
 		body.handle.setUserIndex(static_cast<int>(ecs::systems::RigidBodyType::Entity));
 		body.handle.setUserIndex2(0); // TODO
@@ -99,7 +99,7 @@ void DynamicsSystem::RegisterIslandRigidBodies(LandIsland& island)
 
 void DynamicsSystem::UpdatePhysicsTransforms()
 {
-	auto& registry = Game::instance()->GetEntityRegistry();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 	registry.Each<Transform, const RigidBody>([&registry](Transform& transform, const RigidBody& body) {
 		btTransform trans;
 		body.motionState->getWorldTransform(trans);
@@ -118,10 +118,10 @@ void DynamicsSystem::UpdatePhysicsTransforms()
 }
 
 std::optional<std::pair<Transform, RigidBodyDetails>>
-DynamicsSystem::RayCastClosestHit(const glm::vec3& origin, const glm::vec3& direction, float t_max) const
+DynamicsSystem::RayCastClosestHit(const glm::vec3& origin, const glm::vec3& direction, float tMax) const
 {
 	auto from = btVector3(origin.x, origin.y, origin.z);
-	auto to = from + t_max * btVector3(direction.x, direction.y, direction.z);
+	auto to = from + tMax * btVector3(direction.x, direction.y, direction.z);
 
 	btCollisionWorld::ClosestRayResultCallback callback(from, to);
 

--- a/src/ECS/Systems/DynamicsSystem.h
+++ b/src/ECS/Systems/DynamicsSystem.h
@@ -60,7 +60,7 @@ public:
 	void RegisterIslandRigidBodies(LandIsland& island);
 	void UpdatePhysicsTransforms();
 	[[nodiscard]] std::optional<std::pair<ecs::components::Transform, RigidBodyDetails>>
-	RayCastClosestHit(const glm::vec3& origin, const glm::vec3& direction, float t_max) const;
+	RayCastClosestHit(const glm::vec3& origin, const glm::vec3& direction, float tMax) const;
 
 private:
 	/// collision configuration contains default setup for memory, collision setup

--- a/src/ECS/Systems/DynamicsSystem.h
+++ b/src/ECS/Systems/DynamicsSystem.h
@@ -59,7 +59,7 @@ public:
 	void RegisterRigidBodies();
 	void RegisterIslandRigidBodies(LandIsland& island);
 	void UpdatePhysicsTransforms();
-	[[nodiscard]] const std::optional<std::pair<ecs::components::Transform, RigidBodyDetails>>
+	[[nodiscard]] std::optional<std::pair<ecs::components::Transform, RigidBodyDetails>>
 	RayCastClosestHit(const glm::vec3& origin, const glm::vec3& direction, float t_max) const;
 
 private:

--- a/src/ECS/Systems/LivingActionSystem.cpp
+++ b/src/ECS/Systems/LivingActionSystem.cpp
@@ -24,7 +24,7 @@ using namespace openblack::ecs::systems;
 uint32_t VillagerInvalidState(LivingAction& action)
 {
 	SPDLOG_LOGGER_ERROR(spdlog::get("ai"), "Villager #{}: Stuck in an invalid state",
-	                    static_cast<uint32_t>(Game::instance()->GetEntityRegistry().ToEntity(action)));
+	                    static_cast<uint32_t>(Game::Instance()->GetEntityRegistry().ToEntity(action)));
 	assert(false);
 	return 0;
 }
@@ -37,7 +37,7 @@ uint32_t VillagerCreated(LivingAction& action)
 	}
 	else
 	{
-		LivingActionSystem::instance().VillagerSetState(action, LivingAction::Index::Top, VillagerStates::DecideWhatToDo,
+		LivingActionSystem::Instance().VillagerSetState(action, LivingAction::Index::Top, VillagerStates::DecideWhatToDo,
 		                                                false);
 	}
 	return 0;
@@ -50,341 +50,341 @@ struct VillagerStateTableEntry
 	std::function<bool(LivingAction&)> exitState = nullptr;
 	std::function<bool(LivingAction&)> saveState = nullptr;
 	std::function<bool(LivingAction&)> loadState = nullptr;
-	std::function<bool(LivingAction&)> field_0x50 = nullptr;
-	std::function<bool(LivingAction&)> field_0x60 = nullptr;
+	std::function<bool(LivingAction&)> field0x50 = nullptr;
+	std::function<bool(LivingAction&)> field0x60 = nullptr;
 	std::function<int(LivingAction&)> transitionAnimation = nullptr;
 	std::function<bool(LivingAction&)> validate = nullptr;
 };
 
-static VillagerStateTableEntry TodoEntry = {
+static const VillagerStateTableEntry k_TodoEntry = {
     .state = [](LivingAction& action) -> uint32_t {
 	    SPDLOG_LOGGER_WARN(spdlog::get("ai"), "Villager #{}: TODO: Unimplemented state function: {}",
-	                       static_cast<uint32_t>(Game::instance()->GetEntityRegistry().ToEntity(action)),
-	                       VillagerStateStrings.at(static_cast<size_t>(
-	                           LivingActionSystem::instance().VillagerGetState(action, LivingAction::Index::Top))));
+	                       static_cast<uint32_t>(Game::Instance()->GetEntityRegistry().ToEntity(action)),
+	                       k_VillagerStateStrings.at(static_cast<size_t>(
+	                           LivingActionSystem::Instance().VillagerGetState(action, LivingAction::Index::Top))));
 	    return 0;
     },
     .entryState = [](LivingAction& action, VillagerStates src, VillagerStates dst) -> bool {
 	    SPDLOG_LOGGER_WARN(spdlog::get("ai"), "Villager #{}: TODO: Unimplemented entry state function ({} -> {})",
-	                       static_cast<uint32_t>(Game::instance()->GetEntityRegistry().ToEntity(action)),
-	                       VillagerStateStrings.at(static_cast<size_t>(src)),
-	                       VillagerStateStrings.at(static_cast<size_t>(dst)));
+	                       static_cast<uint32_t>(Game::Instance()->GetEntityRegistry().ToEntity(action)),
+	                       k_VillagerStateStrings.at(static_cast<size_t>(src)),
+	                       k_VillagerStateStrings.at(static_cast<size_t>(dst)));
 	    return false;
     },
     .exitState = [](LivingAction& action) -> bool {
 	    SPDLOG_LOGGER_WARN(spdlog::get("ai"), "Villager #{}: TODO: Unimplemented exit state function)",
-	                       static_cast<uint32_t>(Game::instance()->GetEntityRegistry().ToEntity(action)));
+	                       static_cast<uint32_t>(Game::Instance()->GetEntityRegistry().ToEntity(action)));
 	    return false;
     },
     .saveState = [](LivingAction& action) -> bool {
 	    SPDLOG_LOGGER_WARN(spdlog::get("ai"), "Villager #{}: TODO: Unimplemented save state function: {}",
-	                       static_cast<uint32_t>(Game::instance()->GetEntityRegistry().ToEntity(action)),
-	                       VillagerStateStrings.at(static_cast<size_t>(
-	                           LivingActionSystem::instance().VillagerGetState(action, LivingAction::Index::Top))));
+	                       static_cast<uint32_t>(Game::Instance()->GetEntityRegistry().ToEntity(action)),
+	                       k_VillagerStateStrings.at(static_cast<size_t>(
+	                           LivingActionSystem::Instance().VillagerGetState(action, LivingAction::Index::Top))));
 	    return false;
     },
     .loadState = [](LivingAction& action) -> bool {
 	    SPDLOG_LOGGER_WARN(spdlog::get("ai"), "Villager #{}: TODO: Unimplemented load state function: {}",
-	                       static_cast<uint32_t>(Game::instance()->GetEntityRegistry().ToEntity(action)),
-	                       VillagerStateStrings.at(static_cast<size_t>(
-	                           LivingActionSystem::instance().VillagerGetState(action, LivingAction::Index::Top))));
+	                       static_cast<uint32_t>(Game::Instance()->GetEntityRegistry().ToEntity(action)),
+	                       k_VillagerStateStrings.at(static_cast<size_t>(
+	                           LivingActionSystem::Instance().VillagerGetState(action, LivingAction::Index::Top))));
 	    return false;
     },
-    .field_0x50 = [](LivingAction& action) -> bool {
-	    SPDLOG_LOGGER_WARN(spdlog::get("ai"), "Villager #{}: TODO: Unimplemented field_0x50 state function: {}",
-	                       static_cast<uint32_t>(Game::instance()->GetEntityRegistry().ToEntity(action)),
-	                       VillagerStateStrings.at(static_cast<size_t>(
-	                           LivingActionSystem::instance().VillagerGetState(action, LivingAction::Index::Top))));
+    .field0x50 = [](LivingAction& action) -> bool {
+	    SPDLOG_LOGGER_WARN(spdlog::get("ai"), "Villager #{}: TODO: Unimplemented field0x50 state function: {}",
+	                       static_cast<uint32_t>(Game::Instance()->GetEntityRegistry().ToEntity(action)),
+	                       k_VillagerStateStrings.at(static_cast<size_t>(
+	                           LivingActionSystem::Instance().VillagerGetState(action, LivingAction::Index::Top))));
 	    return false;
     },
-    .field_0x60 = [](LivingAction& action) -> bool {
-	    SPDLOG_LOGGER_WARN(spdlog::get("ai"), "Villager #{}: TODO: Unimplemented field_0x60 state function: {}",
-	                       static_cast<uint32_t>(Game::instance()->GetEntityRegistry().ToEntity(action)),
-	                       VillagerStateStrings.at(static_cast<size_t>(
-	                           LivingActionSystem::instance().VillagerGetState(action, LivingAction::Index::Top))));
+    .field0x60 = [](LivingAction& action) -> bool {
+	    SPDLOG_LOGGER_WARN(spdlog::get("ai"), "Villager #{}: TODO: Unimplemented field0x60 state function: {}",
+	                       static_cast<uint32_t>(Game::Instance()->GetEntityRegistry().ToEntity(action)),
+	                       k_VillagerStateStrings.at(static_cast<size_t>(
+	                           LivingActionSystem::Instance().VillagerGetState(action, LivingAction::Index::Top))));
 	    return false;
     },
     .transitionAnimation = [](LivingAction& action) -> int {
 	    SPDLOG_LOGGER_WARN(spdlog::get("ai"), "Villager #{}: TODO: Unimplemented transition animation function: {}",
-	                       static_cast<uint32_t>(Game::instance()->GetEntityRegistry().ToEntity(action)),
-	                       VillagerStateStrings.at(static_cast<size_t>(
-	                           LivingActionSystem::instance().VillagerGetState(action, LivingAction::Index::Top))));
+	                       static_cast<uint32_t>(Game::Instance()->GetEntityRegistry().ToEntity(action)),
+	                       k_VillagerStateStrings.at(static_cast<size_t>(
+	                           LivingActionSystem::Instance().VillagerGetState(action, LivingAction::Index::Top))));
 	    return -1;
     },
     .validate = [](LivingAction& action) -> bool {
 	    SPDLOG_LOGGER_WARN(spdlog::get("ai"), "Villager #{}: TODO: Unimplemented validate function: {}",
-	                       static_cast<uint32_t>(Game::instance()->GetEntityRegistry().ToEntity(action)),
-	                       VillagerStateStrings.at(static_cast<size_t>(
-	                           LivingActionSystem::instance().VillagerGetState(action, LivingAction::Index::Top))));
+	                       static_cast<uint32_t>(Game::Instance()->GetEntityRegistry().ToEntity(action)),
+	                       k_VillagerStateStrings.at(static_cast<size_t>(
+	                           LivingActionSystem::Instance().VillagerGetState(action, LivingAction::Index::Top))));
 	    return false;
     },
 };
 
-std::array<VillagerStateTableEntry, static_cast<size_t>(VillagerStates::_COUNT)> VillagerStateTable = {
+const static std::array<VillagerStateTableEntry, static_cast<size_t>(VillagerStates::_COUNT)> k_VillagerStateTable = {
     /* INVALID_STATE */ VillagerStateTableEntry {
         .state = &VillagerInvalidState,
     },
-    /* MOVE_TO_POS */ TodoEntry,
-    /* MOVE_TO_OBJECT */ TodoEntry,
-    /* MOVE_ON_STRUCTURE */ TodoEntry,
-    /* IN_SCRIPT */ TodoEntry,
-    /* IN_DANCE */ TodoEntry,
-    /* FLEEING_FROM_OBJECT_REACTION */ TodoEntry,
-    /* LOOKING_AT_OBJECT_REACTION */ TodoEntry,
-    /* FOLLOWING_OBJECT_REACTION */ TodoEntry,
-    /* INSPECT_OBJECT_REACTION */ TodoEntry,
-    /* FLYING */ TodoEntry,
-    /* LANDED */ TodoEntry,
-    /* LOOK_AT_FLYING_OBJECT_REACTION */ TodoEntry,
-    /* SET_DYING */ TodoEntry,
-    /* DYING */ TodoEntry,
-    /* DEAD */ TodoEntry,
-    /* DROWNING */ TodoEntry,
-    /* DOWNED */ TodoEntry,
-    /* BEING_EATEN */ TodoEntry,
-    /* GOTO_FOOD_REACTION */ TodoEntry,
-    /* ARRIVES_AT_FOOD_REACTION */ TodoEntry,
-    /* GOTO_WOOD_REACTION */ TodoEntry,
-    /* ARRIVES_AT_WOOD_REACTION */ TodoEntry,
-    /* WAIT_FOR_ANIMATION */ TodoEntry,
-    /* IN_HAND */ TodoEntry,
-    /* GOTO_PICKUP_BALL_REACTION */ TodoEntry,
-    /* ARRIVES_AT_PICKUP_BALL_REACTION */ TodoEntry,
-    /* MOVE_IN_FLOCK */ TodoEntry,
-    /* MOVE_ALONG_PATH */ TodoEntry,
-    /* MOVE_ON_PATH */ TodoEntry,
-    /* FLEEING_AND_LOOKING_AT_OBJECT_REACTION */ TodoEntry,
-    /* GOTO_STORAGE_PIT_FOR_DROP_OFF */ TodoEntry,
-    /* ARRIVES_AT_STORAGE_PIT_FOR_DROP_OFF */ TodoEntry,
-    /* GOTO_STORAGE_PIT_FOR_FOOD */ TodoEntry,
-    /* ARRIVES_AT_STORAGE_PIT_FOR_FOOD */ TodoEntry,
-    /* ARRIVES_AT_HOME_WITH_FOOD */ TodoEntry,
-    /* GO_HOME */ TodoEntry,
-    /* ARRIVES_HOME */ TodoEntry,
-    /* AT_HOME */ TodoEntry,
-    /* ARRIVES_AT_STORAGE_PIT_FOR_BUILDING_MATERIALS */ TodoEntry,
-    /* ARRIVES_AT_BUILDING_SITE */ TodoEntry,
-    /* BUILDING */ TodoEntry,
-    /* GOTO_STORAGE_PIT_FOR_WORSHIP_SUPPLIES */ TodoEntry,
-    /* ARRIVES_AT_STORAGE_PIT_FOR_WORSHIP_SUPPLIES */ TodoEntry,
-    /* GOTO_WORSHIP_SITE_WITH_SUPPLIES */ TodoEntry,
-    /* MOVE_TO_WORSHIP_SITE_WITH_SUPPLIES */ TodoEntry,
-    /* ARRIVES_AT_WORSHIP_SITE_WITH_SUPPLIES */ TodoEntry,
-    /* FORESTER_MOVE_TO_FOREST */ TodoEntry,
-    /* FORESTER_GOTO_FOREST */ TodoEntry,
-    /* FORESTER_ARRIVES_AT_FOREST */ TodoEntry,
-    /* FORESTER_CHOPS_TREE */ TodoEntry,
-    /* FORESTER_CHOPS_TREE_FOR_BUILDING */ TodoEntry,
-    /* FORESTER_FINISHED_FORESTERING */ TodoEntry,
-    /* ARRIVES_AT_BIG_FOREST */ TodoEntry,
-    /* ARRIVES_AT_BIG_FOREST_FOR_BUILDING */ TodoEntry,
-    /* FISHERMAN_ARRIVES_AT_FISHING */ TodoEntry,
-    /* FISHING */ TodoEntry,
-    /* WAIT_FOR_COUNTER */ TodoEntry,
-    /* GOTO_WORSHIP_SITE_FOR_WORSHIP */ TodoEntry,
-    /* ARRIVES_AT_WORSHIP_SITE_FOR_WORSHIP */ TodoEntry,
-    /* WORSHIPPING_AT_WORSHIP_SITE */ TodoEntry,
-    /* GOTO_ALTAR_FOR_REST */ TodoEntry,
-    /* ARRIVES_AT_ALTAR_FOR_REST */ TodoEntry,
-    /* AT_ALTAR_REST */ TodoEntry,
-    /* AT_ALTAR_FINISHED_REST */ TodoEntry,
-    /* RESTART_WORSHIPPING_AT_WORSHIP_SITE */ TodoEntry,
-    /* RESTART_WORSHIPPING_CREATURE */ TodoEntry,
-    /* FARMER_ARRIVES_AT_FARM */ TodoEntry,
-    /* FARMER_PLANTS_CROP */ TodoEntry,
-    /* FARMER_DIGS_UP_CROP */ TodoEntry,
-    /* MOVE_TO_FOOTBALL_PITCH_CONSTRUCTION */ TodoEntry,
-    /* FOOTBALL_WALK_TO_POSITION */ TodoEntry,
-    /* FOOTBALL_WAIT_FOR_KICK_OFF */ TodoEntry,
-    /* FOOTBALL_ATTACKER */ TodoEntry,
-    /* FOOTBALL_GOALIE */ TodoEntry,
-    /* FOOTBALL_DEFENDER */ TodoEntry,
-    /* FOOTBALL_WON_GOAL */ TodoEntry,
-    /* FOOTBALL_LOST_GOAL */ TodoEntry,
-    /* START_MOVE_TO_PICK_UP_BALL_FOR_DEAD_BALL */ TodoEntry,
-    /* ARRIVED_AT_PICK_UP_BALL_FOR_DEAD_BALL */ TodoEntry,
-    /* ARRIVED_AT_PUT_DOWN_BALL_FOR_DEAD_BALL_START */ TodoEntry,
-    /* ARRIVED_AT_PUT_DOWN_BALL_FOR_DEAD_BALL_END */ TodoEntry,
-    /* FOOTBALL_MATCH_PAUSED */ TodoEntry,
-    /* FOOTBALL_WATCH_MATCH */ TodoEntry,
-    /* FOOTBALL_MEXICAN_WAVE */ TodoEntry,
+    /* MOVE_TO_POS */ k_TodoEntry,
+    /* MOVE_TO_OBJECT */ k_TodoEntry,
+    /* MOVE_ON_STRUCTURE */ k_TodoEntry,
+    /* IN_SCRIPT */ k_TodoEntry,
+    /* IN_DANCE */ k_TodoEntry,
+    /* FLEEING_FROM_OBJECT_REACTION */ k_TodoEntry,
+    /* LOOKING_AT_OBJECT_REACTION */ k_TodoEntry,
+    /* FOLLOWING_OBJECT_REACTION */ k_TodoEntry,
+    /* INSPECT_OBJECT_REACTION */ k_TodoEntry,
+    /* FLYING */ k_TodoEntry,
+    /* LANDED */ k_TodoEntry,
+    /* LOOK_AT_FLYING_OBJECT_REACTION */ k_TodoEntry,
+    /* SET_DYING */ k_TodoEntry,
+    /* DYING */ k_TodoEntry,
+    /* DEAD */ k_TodoEntry,
+    /* DROWNING */ k_TodoEntry,
+    /* DOWNED */ k_TodoEntry,
+    /* BEING_EATEN */ k_TodoEntry,
+    /* GOTO_FOOD_REACTION */ k_TodoEntry,
+    /* ARRIVES_AT_FOOD_REACTION */ k_TodoEntry,
+    /* GOTO_WOOD_REACTION */ k_TodoEntry,
+    /* ARRIVES_AT_WOOD_REACTION */ k_TodoEntry,
+    /* WAIT_FOR_ANIMATION */ k_TodoEntry,
+    /* IN_HAND */ k_TodoEntry,
+    /* GOTO_PICKUP_BALL_REACTION */ k_TodoEntry,
+    /* ARRIVES_AT_PICKUP_BALL_REACTION */ k_TodoEntry,
+    /* MOVE_IN_FLOCK */ k_TodoEntry,
+    /* MOVE_ALONG_PATH */ k_TodoEntry,
+    /* MOVE_ON_PATH */ k_TodoEntry,
+    /* FLEEING_AND_LOOKING_AT_OBJECT_REACTION */ k_TodoEntry,
+    /* GOTO_STORAGE_PIT_FOR_DROP_OFF */ k_TodoEntry,
+    /* ARRIVES_AT_STORAGE_PIT_FOR_DROP_OFF */ k_TodoEntry,
+    /* GOTO_STORAGE_PIT_FOR_FOOD */ k_TodoEntry,
+    /* ARRIVES_AT_STORAGE_PIT_FOR_FOOD */ k_TodoEntry,
+    /* ARRIVES_AT_HOME_WITH_FOOD */ k_TodoEntry,
+    /* GO_HOME */ k_TodoEntry,
+    /* ARRIVES_HOME */ k_TodoEntry,
+    /* AT_HOME */ k_TodoEntry,
+    /* ARRIVES_AT_STORAGE_PIT_FOR_BUILDING_MATERIALS */ k_TodoEntry,
+    /* ARRIVES_AT_BUILDING_SITE */ k_TodoEntry,
+    /* BUILDING */ k_TodoEntry,
+    /* GOTO_STORAGE_PIT_FOR_WORSHIP_SUPPLIES */ k_TodoEntry,
+    /* ARRIVES_AT_STORAGE_PIT_FOR_WORSHIP_SUPPLIES */ k_TodoEntry,
+    /* GOTO_WORSHIP_SITE_WITH_SUPPLIES */ k_TodoEntry,
+    /* MOVE_TO_WORSHIP_SITE_WITH_SUPPLIES */ k_TodoEntry,
+    /* ARRIVES_AT_WORSHIP_SITE_WITH_SUPPLIES */ k_TodoEntry,
+    /* FORESTER_MOVE_TO_FOREST */ k_TodoEntry,
+    /* FORESTER_GOTO_FOREST */ k_TodoEntry,
+    /* FORESTER_ARRIVES_AT_FOREST */ k_TodoEntry,
+    /* FORESTER_CHOPS_TREE */ k_TodoEntry,
+    /* FORESTER_CHOPS_TREE_FOR_BUILDING */ k_TodoEntry,
+    /* FORESTER_FINISHED_FORESTERING */ k_TodoEntry,
+    /* ARRIVES_AT_BIG_FOREST */ k_TodoEntry,
+    /* ARRIVES_AT_BIG_FOREST_FOR_BUILDING */ k_TodoEntry,
+    /* FISHERMAN_ARRIVES_AT_FISHING */ k_TodoEntry,
+    /* FISHING */ k_TodoEntry,
+    /* WAIT_FOR_COUNTER */ k_TodoEntry,
+    /* GOTO_WORSHIP_SITE_FOR_WORSHIP */ k_TodoEntry,
+    /* ARRIVES_AT_WORSHIP_SITE_FOR_WORSHIP */ k_TodoEntry,
+    /* WORSHIPPING_AT_WORSHIP_SITE */ k_TodoEntry,
+    /* GOTO_ALTAR_FOR_REST */ k_TodoEntry,
+    /* ARRIVES_AT_ALTAR_FOR_REST */ k_TodoEntry,
+    /* AT_ALTAR_REST */ k_TodoEntry,
+    /* AT_ALTAR_FINISHED_REST */ k_TodoEntry,
+    /* RESTART_WORSHIPPING_AT_WORSHIP_SITE */ k_TodoEntry,
+    /* RESTART_WORSHIPPING_CREATURE */ k_TodoEntry,
+    /* FARMER_ARRIVES_AT_FARM */ k_TodoEntry,
+    /* FARMER_PLANTS_CROP */ k_TodoEntry,
+    /* FARMER_DIGS_UP_CROP */ k_TodoEntry,
+    /* MOVE_TO_FOOTBALL_PITCH_CONSTRUCTION */ k_TodoEntry,
+    /* FOOTBALL_WALK_TO_POSITION */ k_TodoEntry,
+    /* FOOTBALL_WAIT_FOR_KICK_OFF */ k_TodoEntry,
+    /* FOOTBALL_ATTACKER */ k_TodoEntry,
+    /* FOOTBALL_GOALIE */ k_TodoEntry,
+    /* FOOTBALL_DEFENDER */ k_TodoEntry,
+    /* FOOTBALL_WON_GOAL */ k_TodoEntry,
+    /* FOOTBALL_LOST_GOAL */ k_TodoEntry,
+    /* START_MOVE_TO_PICK_UP_BALL_FOR_DEAD_BALL */ k_TodoEntry,
+    /* ARRIVED_AT_PICK_UP_BALL_FOR_DEAD_BALL */ k_TodoEntry,
+    /* ARRIVED_AT_PUT_DOWN_BALL_FOR_DEAD_BALL_START */ k_TodoEntry,
+    /* ARRIVED_AT_PUT_DOWN_BALL_FOR_DEAD_BALL_END */ k_TodoEntry,
+    /* FOOTBALL_MATCH_PAUSED */ k_TodoEntry,
+    /* FOOTBALL_WATCH_MATCH */ k_TodoEntry,
+    /* FOOTBALL_MEXICAN_WAVE */ k_TodoEntry,
     /* CREATED */
     VillagerStateTableEntry {
         .state = &VillagerCreated,
-        .field_0x50 = TodoEntry.field_0x50,
+        .field0x50 = k_TodoEntry.field0x50,
     },
-    /* ARRIVES_IN_ABODE_TO_TRADE */ TodoEntry,
-    /* ARRIVES_IN_ABODE_TO_PICK_UP_EXCESS */ TodoEntry,
-    /* MAKE_SCARED_STIFF */ TodoEntry,
-    /* SCARED_STIFF */ TodoEntry,
-    /* WORSHIPPING_CREATURE */ TodoEntry,
-    /* SHEPHERD_LOOK_FOR_FLOCK */ TodoEntry,
-    /* SHEPHERD_MOVE_FLOCK_TO_WATER */ TodoEntry,
-    /* SHEPHERD_MOVE_FLOCK_TO_FOOD */ TodoEntry,
-    /* SHEPHERD_MOVE_FLOCK_BACK */ TodoEntry,
-    /* SHEPHERD_DECIDE_WHAT_TO_DO_WITH_FLOCK */ TodoEntry,
-    /* SHEPHERD_WAIT_FOR_FLOCK */ TodoEntry,
-    /* SHEPHERD_SLAUGHTER_ANIMAL */ TodoEntry,
-    /* SHEPHERD_FETCH_STRAY */ TodoEntry,
-    /* SHEPHERD_GOTO_FLOCK */ TodoEntry,
-    /* HOUSEWIFE_AT_HOME */ TodoEntry,
-    /* HOUSEWIFE_GOTO_STORAGE_PIT */ TodoEntry,
-    /* HOUSEWIFE_ARRIVES_AT_STORAGE_PIT */ TodoEntry,
-    /* HOUSEWIFE_PICKUP_FROM_STORAGE_PIT */ TodoEntry,
-    /* HOUSEWIFE_RETURN_HOME_WITH_FOOD */ TodoEntry,
-    /* HOUSEWIFE_MAKE_DINNER */ TodoEntry,
-    /* HOUSEWIFE_SERVES_DINNER */ TodoEntry,
-    /* HOUSEWIFE_CLEARS_AWAY_DINNER */ TodoEntry,
-    /* HOUSEWIFE_DOES_HOUSEWORK */ TodoEntry,
-    /* HOUSEWIFE_GOSSIPS_AROUND_STORAGE_PIT */ TodoEntry,
-    /* HOUSEWIFE_STARTS_GIVING_BIRTH */ TodoEntry,
-    /* HOUSEWIFE_GIVING_BIRTH */ TodoEntry,
-    /* HOUSEWIFE_GIVEN_BIRTH */ TodoEntry,
-    /* CHILD_AT_CRECHE */ TodoEntry,
-    /* CHILD_FOLLOWS_MOTHER */ TodoEntry,
-    /* CHILD_BECOMES_ADULT */ TodoEntry,
-    /* SITS_DOWN_TO_DINNER */ TodoEntry,
-    /* EAT_FOOD */ TodoEntry,
-    /* EAT_FOOD_AT_HOME */ TodoEntry,
-    /* GOTO_BED_AT_HOME */ TodoEntry,
-    /* SLEEPING_AT_HOME */ TodoEntry,
-    /* WAKE_UP_AT_HOME */ TodoEntry,
-    /* START_HAVING_SEX */ TodoEntry,
-    /* HAVING_SEX */ TodoEntry,
-    /* STOP_HAVING_SEX */ TodoEntry,
-    /* START_HAVING_SEX_AT_HOME */ TodoEntry,
-    /* HAVING_SEX_AT_HOME */ TodoEntry,
-    /* STOP_HAVING_SEX_AT_HOME */ TodoEntry,
-    /* WAIT_FOR_DINNER */ TodoEntry,
-    /* HOMELESS_START */ TodoEntry,
-    /* VAGRANT_START */ TodoEntry,
-    /* MORN_DEATH */ TodoEntry,
-    /* PERFORM_INSPECTION_REACTION */ TodoEntry,
-    /* APPROACH_OBJECT_REACTION */ TodoEntry,
-    /* INITIALISE_TELL_OTHERS_ABOUT_OBJECT */ TodoEntry,
-    /* TELL_OTHERS_ABOUT_INTERESTING_OBJECT */ TodoEntry,
-    /* APPROACH_VILLAGER_TO_TALK_TO */ TodoEntry,
-    /* TELL_PARTICULAR_VILLAGER_ABOUT_OBJECT */ TodoEntry,
-    /* INITIALISE_LOOK_AROUND_FOR_VILLAGER_TO_TELL */ TodoEntry,
-    /* LOOK_AROUND_FOR_VILLAGER_TO_TELL */ TodoEntry,
-    /* MOVE_TOWARDS_OBJECT_TO_LOOK_AT */ TodoEntry,
-    /* INITIALISE_IMPRESSED_REACTION */ TodoEntry,
-    /* PERFORM_IMPRESSED_REACTION */ TodoEntry,
-    /* INITIALISE_FIGHT_REACTION */ TodoEntry,
-    /* PERFORM_FIGHT_REACTION */ TodoEntry,
-    /* HOMELESS_EAT_DINNER */ TodoEntry,
-    /* INSPECT_CREATURE_REACTION */ TodoEntry,
-    /* PERFORM_INSPECT_CREATURE_REACTION */ TodoEntry,
-    /* APPROACH_CREATURE_REACTION */ TodoEntry,
-    /* INITIALISE_BEWILDERED_BY_MAGIC_TREE_REACTION */ TodoEntry,
-    /* PERFORM_BEWILDERED_BY_MAGIC_TREE_REACTION */ TodoEntry,
-    /* TURN_TO_FACE_MAGIC_TREE */ TodoEntry,
-    /* LOOK_AT_MAGIC_TREE */ TodoEntry,
-    /* DANCE_FOR_EDITING_PURPOSES */ TodoEntry,
-    /* MOVE_TO_DANCE_POS */ TodoEntry,
-    /* INITIALISE_RESPECT_CREATURE_REACTION */ TodoEntry,
-    /* PERFORM_RESPECT_CREATURE_REACTION */ TodoEntry,
-    /* FINISH_RESPECT_CREATURE_REACTION */ TodoEntry,
-    /* APPROACH_HAND_REACTION */ TodoEntry,
-    /* FLEEING_FROM_CREATURE_REACTION */ TodoEntry,
-    /* TURN_TO_FACE_CREATURE_REACTION */ TodoEntry,
-    /* WATCH_FLYING_OBJECT_REACTION */ TodoEntry,
-    /* POINT_AT_FLYING_OBJECT_REACTION */ TodoEntry,
-    /* DECIDE_WHAT_TO_DO */ TodoEntry,
-    /* INTERACT_DECIDE_WHAT_TO_DO */ TodoEntry,
-    /* EAT_OUTSIDE */ TodoEntry,
-    /* RUN_AWAY_FROM_OBJECT_REACTION */ TodoEntry,
-    /* MOVE_TOWARDS_CREATURE_REACTION */ TodoEntry,
-    /* AMAZED_BY_MAGIC_SHIELD_REACTION */ TodoEntry,
-    /* VILLAGER_GOSSIPS */ TodoEntry,
-    /* CHECK_INTERACT_WITH_ANIMAL */ TodoEntry,
-    /* CHECK_INTERACT_WITH_WORSHIP_SITE */ TodoEntry,
-    /* CHECK_INTERACT_WITH_ABODE */ TodoEntry,
-    /* CHECK_INTERACT_WITH_FIELD */ TodoEntry,
-    /* CHECK_INTERACT_WITH_FISH_FARM */ TodoEntry,
-    /* CHECK_INTERACT_WITH_TREE */ TodoEntry,
-    /* CHECK_INTERACT_WITH_BALL */ TodoEntry,
-    /* CHECK_INTERACT_WITH_POT */ TodoEntry,
-    /* CHECK_INTERACT_WITH_FOOTBALL */ TodoEntry,
-    /* CHECK_INTERACT_WITH_VILLAGER */ TodoEntry,
-    /* CHECK_INTERACT_WITH_MAGIC_LIVING */ TodoEntry,
-    /* CHECK_INTERACT_WITH_ROCK */ TodoEntry,
-    /* ARRIVES_AT_ROCK_FOR_WOOD */ TodoEntry,
-    /* GOT_WOOD_FROM_ROCK */ TodoEntry,
-    /* REENTER_BUILDING_STATE */ TodoEntry,
-    /* ARRIVE_AT_PUSH_OBJECT */ TodoEntry,
-    /* TAKE_WOOD_FROM_TREE */ TodoEntry,
-    /* TAKE_WOOD_FROM_POT */ TodoEntry,
-    /* TAKE_WOOD_FROM_TREE_FOR_BUILDING */ TodoEntry,
-    /* TAKE_WOOD_FROM_POT_FOR_BUILDING */ TodoEntry,
-    /* SHEPHERD_TAKE_ANIMAL_FOR_SLAUGHTER */ TodoEntry,
-    /* SHEPHERD_TAKES_CONTROL_OF_FLOCK */ TodoEntry,
-    /* SHEPHERD_RELEASES_CONTROL_OF_FLOCK */ TodoEntry,
-    /* DANCE_BUT_NOT_WORSHIP */ TodoEntry,
-    /* FAINTING_REACTION */ TodoEntry,
-    /* START_CONFUSED_REACTION */ TodoEntry,
-    /* CONFUSED_REACTION */ TodoEntry,
-    /* AFTER_TAP_ON_ABODE */ TodoEntry,
-    /* WEAK_ON_GROUND */ TodoEntry,
-    /* SCRIPT_WANDER_AROUND_POSITION */ TodoEntry,
-    /* SCRIPT_PLAY_ANIM */ TodoEntry,
-    /* GO_TOWARDS_TELEPORT_REACTION */ TodoEntry,
-    /* TELEPORT_REACTION */ TodoEntry,
-    /* DANCE_WHILE_REACTING */ TodoEntry,
-    /* CONTROLLED_BY_CREATURE */ TodoEntry,
-    /* POINT_AT_DEAD_PERSON */ TodoEntry,
-    /* GO_TOWARDS_DEAD_PERSON */ TodoEntry,
-    /* LOOK_AT_DEAD_PERSON */ TodoEntry,
-    /* MOURN_DEAD_PERSON */ TodoEntry,
-    /* NOTHING_TO_DO */ TodoEntry,
-    /* ARRIVES_AT_WORKSHOP_FOR_DROP_OFF */ TodoEntry,
-    /* ARRIVES_AT_STORAGE_PIT_FOR_WORKSHOP_MATERIALS */ TodoEntry,
-    /* SHOW_POISONED */ TodoEntry,
-    /* HIDING_AT_WORSHIP_SITE */ TodoEntry,
-    /* CROWD_REACTION */ TodoEntry,
-    /* REACT_TO_FIRE */ TodoEntry,
-    /* PUT_OUT_FIRE_BY_BEATING */ TodoEntry,
-    /* PUT_OUT_FIRE_WITH_WATER */ TodoEntry,
-    /* GET_WATER_TO_PUT_OUT_FIRE */ TodoEntry,
-    /* ON_FIRE */ TodoEntry,
-    /* MOVE_AROUND_FIRE */ TodoEntry,
-    /* DISCIPLE_NOTHING_TO_DO */ TodoEntry,
-    /* FOOTBALL_MOVE_TO_BALL */ TodoEntry,
-    /* ARRIVES_AT_STORAGE_PIT_FOR_TRADER_PICK_UP */ TodoEntry,
-    /* ARRIVES_AT_STORAGE_PIT_FOR_TRADER_DROP_OFF */ TodoEntry,
-    /* BREEDER_DISCIPLE */ TodoEntry,
-    /* MISSIONARY_DISCIPLE */ TodoEntry,
-    /* REACT_TO_BREEDER */ TodoEntry,
-    /* SHEPHERD_CHECK_ANIMAL_FOR_SLAUGHTER */ TodoEntry,
-    /* INTERACT_DECIDE_WHAT_TO_DO_FOR_OTHER_VILLAGER */ TodoEntry,
-    /* ARTIFACT_DANCE */ TodoEntry,
-    /* FLEEING_FROM_PREDATOR_REACTION */ TodoEntry,
-    /* WAIT_FOR_WOOD */ TodoEntry,
-    /* INSPECT_OBJECT */ TodoEntry,
-    /* GO_HOME_AND_CHANGE */ TodoEntry,
-    /* WAIT_FOR_MATE */ TodoEntry,
-    /* GO_AND_HIDE_IN_NEARBY_BUILDING */ TodoEntry,
-    /* LOOK_TO_SEE_IF_IT_IS_SAFE */ TodoEntry,
-    /* SLEEP_IN_TENT */ TodoEntry,
-    /* PAUSE_FOR_A_SECOND */ TodoEntry,
-    /* PANIC_REACTION */ TodoEntry,
-    /* GET_FOOD_AT_WORSHIP_SITE */ TodoEntry,
-    /* GOTO_CONGREGATE_IN_TOWN_AFTER_EMERGENCY */ TodoEntry,
-    /* CONGREGATE_IN_TOWN_AFTER_EMERGENCY */ TodoEntry,
-    /* SCRIPT_IN_CROWD */ TodoEntry,
-    /* GO_AND_CHILLOUT_OUTSIDE_HOME */ TodoEntry,
-    /* SIT_AND_CHILLOUT */ TodoEntry,
-    /* SCRIPT_GO_AND_MOVE_ALONG_PATH */ TodoEntry,
-    /* RESTART_MEETING */ TodoEntry,
-    /* GOTO_ABODE_BURNING_REACTION */ TodoEntry,
-    /* ARRIVES_AT_ABODE_BURNING_REACTION */ TodoEntry,
-    /* REPAIRS_ABODE */ TodoEntry,
-    /* ARRIVES_AT_SCAFFOLD_FOR_PICKUP */ TodoEntry,
-    /* ARRIVES_AT_BUILDING_SITE_WITH_SCAFFOLD */ TodoEntry,
-    /* MOVE_SCAFFOLD_TO_BUILDING_SITE */ TodoEntry,
+    /* ARRIVES_IN_ABODE_TO_TRADE */ k_TodoEntry,
+    /* ARRIVES_IN_ABODE_TO_PICK_UP_EXCESS */ k_TodoEntry,
+    /* MAKE_SCARED_STIFF */ k_TodoEntry,
+    /* SCARED_STIFF */ k_TodoEntry,
+    /* WORSHIPPING_CREATURE */ k_TodoEntry,
+    /* SHEPHERD_LOOK_FOR_FLOCK */ k_TodoEntry,
+    /* SHEPHERD_MOVE_FLOCK_TO_WATER */ k_TodoEntry,
+    /* SHEPHERD_MOVE_FLOCK_TO_FOOD */ k_TodoEntry,
+    /* SHEPHERD_MOVE_FLOCK_BACK */ k_TodoEntry,
+    /* SHEPHERD_DECIDE_WHAT_TO_DO_WITH_FLOCK */ k_TodoEntry,
+    /* SHEPHERD_WAIT_FOR_FLOCK */ k_TodoEntry,
+    /* SHEPHERD_SLAUGHTER_ANIMAL */ k_TodoEntry,
+    /* SHEPHERD_FETCH_STRAY */ k_TodoEntry,
+    /* SHEPHERD_GOTO_FLOCK */ k_TodoEntry,
+    /* HOUSEWIFE_AT_HOME */ k_TodoEntry,
+    /* HOUSEWIFE_GOTO_STORAGE_PIT */ k_TodoEntry,
+    /* HOUSEWIFE_ARRIVES_AT_STORAGE_PIT */ k_TodoEntry,
+    /* HOUSEWIFE_PICKUP_FROM_STORAGE_PIT */ k_TodoEntry,
+    /* HOUSEWIFE_RETURN_HOME_WITH_FOOD */ k_TodoEntry,
+    /* HOUSEWIFE_MAKE_DINNER */ k_TodoEntry,
+    /* HOUSEWIFE_SERVES_DINNER */ k_TodoEntry,
+    /* HOUSEWIFE_CLEARS_AWAY_DINNER */ k_TodoEntry,
+    /* HOUSEWIFE_DOES_HOUSEWORK */ k_TodoEntry,
+    /* HOUSEWIFE_GOSSIPS_AROUND_STORAGE_PIT */ k_TodoEntry,
+    /* HOUSEWIFE_STARTS_GIVING_BIRTH */ k_TodoEntry,
+    /* HOUSEWIFE_GIVING_BIRTH */ k_TodoEntry,
+    /* HOUSEWIFE_GIVEN_BIRTH */ k_TodoEntry,
+    /* CHILD_AT_CRECHE */ k_TodoEntry,
+    /* CHILD_FOLLOWS_MOTHER */ k_TodoEntry,
+    /* CHILD_BECOMES_ADULT */ k_TodoEntry,
+    /* SITS_DOWN_TO_DINNER */ k_TodoEntry,
+    /* EAT_FOOD */ k_TodoEntry,
+    /* EAT_FOOD_AT_HOME */ k_TodoEntry,
+    /* GOTO_BED_AT_HOME */ k_TodoEntry,
+    /* SLEEPING_AT_HOME */ k_TodoEntry,
+    /* WAKE_UP_AT_HOME */ k_TodoEntry,
+    /* START_HAVING_SEX */ k_TodoEntry,
+    /* HAVING_SEX */ k_TodoEntry,
+    /* STOP_HAVING_SEX */ k_TodoEntry,
+    /* START_HAVING_SEX_AT_HOME */ k_TodoEntry,
+    /* HAVING_SEX_AT_HOME */ k_TodoEntry,
+    /* STOP_HAVING_SEX_AT_HOME */ k_TodoEntry,
+    /* WAIT_FOR_DINNER */ k_TodoEntry,
+    /* HOMELESS_START */ k_TodoEntry,
+    /* VAGRANT_START */ k_TodoEntry,
+    /* MORN_DEATH */ k_TodoEntry,
+    /* PERFORM_INSPECTION_REACTION */ k_TodoEntry,
+    /* APPROACH_OBJECT_REACTION */ k_TodoEntry,
+    /* INITIALISE_TELL_OTHERS_ABOUT_OBJECT */ k_TodoEntry,
+    /* TELL_OTHERS_ABOUT_INTERESTING_OBJECT */ k_TodoEntry,
+    /* APPROACH_VILLAGER_TO_TALK_TO */ k_TodoEntry,
+    /* TELL_PARTICULAR_VILLAGER_ABOUT_OBJECT */ k_TodoEntry,
+    /* INITIALISE_LOOK_AROUND_FOR_VILLAGER_TO_TELL */ k_TodoEntry,
+    /* LOOK_AROUND_FOR_VILLAGER_TO_TELL */ k_TodoEntry,
+    /* MOVE_TOWARDS_OBJECT_TO_LOOK_AT */ k_TodoEntry,
+    /* INITIALISE_IMPRESSED_REACTION */ k_TodoEntry,
+    /* PERFORM_IMPRESSED_REACTION */ k_TodoEntry,
+    /* INITIALISE_FIGHT_REACTION */ k_TodoEntry,
+    /* PERFORM_FIGHT_REACTION */ k_TodoEntry,
+    /* HOMELESS_EAT_DINNER */ k_TodoEntry,
+    /* INSPECT_CREATURE_REACTION */ k_TodoEntry,
+    /* PERFORM_INSPECT_CREATURE_REACTION */ k_TodoEntry,
+    /* APPROACH_CREATURE_REACTION */ k_TodoEntry,
+    /* INITIALISE_BEWILDERED_BY_MAGIC_TREE_REACTION */ k_TodoEntry,
+    /* PERFORM_BEWILDERED_BY_MAGIC_TREE_REACTION */ k_TodoEntry,
+    /* TURN_TO_FACE_MAGIC_TREE */ k_TodoEntry,
+    /* LOOK_AT_MAGIC_TREE */ k_TodoEntry,
+    /* DANCE_FOR_EDITING_PURPOSES */ k_TodoEntry,
+    /* MOVE_TO_DANCE_POS */ k_TodoEntry,
+    /* INITIALISE_RESPECT_CREATURE_REACTION */ k_TodoEntry,
+    /* PERFORM_RESPECT_CREATURE_REACTION */ k_TodoEntry,
+    /* FINISH_RESPECT_CREATURE_REACTION */ k_TodoEntry,
+    /* APPROACH_HAND_REACTION */ k_TodoEntry,
+    /* FLEEING_FROM_CREATURE_REACTION */ k_TodoEntry,
+    /* TURN_TO_FACE_CREATURE_REACTION */ k_TodoEntry,
+    /* WATCH_FLYING_OBJECT_REACTION */ k_TodoEntry,
+    /* POINT_AT_FLYING_OBJECT_REACTION */ k_TodoEntry,
+    /* DECIDE_WHAT_TO_DO */ k_TodoEntry,
+    /* INTERACT_DECIDE_WHAT_TO_DO */ k_TodoEntry,
+    /* EAT_OUTSIDE */ k_TodoEntry,
+    /* RUN_AWAY_FROM_OBJECT_REACTION */ k_TodoEntry,
+    /* MOVE_TOWARDS_CREATURE_REACTION */ k_TodoEntry,
+    /* AMAZED_BY_MAGIC_SHIELD_REACTION */ k_TodoEntry,
+    /* VILLAGER_GOSSIPS */ k_TodoEntry,
+    /* CHECK_INTERACT_WITH_ANIMAL */ k_TodoEntry,
+    /* CHECK_INTERACT_WITH_WORSHIP_SITE */ k_TodoEntry,
+    /* CHECK_INTERACT_WITH_ABODE */ k_TodoEntry,
+    /* CHECK_INTERACT_WITH_FIELD */ k_TodoEntry,
+    /* CHECK_INTERACT_WITH_FISH_FARM */ k_TodoEntry,
+    /* CHECK_INTERACT_WITH_TREE */ k_TodoEntry,
+    /* CHECK_INTERACT_WITH_BALL */ k_TodoEntry,
+    /* CHECK_INTERACT_WITH_POT */ k_TodoEntry,
+    /* CHECK_INTERACT_WITH_FOOTBALL */ k_TodoEntry,
+    /* CHECK_INTERACT_WITH_VILLAGER */ k_TodoEntry,
+    /* CHECK_INTERACT_WITH_MAGIC_LIVING */ k_TodoEntry,
+    /* CHECK_INTERACT_WITH_ROCK */ k_TodoEntry,
+    /* ARRIVES_AT_ROCK_FOR_WOOD */ k_TodoEntry,
+    /* GOT_WOOD_FROM_ROCK */ k_TodoEntry,
+    /* REENTER_BUILDING_STATE */ k_TodoEntry,
+    /* ARRIVE_AT_PUSH_OBJECT */ k_TodoEntry,
+    /* TAKE_WOOD_FROM_TREE */ k_TodoEntry,
+    /* TAKE_WOOD_FROM_POT */ k_TodoEntry,
+    /* TAKE_WOOD_FROM_TREE_FOR_BUILDING */ k_TodoEntry,
+    /* TAKE_WOOD_FROM_POT_FOR_BUILDING */ k_TodoEntry,
+    /* SHEPHERD_TAKE_ANIMAL_FOR_SLAUGHTER */ k_TodoEntry,
+    /* SHEPHERD_TAKES_CONTROL_OF_FLOCK */ k_TodoEntry,
+    /* SHEPHERD_RELEASES_CONTROL_OF_FLOCK */ k_TodoEntry,
+    /* DANCE_BUT_NOT_WORSHIP */ k_TodoEntry,
+    /* FAINTING_REACTION */ k_TodoEntry,
+    /* START_CONFUSED_REACTION */ k_TodoEntry,
+    /* CONFUSED_REACTION */ k_TodoEntry,
+    /* AFTER_TAP_ON_ABODE */ k_TodoEntry,
+    /* WEAK_ON_GROUND */ k_TodoEntry,
+    /* SCRIPT_WANDER_AROUND_POSITION */ k_TodoEntry,
+    /* SCRIPT_PLAY_ANIM */ k_TodoEntry,
+    /* GO_TOWARDS_TELEPORT_REACTION */ k_TodoEntry,
+    /* TELEPORT_REACTION */ k_TodoEntry,
+    /* DANCE_WHILE_REACTING */ k_TodoEntry,
+    /* CONTROLLED_BY_CREATURE */ k_TodoEntry,
+    /* POINT_AT_DEAD_PERSON */ k_TodoEntry,
+    /* GO_TOWARDS_DEAD_PERSON */ k_TodoEntry,
+    /* LOOK_AT_DEAD_PERSON */ k_TodoEntry,
+    /* MOURN_DEAD_PERSON */ k_TodoEntry,
+    /* NOTHING_TO_DO */ k_TodoEntry,
+    /* ARRIVES_AT_WORKSHOP_FOR_DROP_OFF */ k_TodoEntry,
+    /* ARRIVES_AT_STORAGE_PIT_FOR_WORKSHOP_MATERIALS */ k_TodoEntry,
+    /* SHOW_POISONED */ k_TodoEntry,
+    /* HIDING_AT_WORSHIP_SITE */ k_TodoEntry,
+    /* CROWD_REACTION */ k_TodoEntry,
+    /* REACT_TO_FIRE */ k_TodoEntry,
+    /* PUT_OUT_FIRE_BY_BEATING */ k_TodoEntry,
+    /* PUT_OUT_FIRE_WITH_WATER */ k_TodoEntry,
+    /* GET_WATER_TO_PUT_OUT_FIRE */ k_TodoEntry,
+    /* ON_FIRE */ k_TodoEntry,
+    /* MOVE_AROUND_FIRE */ k_TodoEntry,
+    /* DISCIPLE_NOTHING_TO_DO */ k_TodoEntry,
+    /* FOOTBALL_MOVE_TO_BALL */ k_TodoEntry,
+    /* ARRIVES_AT_STORAGE_PIT_FOR_TRADER_PICK_UP */ k_TodoEntry,
+    /* ARRIVES_AT_STORAGE_PIT_FOR_TRADER_DROP_OFF */ k_TodoEntry,
+    /* BREEDER_DISCIPLE */ k_TodoEntry,
+    /* MISSIONARY_DISCIPLE */ k_TodoEntry,
+    /* REACT_TO_BREEDER */ k_TodoEntry,
+    /* SHEPHERD_CHECK_ANIMAL_FOR_SLAUGHTER */ k_TodoEntry,
+    /* INTERACT_DECIDE_WHAT_TO_DO_FOR_OTHER_VILLAGER */ k_TodoEntry,
+    /* ARTIFACT_DANCE */ k_TodoEntry,
+    /* FLEEING_FROM_PREDATOR_REACTION */ k_TodoEntry,
+    /* WAIT_FOR_WOOD */ k_TodoEntry,
+    /* INSPECT_OBJECT */ k_TodoEntry,
+    /* GO_HOME_AND_CHANGE */ k_TodoEntry,
+    /* WAIT_FOR_MATE */ k_TodoEntry,
+    /* GO_AND_HIDE_IN_NEARBY_BUILDING */ k_TodoEntry,
+    /* LOOK_TO_SEE_IF_IT_IS_SAFE */ k_TodoEntry,
+    /* SLEEP_IN_TENT */ k_TodoEntry,
+    /* PAUSE_FOR_A_SECOND */ k_TodoEntry,
+    /* PANIC_REACTION */ k_TodoEntry,
+    /* GET_FOOD_AT_WORSHIP_SITE */ k_TodoEntry,
+    /* GOTO_CONGREGATE_IN_TOWN_AFTER_EMERGENCY */ k_TodoEntry,
+    /* CONGREGATE_IN_TOWN_AFTER_EMERGENCY */ k_TodoEntry,
+    /* SCRIPT_IN_CROWD */ k_TodoEntry,
+    /* GO_AND_CHILLOUT_OUTSIDE_HOME */ k_TodoEntry,
+    /* SIT_AND_CHILLOUT */ k_TodoEntry,
+    /* SCRIPT_GO_AND_MOVE_ALONG_PATH */ k_TodoEntry,
+    /* RESTART_MEETING */ k_TodoEntry,
+    /* GOTO_ABODE_BURNING_REACTION */ k_TodoEntry,
+    /* ARRIVES_AT_ABODE_BURNING_REACTION */ k_TodoEntry,
+    /* REPAIRS_ABODE */ k_TodoEntry,
+    /* ARRIVES_AT_SCAFFOLD_FOR_PICKUP */ k_TodoEntry,
+    /* ARRIVES_AT_BUILDING_SITE_WITH_SCAFFOLD */ k_TodoEntry,
+    /* MOVE_SCAFFOLD_TO_BUILDING_SITE */ k_TodoEntry,
 };
 
-LivingActionSystem& LivingActionSystem::instance()
+LivingActionSystem& LivingActionSystem::Instance()
 {
 	static LivingActionSystem* instance = nullptr;
 	if (instance == nullptr)
@@ -398,7 +398,7 @@ LivingActionSystem::LivingActionSystem() = default;
 
 void LivingActionSystem::Update()
 {
-	auto& registry = Game::instance()->GetEntityRegistry();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 
 	registry.Each<LivingAction>([](LivingAction& action) { ++action.turnsSinceStateChange; });
 
@@ -432,10 +432,11 @@ void LivingActionSystem::VillagerSetState(LivingAction& action, LivingAction::In
 	const auto previousState = static_cast<VillagerStates>(action.states.at(static_cast<size_t>(index)));
 	if (previousState != state)
 	{
-		[[maybe_unused]] auto& registry = Game::instance()->GetEntityRegistry();
-		SPDLOG_LOGGER_TRACE(
-		    spdlog::get("ai"), "Villager #{}: Setting state {} -> {}", static_cast<int>(registry.ToEntity(action)),
-		    VillagerStateStrings.at(static_cast<size_t>(previousState)), VillagerStateStrings.at(static_cast<size_t>(state)));
+		[[maybe_unused]] auto& registry = Game::Instance()->GetEntityRegistry();
+		SPDLOG_LOGGER_TRACE(spdlog::get("ai"), "Villager #{}: Setting state {} -> {}",
+		                    static_cast<int>(registry.ToEntity(action)),
+		                    k_VillagerStateStrings.at(static_cast<size_t>(previousState)),
+		                    k_VillagerStateStrings.at(static_cast<size_t>(state)));
 
 		if (index == LivingAction::Index::Top)
 		{
@@ -458,7 +459,7 @@ void LivingActionSystem::VillagerSetState(LivingAction& action, LivingAction::In
 uint32_t LivingActionSystem::VillagerCallState(LivingAction& action, LivingAction::Index index) const
 {
 	const auto state = action.states.at(static_cast<size_t>(index));
-	const auto& entry = VillagerStateTable.at(static_cast<size_t>(state));
+	const auto& entry = k_VillagerStateTable.at(static_cast<size_t>(state));
 	const auto& callback = entry.state;
 	if (!callback)
 	{
@@ -471,7 +472,7 @@ bool LivingActionSystem::VillagerCallEntryState(LivingAction& action, LivingActi
                                                 VillagerStates dst) const
 {
 	const auto state = action.states.at(static_cast<size_t>(index));
-	const auto& entry = VillagerStateTable.at(static_cast<size_t>(state));
+	const auto& entry = k_VillagerStateTable.at(static_cast<size_t>(state));
 	const auto& callback = entry.entryState;
 	if (!callback)
 	{
@@ -483,7 +484,7 @@ bool LivingActionSystem::VillagerCallEntryState(LivingAction& action, LivingActi
 bool LivingActionSystem::VillagerCallExitState(LivingAction& action, LivingAction::Index index) const
 {
 	const auto& state = action.states.at(static_cast<size_t>(index));
-	const auto& entry = VillagerStateTable.at(static_cast<size_t>(state));
+	const auto& entry = k_VillagerStateTable.at(static_cast<size_t>(state));
 	const auto& callback = entry.exitState;
 	if (!callback)
 	{
@@ -495,7 +496,7 @@ bool LivingActionSystem::VillagerCallExitState(LivingAction& action, LivingActio
 int LivingActionSystem::VillagerCallOutOfAnimation(LivingAction& action, LivingAction::Index index) const
 {
 	const auto state = action.states.at(static_cast<size_t>(index));
-	const auto& entry = VillagerStateTable.at(static_cast<size_t>(state));
+	const auto& entry = k_VillagerStateTable.at(static_cast<size_t>(state));
 	const auto& callback = entry.transitionAnimation;
 	if (!callback)
 	{
@@ -507,7 +508,7 @@ int LivingActionSystem::VillagerCallOutOfAnimation(LivingAction& action, LivingA
 bool LivingActionSystem::VillagerCallValidate(LivingAction& action, LivingAction::Index index) const
 {
 	const auto state = action.states.at(static_cast<size_t>(index));
-	const auto& entry = VillagerStateTable.at(static_cast<size_t>(state));
+	const auto& entry = k_VillagerStateTable.at(static_cast<size_t>(state));
 	const auto& callback = entry.validate;
 	if (!callback)
 	{

--- a/src/ECS/Systems/LivingActionSystem.cpp
+++ b/src/ECS/Systems/LivingActionSystem.cpp
@@ -499,7 +499,7 @@ int LivingActionSystem::VillagerCallOutOfAnimation(LivingAction& action, LivingA
 	const auto& callback = entry.transitionAnimation;
 	if (!callback)
 	{
-		return false;
+		return -1;
 	}
 	return callback(action);
 }

--- a/src/ECS/Systems/LivingActionSystem.cpp
+++ b/src/ECS/Systems/LivingActionSystem.cpp
@@ -386,10 +386,10 @@ const static std::array<VillagerStateTableEntry, static_cast<size_t>(VillagerSta
 
 LivingActionSystem& LivingActionSystem::Instance()
 {
-	static LivingActionSystem* instance = nullptr;
+	static std::unique_ptr<LivingActionSystem> instance = nullptr;
 	if (instance == nullptr)
 	{
-		instance = new LivingActionSystem();
+		instance.reset(new LivingActionSystem());
 	}
 	return *instance;
 }

--- a/src/ECS/Systems/LivingActionSystem.h
+++ b/src/ECS/Systems/LivingActionSystem.h
@@ -16,7 +16,7 @@ namespace openblack::ecs::systems
 class LivingActionSystem
 {
 public:
-	static LivingActionSystem& instance();
+	static LivingActionSystem& Instance();
 	void Update();
 
 	[[nodiscard]] VillagerStates VillagerGetState(const components::LivingAction& action,

--- a/src/ECS/Systems/PathfindingSystem.cpp
+++ b/src/ECS/Systems/PathfindingSystem.cpp
@@ -20,7 +20,7 @@ using namespace openblack;
 using namespace openblack::ecs::components;
 using namespace openblack::ecs::systems;
 
-PathfindingSystem& PathfindingSystem::instance()
+PathfindingSystem& PathfindingSystem::Instance()
 {
 	static auto* instance = new PathfindingSystem();
 	return *instance;
@@ -30,7 +30,7 @@ PathfindingSystem::PathfindingSystem() = default;
 
 void PathfindingSystem::Update()
 {
-	auto& registry = Game::instance()->GetEntityRegistry();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 
 	// ARRIVED:
 	registry.Each<const MoveStateArrivedTag, const Transform, const WallHug>(

--- a/src/ECS/Systems/PathfindingSystem.cpp
+++ b/src/ECS/Systems/PathfindingSystem.cpp
@@ -22,7 +22,11 @@ using namespace openblack::ecs::systems;
 
 PathfindingSystem& PathfindingSystem::Instance()
 {
-	static auto* instance = new PathfindingSystem();
+	static std::unique_ptr<PathfindingSystem> instance;
+	if (instance == nullptr)
+	{
+		instance.reset(new PathfindingSystem());
+	}
 	return *instance;
 }
 

--- a/src/ECS/Systems/PathfindingSystem.cpp
+++ b/src/ECS/Systems/PathfindingSystem.cpp
@@ -22,7 +22,7 @@ using namespace openblack::ecs::systems;
 
 PathfindingSystem& PathfindingSystem::instance()
 {
-	static auto instance = new PathfindingSystem();
+	static auto* instance = new PathfindingSystem();
 	return *instance;
 }
 

--- a/src/ECS/Systems/PathfindingSystem.h
+++ b/src/ECS/Systems/PathfindingSystem.h
@@ -14,7 +14,7 @@ namespace openblack::ecs::systems
 class PathfindingSystem
 {
 public:
-	static PathfindingSystem& instance();
+	static PathfindingSystem& Instance();
 
 	void Update();
 

--- a/src/ECS/Systems/RenderingSystem.cpp
+++ b/src/ECS/Systems/RenderingSystem.cpp
@@ -26,7 +26,11 @@ using namespace openblack::ecs::components;
 
 RenderingSystem& RenderingSystem::Instance()
 {
-	static auto* instance = new RenderingSystem();
+	static std::unique_ptr<RenderingSystem> instance;
+	if (instance == nullptr)
+	{
+		instance.reset(new RenderingSystem());
+	}
 	return *instance;
 }
 

--- a/src/ECS/Systems/RenderingSystem.cpp
+++ b/src/ECS/Systems/RenderingSystem.cpp
@@ -26,7 +26,7 @@ using namespace openblack::ecs::components;
 
 RenderingSystem& RenderingSystem::instance()
 {
-	static auto instance = new RenderingSystem();
+	static auto* instance = new RenderingSystem();
 	return *instance;
 }
 
@@ -40,7 +40,7 @@ void RenderingSystem::PrepareDrawDescs(bool drawBoundingBox)
 	uint32_t instanceCount = 0;
 	std::map<entt::id_type, uint32_t> meshIds;
 
-	registry.Each<const Mesh, const Transform>([&meshIds, &instanceCount](const Mesh& mesh, const Transform&) {
+	registry.Each<const Mesh, const Transform>([&meshIds, &instanceCount](const Mesh& mesh, const Transform& /*unused*/) {
 		auto count = meshIds.insert(std::make_pair(mesh.id, mesh.submeshId));
 		count.first->second++;
 		instanceCount++;

--- a/src/ECS/Systems/RenderingSystem.cpp
+++ b/src/ECS/Systems/RenderingSystem.cpp
@@ -24,7 +24,7 @@
 using namespace openblack::ecs::systems;
 using namespace openblack::ecs::components;
 
-RenderingSystem& RenderingSystem::instance()
+RenderingSystem& RenderingSystem::Instance()
 {
 	static auto* instance = new RenderingSystem();
 	return *instance;
@@ -34,7 +34,7 @@ RenderingSystem::RenderingSystem() = default;
 
 void RenderingSystem::PrepareDrawDescs(bool drawBoundingBox)
 {
-	auto& registry = Game::instance()->GetEntityRegistry();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 
 	// Count number of instances
 	uint32_t instanceCount = 0;
@@ -82,7 +82,7 @@ void RenderingSystem::PrepareDrawDescs(bool drawBoundingBox)
 
 void RenderingSystem::PrepareDrawUploadUniforms(bool drawBoundingBox)
 {
-	auto& registry = Game::instance()->GetEntityRegistry();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 
 	// Store offsets of uniforms for descs
 	std::map<entt::id_type, uint32_t> uniformOffsets;
@@ -124,7 +124,7 @@ void RenderingSystem::SetDirty()
 
 void RenderingSystem::PrepareDraw(bool drawBoundingBox, bool drawFootpaths, bool drawStreams)
 {
-	auto& registry = Game::instance()->GetEntityRegistry();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 
 	if (_renderContext.dirty || _renderContext.hasBoundingBoxes != drawBoundingBox ||
 	    (_renderContext.footpaths != nullptr) != drawFootpaths || (_renderContext.streams != nullptr) != drawStreams)

--- a/src/ECS/Systems/RenderingSystem.h
+++ b/src/ECS/Systems/RenderingSystem.h
@@ -72,7 +72,7 @@ struct RenderContext
 class RenderingSystem
 {
 public:
-	static RenderingSystem& instance();
+	static RenderingSystem& Instance();
 
 	void SetDirty();
 	void PrepareDraw(bool drawBoundingBox, bool drawFootpaths, bool drawStreams);

--- a/src/ECS/Systems/TownSystem.cpp
+++ b/src/ECS/Systems/TownSystem.cpp
@@ -21,7 +21,11 @@ using namespace openblack::ecs::systems;
 
 TownSystem& TownSystem::Instance()
 {
-	static auto* instance = new TownSystem();
+	static std::unique_ptr<TownSystem> instance;
+	if (instance == nullptr)
+	{
+		instance.reset(new TownSystem());
+	}
 	return *instance;
 }
 

--- a/src/ECS/Systems/TownSystem.cpp
+++ b/src/ECS/Systems/TownSystem.cpp
@@ -19,7 +19,7 @@
 using namespace openblack::ecs::components;
 using namespace openblack::ecs::systems;
 
-TownSystem& TownSystem::instance()
+TownSystem& TownSystem::Instance()
 {
 	static auto* instance = new TownSystem();
 	return *instance;
@@ -29,8 +29,8 @@ TownSystem::TownSystem() = default;
 
 entt::entity TownSystem::FindAbodeWithSpace(entt::entity townEntity) const
 {
-	const auto& infoConstants = Game::instance()->GetInfoConstants();
-	auto& registry = Game::instance()->GetEntityRegistry();
+	const auto& infoConstants = Game::Instance()->GetInfoConstants();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 	const auto& town = registry.Get<Town>(townEntity);
 
 	entt::entity result = entt::null;
@@ -51,17 +51,17 @@ entt::entity TownSystem::FindAbodeWithSpace(entt::entity townEntity) const
 
 entt::entity TownSystem::FindClosestTown(const glm::vec3& point) const
 {
-	const auto& registry = Game::instance()->GetEntityRegistry();
+	const auto& registry = Game::Instance()->GetEntityRegistry();
 
 	entt::entity result = entt::null;
 	auto closest = std::numeric_limits<float>::infinity();
 
 	registry.Each<const Town, const Transform>(
 	    [&point, &result, &closest](entt::entity entity, [[maybe_unused]] auto& town, [[maybe_unused]] auto& transform) {
-		    float distance_2 = glm::dot(point, transform.position);
-		    if (distance_2 < closest)
+		    float distance2 = glm::dot(point, transform.position);
+		    if (distance2 < closest)
 		    {
-			    closest = distance_2;
+			    closest = distance2;
 			    result = entity;
 		    }
 	    });
@@ -71,7 +71,7 @@ entt::entity TownSystem::FindClosestTown(const glm::vec3& point) const
 
 void TownSystem::AddHomelessVillagerToTown(entt::entity townEntity, entt::entity villagerEntity)
 {
-	[[maybe_unused]] auto& registry = Game::instance()->GetEntityRegistry();
+	[[maybe_unused]] auto& registry = Game::Instance()->GetEntityRegistry();
 	[[maybe_unused]] auto& registryContext = registry.Context();
 
 	auto& town = registry.Get<Town>(townEntity);

--- a/src/ECS/Systems/TownSystem.cpp
+++ b/src/ECS/Systems/TownSystem.cpp
@@ -21,7 +21,7 @@ using namespace openblack::ecs::systems;
 
 TownSystem& TownSystem::instance()
 {
-	static auto instance = new TownSystem();
+	static auto* instance = new TownSystem();
 	return *instance;
 }
 

--- a/src/ECS/Systems/TownSystem.h
+++ b/src/ECS/Systems/TownSystem.h
@@ -18,7 +18,7 @@ namespace openblack::ecs::systems
 class TownSystem
 {
 public:
-	static TownSystem& instance();
+	static TownSystem& Instance();
 
 	[[nodiscard]] entt::entity FindAbodeWithSpace(entt::entity townEntity) const;
 	[[nodiscard]] entt::entity FindClosestTown(const glm::vec3& point) const;

--- a/src/Enums.h
+++ b/src/Enums.h
@@ -21,10 +21,10 @@
 namespace openblack
 {
 
-constexpr unsigned int CellSizeMetres = 10;
-constexpr unsigned int GameTicksPerSecond = 10;
-constexpr unsigned int OneMetre = 6554;
-constexpr unsigned int NumberOfStoryLand = 5;
+constexpr unsigned int k_CellSizeMetres = 10;
+constexpr unsigned int k_GameTicksPerSecond = 10;
+constexpr unsigned int k_OneMetre = 6554;
+constexpr unsigned int k_NumberOfStoryLand = 5;
 
 enum class DetailDistance
 {
@@ -218,7 +218,7 @@ enum class Tribe : int32_t
 
 	_COUNT
 };
-static constexpr std::array<std::string_view, static_cast<uint8_t>(Tribe::_COUNT)> TribeStrs = {
+static constexpr std::array<std::string_view, static_cast<uint8_t>(Tribe::_COUNT)> k_TribeStrs = {
     // "NONE",
     "CELTIC",   //
     "AFRICAN",  //
@@ -254,7 +254,7 @@ enum class AbodeNumber : int32_t
 	_COUNT
 };
 
-static constexpr std::array<std::string_view, static_cast<uint32_t>(AbodeNumber::_COUNT)> AbodeNumberStrs = {
+static constexpr std::array<std::string_view, static_cast<uint32_t>(AbodeNumber::_COUNT)> k_AbodeNumberStrs = {
     "A",               //
     "B",               //
     "C",               //
@@ -1306,7 +1306,7 @@ enum class VillagerStates : uint32_t
 	_COUNT = LastState
 };
 
-static constexpr std::array<std::string_view, static_cast<size_t>(VillagerStates::_COUNT)> VillagerStateStrings = {
+static constexpr std::array<std::string_view, static_cast<size_t>(VillagerStates::_COUNT)> k_VillagerStateStrings = {
     "INVALID_STATE",
     "MOVE_TO_POS",
     "MOVE_TO_OBJECT",
@@ -1563,7 +1563,7 @@ static constexpr std::array<std::string_view, static_cast<size_t>(VillagerStates
     "ARRIVES_AT_ABODE_BURNING_REACTION",
     "REPAIRS_ABODE",
 };
-static_assert(VillagerStateStrings.size() == static_cast<size_t>(VillagerStates::_COUNT),
+static_assert(k_VillagerStateStrings.size() == static_cast<size_t>(VillagerStates::_COUNT),
               "The number of state type strings should be the same as the number of state types");
 
 enum class AlignmentType : uint32_t
@@ -2248,7 +2248,7 @@ enum class VillagerNumber : uint32_t
 
 	_COUNT
 };
-static constexpr std::array<std::string_view, static_cast<uint32_t>(VillagerNumber::_COUNT)> VillagerNumberStrs = {
+static constexpr std::array<std::string_view, static_cast<uint32_t>(VillagerNumber::_COUNT)> k_VillagerNumberStrs = {
     "HOUSEWIFE", //
     "FORESTER",  //
     "FISHERMAN", //
@@ -3149,7 +3149,7 @@ enum class VillagerRoles : uint8_t
 	_COUNT
 };
 
-static constexpr std::array<std::string_view, static_cast<uint8_t>(VillagerRoles::_COUNT)> VillagerRoleStrs = {
+static constexpr std::array<std::string_view, static_cast<uint8_t>(VillagerRoles::_COUNT)> k_VillagerRoleStrs = {
     "NONE",            //
     "HOUSEWIFE",       //
     "FARMER",          //
@@ -3197,7 +3197,7 @@ enum class PlayerNames : uint8_t
 	_COUNT
 };
 
-static constexpr std::array<std::string_view, static_cast<uint8_t>(PlayerNames::_COUNT)> PlayerNamesStrs = {
+static constexpr std::array<std::string_view, static_cast<uint8_t>(PlayerNames::_COUNT)> k_PlayerNamesStrs = {
     "PLAYER_ONE",   //
     "PLAYER_TWO",   //
     "PLAYER_THREE", //

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -328,7 +328,7 @@ bool Game::Update()
 	{
 		auto sdlInput = _profiler->BeginScoped(Profiler::Stage::SdlInput);
 		SDL_Event e;
-		while (SDL_PollEvent(&e))
+		while (SDL_PollEvent(&e) != 0)
 		{
 			_eventManager->Create<SDL_Event>(e);
 		}
@@ -376,7 +376,8 @@ bool Game::Update()
 			const auto scale = glm::vec3(50.0f, 50.0f, 50.0f);
 			if (screenSize.x > 0 && screenSize.y > 0)
 			{
-				glm::vec3 rayOrigin, rayDirection;
+				glm::vec3 rayOrigin;
+				glm::vec3 rayDirection;
 				_camera->DeprojectScreenToWorld(_mousePosition, screenSize, rayOrigin, rayDirection);
 
 				if (auto hit = _dynamicsSystem->RayCastClosestHit(rayOrigin, rayDirection, 1e10f))
@@ -462,7 +463,7 @@ bool Game::Initialize()
 	meshManager.Load("coffre", _fileSystem->FindPath(_fileSystem->MiscPath() / "coffre.l3d"));
 	pack::PackFile pack;
 	pack.Open(_fileSystem->FindPath(_fileSystem->DataPath() / "AllMeshes.g3d"));
-	auto& meshes = pack.GetMeshes();
+	const auto& meshes = pack.GetMeshes();
 	for (size_t i = 0; const auto& mesh : meshes)
 	{
 		const auto meshId = static_cast<MeshId>(i);
@@ -470,7 +471,7 @@ bool Game::Initialize()
 		++i;
 	}
 
-	auto& textures = pack.GetTextures();
+	const auto& textures = pack.GetTextures();
 	for (auto const& [name, g3dTexture] : textures)
 	{
 		textureManager.Load(g3dTexture.header.id, name, g3dTexture);
@@ -479,7 +480,7 @@ bool Game::Initialize()
 	animationManager.Load("coffre", _fileSystem->FindPath(_fileSystem->MiscPath() / "coffre.anm"));
 	pack::PackFile animationPack;
 	animationPack.Open(_fileSystem->FindPath(_fileSystem->DataPath() / "AllAnims.anm"));
-	auto& animations = animationPack.GetAnimations();
+	const auto& animations = animationPack.GetAnimations();
 	for (size_t i = 0; i < animations.size(); i++)
 	{
 		animationManager.Load(i, animations[i]);
@@ -598,13 +599,15 @@ bool Game::Run()
 
 	if (_window)
 	{
-		int width, height;
+		int width;
+		int height;
 		_window->GetSize(width, height);
 		_renderer->ConfigureView(graphics::RenderPass::Main, static_cast<uint16_t>(width), static_cast<uint16_t>(height));
 	}
 
 	{
-		uint16_t waterWidth, waterHeight;
+		uint16_t waterWidth;
+		uint16_t waterHeight;
 		_water->GetFrameBuffer().GetSize(waterWidth, waterHeight);
 		_renderer->ConfigureView(graphics::RenderPass::Reflection, waterWidth, waterHeight);
 	}
@@ -732,13 +735,7 @@ void Game::LoadLandscape(const std::filesystem::path& path)
 bool Game::LoadVariables()
 {
 	InfoFile infoFile;
-
-	if (!infoFile.LoadFromFile(_fileSystem->ScriptsPath() / "info.dat", _infoConstants))
-	{
-		return false;
-	}
-
-	return true;
+	return infoFile.LoadFromFile(_fileSystem->ScriptsPath() / "info.dat", _infoConstants);
 }
 
 void Game::SetGamePath(std::filesystem::path gamePath)

--- a/src/Game.h
+++ b/src/Game.h
@@ -81,7 +81,7 @@ enum class LoggingSubsystem : uint8_t
 	_count
 };
 
-static std::array<std::string_view, static_cast<size_t>(LoggingSubsystem::_count)> LoggingSubsystemStrs {
+constexpr static std::array<std::string_view, static_cast<size_t>(LoggingSubsystem::_count)> k_LoggingSubsystemStrs {
     "game",        //
     "graphics",    //
     "scripting",   //
@@ -101,16 +101,16 @@ struct Arguments
 	float scale;
 	uint32_t numFramesToSimulate;
 	std::string logFile;
-	std::array<spdlog::level::level_enum, LoggingSubsystemStrs.size()> logLevels;
+	std::array<spdlog::level::level_enum, k_LoggingSubsystemStrs.size()> logLevels;
 };
 
 class Game
 {
 public:
-	static constexpr auto kTurnDuration = std::chrono::milliseconds(100);
-	static constexpr float kTurnDurationMultiplierSlow = 2.0f;
-	static constexpr float kTurnDurationMultiplierNormal = 1.0f;
-	static constexpr float kTurnDurationMultiplierFast = 0.5f;
+	static constexpr auto k_TurnDuration = std::chrono::milliseconds(100);
+	static constexpr float k_TurnDurationMultiplierSlow = 2.0f;
+	static constexpr float k_TurnDurationMultiplierNormal = 1.0f;
+	static constexpr float k_TurnDurationMultiplierFast = 0.5f;
 
 	struct Config
 	{
@@ -207,7 +207,7 @@ public:
 	[[nodiscard]] std::chrono::duration<float, std::milli> GetDeltaTime() const { return _turnDeltaTime; }
 	[[nodiscard]] const glm::ivec2& GetMousePosition() const { return _mousePosition; }
 
-	static Game* instance() { return sInstance; }
+	static Game* Instance() { return sInstance; }
 
 private:
 	static Game* sInstance;

--- a/src/GameWindow.cpp
+++ b/src/GameWindow.cpp
@@ -108,8 +108,8 @@ void GameWindow::GetNativeHandles(void*& nativeWindow, void*& nativeDisplay) con
 #if defined(SDL_VIDEO_DRIVER_WAYLAND)
 	if (wmi.subsystem == SDL_SYSWM_WAYLAND)
 	{
-		auto* win_impl = static_cast<wl_egl_window*>(SDL_GetWindowData(_window.get(), "wl_egl_window"));
-		if (win_impl == nullptr)
+		auto* winImpl = static_cast<wl_egl_window*>(SDL_GetWindowData(_window.get(), "wl_egl_window"));
+		if (winImpl == nullptr)
 		{
 			int width;
 			int height;
@@ -119,11 +119,11 @@ void GameWindow::GetNativeHandles(void*& nativeWindow, void*& nativeDisplay) con
 			{
 				throw std::runtime_error("Failed getting native window handles: " + std::string(SDL_GetError()));
 			}
-			win_impl = wl_egl_window_create(surface, width, height);
-			SDL_SetWindowData(_window.get(), "wl_egl_window", win_impl);
+			winImpl = wl_egl_window_create(surface, width, height);
+			SDL_SetWindowData(_window.get(), "wl_egl_window", winImpl);
 		}
 		// NOLINTNEXTLINE(performance-no-int-to-ptr)
-		nativeWindow = reinterpret_cast<void*>(win_impl);
+		nativeWindow = reinterpret_cast<void*>(winImpl);
 		nativeDisplay = wmi.info.wl.display;
 	}
 	else

--- a/src/Graphics/DebugLines.cpp
+++ b/src/Graphics/DebugLines.cpp
@@ -23,7 +23,7 @@ std::unique_ptr<Mesh> DebugLines::CreateDebugLines(const Vertex* data, uint32_t 
 	decl.emplace_back(VertexAttrib::Attribute::Position, static_cast<uint8_t>(4), VertexAttrib::Type::Float);
 	decl.emplace_back(VertexAttrib::Attribute::Color0, static_cast<uint8_t>(4), VertexAttrib::Type::Float);
 
-	auto vertexBuffer = new VertexBuffer("DebugLines", data, vertexCount, decl);
+	auto* vertexBuffer = new VertexBuffer("DebugLines", data, vertexCount, decl);
 	bgfx::frame();
 	auto mesh = std::make_unique<Mesh>(vertexBuffer, nullptr, Mesh::Topology::LineList);
 	bgfx::frame();

--- a/src/Graphics/IndexBuffer.cpp
+++ b/src/Graphics/IndexBuffer.cpp
@@ -25,7 +25,7 @@ IndexBuffer::IndexBuffer(std::string name, const void* indices, uint32_t indexCo
 	assert(indices != nullptr);
 	assert(indexCount > 0);
 
-	auto mem = bgfx::makeRef(indices, indexCount * GetTypeSize(_type));
+	const auto* mem = bgfx::makeRef(indices, indexCount * GetTypeSize(_type));
 	_handle = bgfx::createIndexBuffer(mem, type == Type::Uint32 ? BGFX_BUFFER_INDEX32 : 0);
 	bgfx::setName(_handle, _name.c_str());
 }

--- a/src/Graphics/Mesh.cpp
+++ b/src/Graphics/Mesh.cpp
@@ -34,7 +34,7 @@ const IndexBuffer& Mesh::GetIndexBuffer() const
 	return *_indexBuffer;
 }
 
-bool Mesh::isIndexed() const
+bool Mesh::IsIndexed() const
 {
 	return _indexBuffer != nullptr && _indexBuffer->GetCount() > 0;
 }

--- a/src/Graphics/Mesh.cpp
+++ b/src/Graphics/Mesh.cpp
@@ -46,7 +46,7 @@ Mesh::Topology Mesh::GetTopology() const noexcept
 
 void Mesh::Draw(const DrawDesc& desc) const
 {
-	if (desc.instanceBuffer && (desc.skip & SkipState::SkipInstanceBuffer) == 0)
+	if (desc.instanceBuffer != nullptr && (desc.skip & SkipState::SkipInstanceBuffer) == 0)
 	{
 		bgfx::setInstanceDataBuffer(*desc.instanceBuffer, desc.instanceStart, desc.instanceCount);
 	}

--- a/src/Graphics/Mesh.h
+++ b/src/Graphics/Mesh.h
@@ -44,7 +44,7 @@ public:
 
 	[[nodiscard]] const VertexBuffer& GetVertexBuffer() const;
 	[[nodiscard]] const IndexBuffer& GetIndexBuffer() const;
-	[[nodiscard]] bool isIndexed() const;
+	[[nodiscard]] bool IsIndexed() const;
 
 	[[nodiscard]] Topology GetTopology() const noexcept;
 

--- a/src/Graphics/Primitive.cpp
+++ b/src/Graphics/Primitive.cpp
@@ -37,7 +37,7 @@ std::unique_ptr<Mesh> Primitive::CreatePlane()
 	decl.reserve(2);
 	decl.emplace_back(VertexAttrib::Attribute::Position, static_cast<uint8_t>(2), VertexAttrib::Type::Float);
 
-	auto vertexBuffer = new VertexBuffer("Plane", vertices.data(), static_cast<uint32_t>(vertices.size()), decl);
+	auto* vertexBuffer = new VertexBuffer("Plane", vertices.data(), static_cast<uint32_t>(vertices.size()), decl);
 	bgfx::frame();
 	auto mesh = std::make_unique<Mesh>(vertexBuffer, nullptr, Mesh::Topology::TriangleList);
 	bgfx::frame();

--- a/src/Graphics/RenderPass.h
+++ b/src/Graphics/RenderPass.h
@@ -27,7 +27,7 @@ enum class RenderPass : uint8_t
 	_count
 };
 
-static constexpr std::array<std::string_view, static_cast<uint8_t>(RenderPass::_count)> RenderPassNames {
+static constexpr std::array<std::string_view, static_cast<uint8_t>(RenderPass::_count)> k_RenderPassNames {
     "Reflection Pass",
     "Main Pass",
     "ImGui Pass",

--- a/src/Graphics/ShaderManager.cpp
+++ b/src/Graphics/ShaderManager.cpp
@@ -79,7 +79,7 @@ struct ShaderDefinition
 	const std::string_view fragmentShaderName;
 };
 
-const std::array<bgfx::EmbeddedShader, 14> s_embeddedShaders = {{
+const std::array<bgfx::EmbeddedShader, 14> k_EmbeddedShaders = {{
     BGFX_EMBEDDED_SHADER(vs_line), BGFX_EMBEDDED_SHADER(vs_line_instanced),     //
     BGFX_EMBEDDED_SHADER(fs_line),                                              //
     BGFX_EMBEDDED_SHADER(vs_object), BGFX_EMBEDDED_SHADER(vs_object_instanced), //
@@ -90,7 +90,7 @@ const std::array<bgfx::EmbeddedShader, 14> s_embeddedShaders = {{
     BGFX_EMBEDDED_SHADER_END()                                                  //
 }};
 
-constexpr std::array Shaders {
+constexpr std::array k_Shaders {
     ShaderDefinition {"DebugLine", "vs_line", "fs_line"},
     ShaderDefinition {"DebugLineInstanced", "vs_line_instanced", "fs_line"},
     ShaderDefinition {"Terrain", "vs_terrain", "fs_terrain"},
@@ -115,12 +115,12 @@ ShaderManager::~ShaderManager()
 
 void ShaderManager::LoadShaders()
 {
-	for (const auto& shader : Shaders)
+	for (const auto& shader : k_Shaders)
 	{
 		bgfx::RendererType::Enum type = bgfx::getRendererType();
-		auto vs = bgfx::createEmbeddedShader(s_embeddedShaders.data(), type, shader.vertexShaderName.data());
+		auto vs = bgfx::createEmbeddedShader(k_EmbeddedShaders.data(), type, shader.vertexShaderName.data());
 		assert(bgfx::isValid(vs));
-		auto fs = bgfx::createEmbeddedShader(s_embeddedShaders.data(), type, shader.fragmentShaderName.data());
+		auto fs = bgfx::createEmbeddedShader(k_EmbeddedShaders.data(), type, shader.fragmentShaderName.data());
 		assert(bgfx::isValid(fs));
 		_shaderPrograms[shader.name.data()] = new ShaderProgram(shader.name.data(), vs, fs);
 	}

--- a/src/Graphics/ShaderManager.cpp
+++ b/src/Graphics/ShaderManager.cpp
@@ -105,7 +105,10 @@ ShaderManager::~ShaderManager()
 {
 	// delete all mapped shaders
 	ShaderMap::iterator iter;
-	for (iter = _shaderPrograms.begin(); iter != _shaderPrograms.end(); ++iter) delete iter->second;
+	for (iter = _shaderPrograms.begin(); iter != _shaderPrograms.end(); ++iter)
+	{
+		delete iter->second;
+	}
 
 	_shaderPrograms.clear();
 }

--- a/src/Graphics/ShaderProgram.cpp
+++ b/src/Graphics/ShaderProgram.cpp
@@ -53,7 +53,9 @@ ShaderProgram::ShaderProgram(const std::string& name, bgfx::ShaderHandle vertexS
 ShaderProgram::~ShaderProgram()
 {
 	if (bgfx::isValid(_program))
+	{
 		bgfx::destroy(_program);
+	}
 }
 
 void ShaderProgram::SetTextureSampler(const char* samplerName, uint8_t bindPoint, const Texture2D& texture) const

--- a/src/Graphics/Texture2D.cpp
+++ b/src/Graphics/Texture2D.cpp
@@ -110,7 +110,7 @@ void Texture2D::Create(uint16_t width, uint16_t height, uint16_t layers, Format 
 		flags |= BGFX_SAMPLER_U_MIRROR | BGFX_SAMPLER_V_MIRROR;
 		break;
 	}
-	auto memory = bgfx::makeRef(data, size);
+	const auto* memory = bgfx::makeRef(data, size);
 	_handle = bgfx::createTexture2D(width, height, false, layers, getBgfxTextureFormat(format), flags, memory);
 	bgfx::setName(_handle, _name.c_str());
 	bgfx::frame();
@@ -133,7 +133,7 @@ void Texture2D::DumpTexture() const
 	{
 		auto filename = "dump/" + _name + "_" + std::to_string(i) + ".png";
 		SPDLOG_LOGGER_INFO(spdlog::get("graphics"), "Writing texture layer {} to {}.", i, filename.c_str());
-		auto current_pixels = &pixels[i * stride * _info.height];
+		auto* current_pixels = &pixels[i * stride * _info.height];
 		auto writeResult = stbi_write_png(filename.c_str(), _info.width, _info.height, numComponents, current_pixels, stride);
 		if (writeResult == 0)
 		{

--- a/src/Graphics/Texture2D.cpp
+++ b/src/Graphics/Texture2D.cpp
@@ -22,7 +22,7 @@ namespace openblack::graphics
 {
 constexpr std::array<bgfx::TextureFormat::Enum,
                      static_cast<size_t>(Format::RGBA4) + 1>
-    textureFormatsBgfx {
+    k_TextureFormatsBgfx {
         bgfx::TextureFormat::BC1,     // BlockCompression1
         bgfx::TextureFormat::BC2,     // BlockCompression2
         bgfx::TextureFormat::BC3,     // BlockCompression3
@@ -75,7 +75,7 @@ constexpr std::array<bgfx::TextureFormat::Enum,
 
 bgfx::TextureFormat::Enum getBgfxTextureFormat(Format format)
 {
-	return textureFormatsBgfx.at(static_cast<size_t>(format));
+	return k_TextureFormatsBgfx.at(static_cast<size_t>(format));
 }
 
 Texture2D::Texture2D(std::string name)
@@ -133,8 +133,8 @@ void Texture2D::DumpTexture() const
 	{
 		auto filename = "dump/" + _name + "_" + std::to_string(i) + ".png";
 		SPDLOG_LOGGER_INFO(spdlog::get("graphics"), "Writing texture layer {} to {}.", i, filename.c_str());
-		auto* current_pixels = &pixels[i * stride * _info.height];
-		auto writeResult = stbi_write_png(filename.c_str(), _info.width, _info.height, numComponents, current_pixels, stride);
+		auto* currentPixels = &pixels[i * stride * _info.height];
+		auto writeResult = stbi_write_png(filename.c_str(), _info.width, _info.height, numComponents, currentPixels, stride);
 		if (writeResult == 0)
 		{
 			SPDLOG_LOGGER_ERROR(spdlog::get("graphics"), "Writing texture to {} failed!", filename.c_str());

--- a/src/Graphics/VertexBuffer.cpp
+++ b/src/Graphics/VertexBuffer.cpp
@@ -55,7 +55,7 @@ VertexBuffer::VertexBuffer(std::string name, const void* vertices, uint32_t vert
 
 	bgfx::VertexLayout layout;
 	layout.begin();
-	for (auto& d : _vertexDecl)
+	for (const auto& d : _vertexDecl)
 	{
 		_vertexDeclOffsets.push_back(_strideBytes);
 		_strideBytes += strides.at(static_cast<size_t>(d._type)).at(d._num - 1);
@@ -65,7 +65,7 @@ VertexBuffer::VertexBuffer(std::string name, const void* vertices, uint32_t vert
 	layout.end();
 	assert(layout.m_stride == _strideBytes);
 
-	auto mem = bgfx::makeRef(vertices, vertexCount * layout.m_stride);
+	const auto* mem = bgfx::makeRef(vertices, vertexCount * layout.m_stride);
 	_handle = bgfx::createVertexBuffer(mem, layout);
 	_layoutHandle = bgfx::createVertexLayout(layout);
 	bgfx::setName(_handle, _name.c_str());
@@ -92,7 +92,7 @@ VertexBuffer::VertexBuffer(std::string name, const bgfx::Memory* mem, VertexDecl
 
 	bgfx::VertexLayout layout;
 	layout.begin();
-	for (auto& d : _vertexDecl)
+	for (const auto& d : _vertexDecl)
 	{
 		_vertexDeclOffsets.push_back(_strideBytes);
 		_strideBytes += strides.at(static_cast<size_t>(d._type)).at(d._num - 1);
@@ -112,9 +112,13 @@ VertexBuffer::VertexBuffer(std::string name, const bgfx::Memory* mem, VertexDecl
 VertexBuffer::~VertexBuffer()
 {
 	if (bgfx::isValid(_handle))
+	{
 		bgfx::destroy(_handle);
+	}
 	if (bgfx::isValid(_layoutHandle))
+	{
 		bgfx::destroy(_layoutHandle);
+	}
 }
 
 uint32_t VertexBuffer::GetCount() const noexcept

--- a/src/Graphics/VertexBuffer.cpp
+++ b/src/Graphics/VertexBuffer.cpp
@@ -18,12 +18,12 @@ using namespace openblack::graphics;
 namespace
 {
 
-constexpr std::array<bgfx::AttribType::Enum, 3> types {
+constexpr std::array<bgfx::AttribType::Enum, 3> k_Types {
     bgfx::AttribType::Uint8,
     bgfx::AttribType::Int16,
     bgfx::AttribType::Float,
 };
-constexpr std::array<bgfx::Attrib::Enum, 18> attributes {
+constexpr std::array<bgfx::Attrib::Enum, 18> k_Attributes {
     bgfx::Attrib::Enum::Position,  bgfx::Attrib::Enum::Normal,    bgfx::Attrib::Enum::Tangent,   bgfx::Attrib::Enum::Bitangent,
     bgfx::Attrib::Enum::Color0,    bgfx::Attrib::Enum::Color1,    bgfx::Attrib::Enum::Color2,    bgfx::Attrib::Enum::Color3,
     bgfx::Attrib::Enum::Indices,   bgfx::Attrib::Enum::Weight,    bgfx::Attrib::Enum::TexCoord0, bgfx::Attrib::Enum::TexCoord1,
@@ -58,9 +58,9 @@ VertexBuffer::VertexBuffer(std::string name, const void* vertices, uint32_t vert
 	for (const auto& d : _vertexDecl)
 	{
 		_vertexDeclOffsets.push_back(_strideBytes);
-		_strideBytes += strides.at(static_cast<size_t>(d._type)).at(d._num - 1);
-		layout.add(attributes.at(static_cast<size_t>(d._attribute)), d._num, types.at(static_cast<size_t>(d._type)),
-		           d._normalized, d._asInt);
+		_strideBytes += strides.at(static_cast<size_t>(d.type)).at(d.num - 1);
+		layout.add(k_Attributes.at(static_cast<size_t>(d.attribute)), d.num, k_Types.at(static_cast<size_t>(d.type)),
+		           d.normalized, d.asInt);
 	}
 	layout.end();
 	assert(layout.m_stride == _strideBytes);
@@ -95,9 +95,9 @@ VertexBuffer::VertexBuffer(std::string name, const bgfx::Memory* mem, VertexDecl
 	for (const auto& d : _vertexDecl)
 	{
 		_vertexDeclOffsets.push_back(_strideBytes);
-		_strideBytes += strides.at(static_cast<size_t>(d._type)).at(d._num - 1);
-		layout.add(attributes.at(static_cast<size_t>(d._attribute)), d._num, types.at(static_cast<size_t>(d._type)),
-		           d._normalized, d._asInt);
+		_strideBytes += strides.at(static_cast<size_t>(d.type)).at(d.num - 1);
+		layout.add(k_Attributes.at(static_cast<size_t>(d.attribute)), d.num, k_Types.at(static_cast<size_t>(d.type)),
+		           d.normalized, d.asInt);
 	}
 	layout.end();
 	assert(layout.m_stride == _strideBytes);

--- a/src/Graphics/VertexBuffer.h
+++ b/src/Graphics/VertexBuffer.h
@@ -50,21 +50,21 @@ struct VertexAttrib
 		Float,
 	};
 
-	Attribute _attribute; ///< Type of data represented
-	uint8_t _num;         ///< Number of components per vertex attribute, must be 1, 2,
-	                      ///< 3, 4.
-	Type _type;           ///< Data type of each attribute component in the array.
-	bool _normalized;     /// < When using fixed point values, range will be
-	                      /// normalized to 0.0-1.0 in shader.
-	bool _asInt;          /// < Should not be altered. Unpacking will have to be done in
-	                      /// vertex shader.
+	Attribute attribute; ///< Type of data represented
+	uint8_t num;         ///< Number of components per vertex attribute, must be 1, 2,
+	                     ///< 3, 4.
+	Type type;           ///< Data type of each attribute component in the array.
+	bool normalized;     /// < When using fixed point values, range will be
+	                     /// normalized to 0.0-1.0 in shader.
+	bool asInt;          /// < Should not be altered. Unpacking will have to be done in
+	                     /// vertex shader.
 
 	VertexAttrib(Attribute attribute, uint8_t num, Type type, bool normalized = false, bool asInt = false)
-	    : _attribute(attribute)
-	    , _num(num)
-	    , _type(type)
-	    , _normalized(normalized)
-	    , _asInt(asInt)
+	    : attribute(attribute)
+	    , num(num)
+	    , type(type)
+	    , normalized(normalized)
+	    , asInt(asInt)
 	{
 	}
 };

--- a/src/Gui/Console.cpp
+++ b/src/Gui/Console.cpp
@@ -37,7 +37,7 @@ Console::Console()
 	// TODO: Add custom spdlog sink here
 	for (const auto& signature : lhscriptx::FeatureScriptCommands::Signatures)
 	{
-		std::string details = "";
+		std::string details;
 		for (bool skip = true; const auto param : signature.parameters)
 		{
 			if (!skip)
@@ -218,7 +218,7 @@ void Console::Draw(Game& game)
 	ImGuiIO& io = ImGui::GetIO();
 
 	glm::ivec2 screenSize {};
-	if (game.GetWindow())
+	if (game.GetWindow() != nullptr)
 	{
 		game.GetWindow()->GetSize(screenSize.x, screenSize.y);
 	}
@@ -226,11 +226,12 @@ void Console::Draw(Game& game)
 	SDL_GetMouseState(&mousePosition.x, &mousePosition.y);
 	if (!io.WantCaptureMouse && screenSize.x > 0 && screenSize.y > 0)
 	{
-		glm::vec3 rayOrigin, rayDirection;
+		glm::vec3 rayOrigin;
+		glm::vec3 rayDirection;
 		game.GetCamera().DeprojectScreenToWorld(mousePosition, screenSize, rayOrigin, rayDirection);
 		if (auto hit = game.GetDynamicsSystem().RayCastClosestHit(rayOrigin, rayDirection, 1e10f))
 		{
-			if (hit->second.userData)
+			if (hit->second.userData != nullptr)
 			{
 				switch (hit->second.type)
 				{
@@ -314,7 +315,7 @@ void Console::Draw(Game& game)
 		// Normally you would store more information in your item (e.g. make Items[] an array of structure, store color/type
 		// etc.)
 		bool pop_color = false;
-		if (strstr(item.c_str(), "[error]"))
+		if (strstr(item.c_str(), "[error]") != nullptr)
 		{
 			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.4f, 0.4f, 1.0f));
 			pop_color = true;
@@ -331,7 +332,9 @@ void Console::Draw(Game& game)
 		}
 	}
 	if (copy_to_clipboard)
+	{
 		ImGui::LogFinish();
+	}
 
 	if (ImGui::GetScrollY() >= ImGui::GetScrollMaxY())
 	{
@@ -356,11 +359,13 @@ void Console::Draw(Game& game)
 		std::string s = _inputBuffer.data();
 
 		// trim string
-		s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) { return !std::isspace(ch); }));
-		s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) { return !std::isspace(ch); }).base(), s.end());
+		s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) { return std::isspace(ch) == 0; }));
+		s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) { return std::isspace(ch) == 0; }).base(), s.end());
 
-		if (s[0])
+		if (s[0] != 0)
+		{
 			ExecCommand(s, game);
+		}
 
 		_inputBuffer[0] = '\0';
 
@@ -413,11 +418,13 @@ void Console::ExecCommand(const std::string& command_line, Game& game)
 	// optimal.
 	_historyPos.reset();
 	for (int i = static_cast<int>(_history.size()) - 1; i >= 0; i--)
+	{
 		if (_history[i] == command_line)
 		{
 			_history.erase(_history.begin() + i);
 			break;
 		}
+	}
 	_history.emplace_back(command_line);
 
 	// Process command

--- a/src/Gui/Console.cpp
+++ b/src/Gui/Console.cpp
@@ -35,7 +35,7 @@ Console::Console()
       }
 {
 	// TODO: Add custom spdlog sink here
-	for (const auto& signature : lhscriptx::FeatureScriptCommands::Signatures)
+	for (const auto& signature : lhscriptx::FeatureScriptCommands::k_Signatures)
 	{
 		std::string details;
 		for (bool skip = true; const auto param : signature.parameters)
@@ -84,71 +84,70 @@ int Console::InputTextCallback(ImGuiInputTextCallbackData* data)
 		// Example of TEXT COMPLETION
 
 		// Locate beginning of current word
-		const char* word_end = data->Buf + data->CursorPos;
-		const char* word_start = word_end;
-		while (word_start > data->Buf)
+		const char* wordEnd = data->Buf + data->CursorPos;
+		const char* wordStart = wordEnd;
+		while (wordStart > data->Buf)
 		{
-			const char c = word_start[-1];
+			const char c = wordStart[-1];
 			if (c == ' ' || c == '\t' || c == ',' || c == ';')
 			{
 				break;
 			}
-			word_start--;
+			wordStart--;
 		}
 
 		// Build a list of candidates
 		std::vector<std::string> candidates;
-		for (auto& Command : _commands)
+		for (auto& command : _commands)
 		{
-			if (word_end == word_start ||
-			    strncmp(Command.first.c_str(), word_start, static_cast<int>(word_end - word_start)) == 0)
+			if (wordEnd == wordStart || strncmp(command.first.c_str(), wordStart, static_cast<int>(wordEnd - wordStart)) == 0)
 			{
-				candidates.push_back(Command.first);
+				candidates.push_back(command.first);
 			}
 		}
 
 		if (candidates.empty())
 		{
 			// No match
-			AddLog("No match for \"%.*s\"!\n", static_cast<int>(word_end - word_start), word_start);
+			AddLog("No match for \"%.*s\"!\n", static_cast<int>(wordEnd - wordStart), wordStart);
 		}
 		else if (candidates.size() == 1)
 		{
 			// Single match. Delete the beginning of the word and replace it entirely so we've got nice casing
-			data->DeleteChars(static_cast<int>(word_start - data->Buf), static_cast<int>(word_end - word_start));
+			data->DeleteChars(static_cast<int>(wordStart - data->Buf), static_cast<int>(wordEnd - wordStart));
 			data->InsertChars(data->CursorPos, candidates[0].c_str());
 		}
 		else
 		{
 			// Multiple matches. Complete as much as we can, so inputing "C" will complete to "CL" and display
 			// "CLEAR" and "CLASSIFY"
-			int match_len = static_cast<int>(word_end - word_start);
+			int matchLen = static_cast<int>(wordEnd - wordStart);
 			for (;;)
 			{
 				char c = 0;
-				bool all_candidates_matches = true;
-				for (size_t i = 0; i < candidates.size() && all_candidates_matches; i++)
+				bool allCandidatesMatches = true;
+				for (size_t i = 0; i < candidates.size() && allCandidatesMatches; i++)
 				{
 					if (i == 0)
 					{
-						c = candidates[i][match_len];
+						c = candidates[i][matchLen];
 					}
-					else if (c == 0 || c != candidates[i][match_len])
+					else if (c == 0 || c != candidates[i][matchLen])
 					{
-						all_candidates_matches = false;
+						allCandidatesMatches = false;
 					}
 				}
-				if (!all_candidates_matches)
+				if (!allCandidatesMatches)
 				{
 					break;
 				}
-				match_len++;
+				matchLen++;
 			}
 
-			if (match_len > 0)
+			if (matchLen > 0)
 			{
-				data->DeleteChars(static_cast<int>(word_start - data->Buf), static_cast<int>(word_end - word_start));
-				data->InsertChars(data->CursorPos, candidates[0].c_str(), candidates[0].c_str() + match_len);
+				data->DeleteChars(static_cast<int>(wordStart - data->Buf), static_cast<int>(wordEnd - wordStart));
+				data->InsertChars(data->CursorPos, candidates[0].c_str(), candidates[0].c_str() + matchLen);
 			}
 
 			// List matches
@@ -164,7 +163,7 @@ int Console::InputTextCallback(ImGuiInputTextCallbackData* data)
 	case ImGuiInputTextFlags_CallbackHistory:
 	{
 		// Example of HISTORY
-		const auto prev_historyPos = _historyPos;
+		const auto prevHistoryPos = _historyPos;
 		if (data->EventKey == ImGuiKey_UpArrow)
 		{
 			if (!_historyPos.has_value())
@@ -196,11 +195,11 @@ int Console::InputTextCallback(ImGuiInputTextCallbackData* data)
 		}
 
 		// A better implementation would preserve the data on the current input line along with cursor position.
-		if (prev_historyPos != _historyPos)
+		if (prevHistoryPos != _historyPos)
 		{
-			auto history_str = _historyPos.has_value() ? _history[*_historyPos] : _partial;
+			auto historyStr = _historyPos.has_value() ? _history[*_historyPos] : _partial;
 			data->DeleteChars(0, data->BufTextLen);
-			data->InsertChars(0, history_str.c_str());
+			data->InsertChars(0, historyStr.c_str());
 		}
 		break;
 	}
@@ -273,13 +272,13 @@ void Console::Draw(Game& game)
 		_items.clear();
 	}
 	ImGui::SameLine();
-	bool copy_to_clipboard = ImGui::SmallButton("Copy");
+	bool copyToClipboard = ImGui::SmallButton("Copy");
 
 	ImGui::Separator();
 
-	const float footer_height_to_reserve =
+	const float footerHeightToReserve =
 	    ImGui::GetStyle().ItemSpacing.y + ImGui::GetFrameHeightWithSpacing(); // 1 separator, 1 input text
-	ImGui::BeginChild("ScrollingRegion", ImVec2(0, -footer_height_to_reserve), false,
+	ImGui::BeginChild("ScrollingRegion", ImVec2(0, -footerHeightToReserve), false,
 	                  ImGuiWindowFlags_HorizontalScrollbar); // Leave room for 1 separator + 1 InputText
 	if (ImGui::BeginPopupContextWindow())
 	{
@@ -306,7 +305,7 @@ void Console::Draw(Game& game)
 	// we can manage to improve this example code! If your items are of variable size you may want to implement code similar
 	// to what ImGuiListClipper does. Or split your data into fixed height items to allow random-seeking into your list.
 	ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(4, 1)); // Tighten spacing
-	if (copy_to_clipboard)
+	if (copyToClipboard)
 	{
 		ImGui::LogToClipboard();
 	}
@@ -314,24 +313,24 @@ void Console::Draw(Game& game)
 	{
 		// Normally you would store more information in your item (e.g. make Items[] an array of structure, store color/type
 		// etc.)
-		bool pop_color = false;
+		bool popColor = false;
 		if (strstr(item.c_str(), "[error]") != nullptr)
 		{
 			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.4f, 0.4f, 1.0f));
-			pop_color = true;
+			popColor = true;
 		}
 		else if (strncmp(item.c_str(), "# ", 2) == 0)
 		{
 			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.8f, 0.6f, 1.0f));
-			pop_color = true;
+			popColor = true;
 		}
 		ImGui::TextUnformatted(item.c_str());
-		if (pop_color)
+		if (popColor)
 		{
 			ImGui::PopStyleColor();
 		}
 	}
-	if (copy_to_clipboard)
+	if (copyToClipboard)
 	{
 		ImGui::LogFinish();
 	}
@@ -410,37 +409,37 @@ void Console::AddLog(const char* fmt, ...)
 	_items.emplace_back(buf.data());
 }
 
-void Console::ExecCommand(const std::string& command_line, Game& game)
+void Console::ExecCommand(const std::string& commandLine, Game& game)
 {
-	AddLog("# %s\n", command_line.c_str());
+	AddLog("# %s\n", commandLine.c_str());
 
 	// Insert into history. First find match and delete it so it can be pushed to the back. This isn't trying to be smart or
 	// optimal.
 	_historyPos.reset();
 	for (int i = static_cast<int>(_history.size()) - 1; i >= 0; i--)
 	{
-		if (_history[i] == command_line)
+		if (_history[i] == commandLine)
 		{
 			_history.erase(_history.begin() + i);
 			break;
 		}
 	}
-	_history.emplace_back(command_line);
+	_history.emplace_back(commandLine);
 
 	// Process command
-	if (command_line == "clear")
+	if (commandLine == "clear")
 	{
 		_items.clear();
 	}
-	else if (command_line == "help")
+	else if (commandLine == "help")
 	{
 		AddLog("Commands:");
-		for (auto& Command : _commands)
+		for (auto& command : _commands)
 		{
-			AddLog("- %s%s", Command.first.c_str(), Command.second.c_str());
+			AddLog("- %s%s", command.first.c_str(), command.second.c_str());
 		}
 	}
-	else if (command_line == "history")
+	else if (commandLine == "history")
 	{
 		size_t first = _history.size() - 10;
 		for (size_t i = first > 0 ? first : 0; i < _history.size(); i++)
@@ -453,7 +452,7 @@ void Console::ExecCommand(const std::string& command_line, Game& game)
 		try
 		{
 			lhscriptx::Script script(&game);
-			script.Load(command_line);
+			script.Load(commandLine);
 		}
 		catch (std::runtime_error& error)
 		{

--- a/src/Gui/Console.h
+++ b/src/Gui/Console.h
@@ -46,7 +46,7 @@ protected:
 
 private:
 	void AddLog(const char* fmt, ...);
-	void ExecCommand(const std::string& command_line, Game& game);
+	void ExecCommand(const std::string& commandLine, Game& game);
 	int InputTextCallback(ImGuiInputTextCallbackData* data);
 
 	bool _reclaimFocus {false};

--- a/src/Gui/Gui.cpp
+++ b/src/Gui/Gui.cpp
@@ -79,7 +79,7 @@ using namespace openblack::gui;
 
 namespace
 {
-const std::array<bgfx::EmbeddedShader, 5> s_embeddedShaders = {{
+const std::array<bgfx::EmbeddedShader, 5> k_EmbeddedShaders = {{
     BGFX_EMBEDDED_SHADER(vs_ocornut_imgui),
     BGFX_EMBEDDED_SHADER(fs_ocornut_imgui),
     BGFX_EMBEDDED_SHADER(vs_imgui_image),
@@ -89,7 +89,7 @@ const std::array<bgfx::EmbeddedShader, 5> s_embeddedShaders = {{
 }};
 } // namespace
 
-std::unique_ptr<Gui> Gui::create(const GameWindow* window, graphics::RenderPass viewId, float scale)
+std::unique_ptr<Gui> Gui::Create(const GameWindow* window, graphics::RenderPass viewId, float scale)
 {
 	IMGUI_CHECKVERSION();
 	auto* imgui = ImGui::CreateContext();
@@ -353,10 +353,10 @@ bool Gui::CreateDeviceObjectsBgfx()
 {
 	// Create shaders
 	bgfx::RendererType::Enum type = bgfx::getRendererType();
-	_program = bgfx::createProgram(bgfx::createEmbeddedShader(s_embeddedShaders.data(), type, "vs_ocornut_imgui"),
-	                               bgfx::createEmbeddedShader(s_embeddedShaders.data(), type, "fs_ocornut_imgui"), true);
-	_imageProgram = bgfx::createProgram(bgfx::createEmbeddedShader(s_embeddedShaders.data(), type, "vs_imgui_image"),
-	                                    bgfx::createEmbeddedShader(s_embeddedShaders.data(), type, "fs_imgui_image"), true);
+	_program = bgfx::createProgram(bgfx::createEmbeddedShader(k_EmbeddedShaders.data(), type, "vs_ocornut_imgui"),
+	                               bgfx::createEmbeddedShader(k_EmbeddedShaders.data(), type, "fs_ocornut_imgui"), true);
+	_imageProgram = bgfx::createProgram(bgfx::createEmbeddedShader(k_EmbeddedShaders.data(), type, "vs_imgui_image"),
+	                                    bgfx::createEmbeddedShader(k_EmbeddedShaders.data(), type, "fs_imgui_image"), true);
 
 	// Create buffers
 	_u_imageLodEnabled = bgfx::createUniform("u_imageLodEnabled", bgfx::UniformType::Vec4);
@@ -391,13 +391,13 @@ void Gui::UpdateMousePosAndButtons()
 
 	int mx;
 	int my;
-	Uint32 mouse_buttons = SDL_GetMouseState(&mx, &my);
+	Uint32 mouseButtons = SDL_GetMouseState(&mx, &my);
 	io.MouseDown[0] = _mousePressed[0] ||
-	                  (mouse_buttons & SDL_BUTTON(SDL_BUTTON_LEFT)) != 0; // If a mouse press event came, always pass it as
-	                                                                      // "mouse held this frame", so we don't miss
-	                                                                      // click-release events that are shorter than 1 frame.
-	io.MouseDown[1] = _mousePressed[1] || (mouse_buttons & SDL_BUTTON(SDL_BUTTON_RIGHT)) != 0;
-	io.MouseDown[2] = _mousePressed[2] || (mouse_buttons & SDL_BUTTON(SDL_BUTTON_MIDDLE)) != 0;
+	                  (mouseButtons & SDL_BUTTON(SDL_BUTTON_LEFT)) != 0; // If a mouse press event came, always pass it as
+	                                                                     // "mouse held this frame", so we don't miss
+	                                                                     // click-release events that are shorter than 1 frame.
+	io.MouseDown[1] = _mousePressed[1] || (mouseButtons & SDL_BUTTON(SDL_BUTTON_RIGHT)) != 0;
+	io.MouseDown[2] = _mousePressed[2] || (mouseButtons & SDL_BUTTON(SDL_BUTTON_MIDDLE)) != 0;
 	_mousePressed[0] = _mousePressed[1] = _mousePressed[2] = false;
 
 #if SDL_HAS_CAPTURE_AND_GLOBAL_MOUSE && !defined(__EMSCRIPTEN__) && !defined(__ANDROID__) && \
@@ -438,8 +438,8 @@ void Gui::UpdateMouseCursor()
 		return;
 	}
 
-	ImGuiMouseCursor imgui_cursor = ImGui::GetMouseCursor();
-	if (io.MouseDrawCursor || imgui_cursor == ImGuiMouseCursor_None)
+	ImGuiMouseCursor imguiCursor = ImGui::GetMouseCursor();
+	if (io.MouseDrawCursor || imguiCursor == ImGuiMouseCursor_None)
 	{
 		// Hide OS mouse cursor if imgui is drawing it or if it wants no cursor
 		SDL_ShowCursor(SDL_FALSE);
@@ -447,7 +447,7 @@ void Gui::UpdateMouseCursor()
 	else
 	{
 		// Show OS mouse cursor
-		auto* const cursor = _mouseCursors.at(imgui_cursor);
+		auto* const cursor = _mouseCursors.at(imguiCursor);
 		SDL_SetCursor(cursor != nullptr ? cursor : _mouseCursors[ImGuiMouseCursor_Arrow]);
 		SDL_ShowCursor(SDL_TRUE);
 	}
@@ -483,7 +483,7 @@ void Gui::UpdateGamepads()
 		if (vn > 0.0f && io.NavInputs[(NAV_NO)] < vn)                                                            \
 			io.NavInputs[(NAV_NO)] = vn;                                                                         \
 	}
-	const int thumb_dead_zone = 8000;                            // SDL_gamecontroller.h suggests using this value.
+	const int thumbDeadZone = 8000;                              // SDL_gamecontroller.h suggests using this value.
 	MAP_BUTTON(ImGuiNavInput_Activate, SDL_CONTROLLER_BUTTON_A); // Cross / A
 	MAP_BUTTON(ImGuiNavInput_Cancel, SDL_CONTROLLER_BUTTON_B);   // Circle / B
 	MAP_BUTTON(ImGuiNavInput_Menu, SDL_CONTROLLER_BUTTON_X);     // Square / X
@@ -503,10 +503,10 @@ void Gui::UpdateGamepads()
 	           SDL_CONTROLLER_BUTTON_LEFTSHOULDER); // L1 / LB
 	MAP_BUTTON(ImGuiNavInput_TweakFast,
 	           SDL_CONTROLLER_BUTTON_RIGHTSHOULDER); // R1 / RB
-	MAP_ANALOG(ImGuiNavInput_LStickLeft, SDL_CONTROLLER_AXIS_LEFTX, -thumb_dead_zone, -32768);
-	MAP_ANALOG(ImGuiNavInput_LStickRight, SDL_CONTROLLER_AXIS_LEFTX, +thumb_dead_zone, +32767);
-	MAP_ANALOG(ImGuiNavInput_LStickUp, SDL_CONTROLLER_AXIS_LEFTY, -thumb_dead_zone, -32767);
-	MAP_ANALOG(ImGuiNavInput_LStickDown, SDL_CONTROLLER_AXIS_LEFTY, +thumb_dead_zone, +32767);
+	MAP_ANALOG(ImGuiNavInput_LStickLeft, SDL_CONTROLLER_AXIS_LEFTX, -thumbDeadZone, -32768);
+	MAP_ANALOG(ImGuiNavInput_LStickRight, SDL_CONTROLLER_AXIS_LEFTX, +thumbDeadZone, +32767);
+	MAP_ANALOG(ImGuiNavInput_LStickUp, SDL_CONTROLLER_AXIS_LEFTY, -thumbDeadZone, -32767);
+	MAP_ANALOG(ImGuiNavInput_LStickDown, SDL_CONTROLLER_AXIS_LEFTY, +thumbDeadZone, +32767);
 
 	io.BackendFlags |= ImGuiBackendFlags_HasGamepad;
 #undef MAP_BUTTON
@@ -525,14 +525,14 @@ void Gui::NewFrameSdl2(SDL_Window* window)
 	{
 		int w;
 		int h;
-		int display_w;
-		int display_h;
+		int displayW;
+		int displayH;
 		SDL_GetWindowSize(window, &w, &h);
-		SDL_GL_GetDrawableSize(window, &display_w, &display_h);
+		SDL_GL_GetDrawableSize(window, &displayW, &displayH);
 		io.DisplaySize = ImVec2(static_cast<float>(w), static_cast<float>(h));
 		if (w > 0 && h > 0)
 		{
-			io.DisplayFramebufferScale = ImVec2(static_cast<float>(display_w) / w, static_cast<float>(display_h) / h);
+			io.DisplayFramebufferScale = ImVec2(static_cast<float>(displayW) / w, static_cast<float>(displayH) / h);
 		}
 	}
 	else
@@ -544,10 +544,10 @@ void Gui::NewFrameSdl2(SDL_Window* window)
 	// Setup time step (we don't use SDL_GetTicks() because it is using
 	// millisecond resolution)
 	static Uint64 frequency = SDL_GetPerformanceFrequency();
-	Uint64 current_time = SDL_GetPerformanceCounter();
-	io.DeltaTime = _time > 0 ? static_cast<float>(static_cast<double>(current_time - _time) / frequency)
-	                         : static_cast<float>(1.0f / 60.0f);
-	_time = current_time;
+	Uint64 currentTime = SDL_GetPerformanceCounter();
+	io.DeltaTime =
+	    _time > 0 ? static_cast<float>(static_cast<double>(currentTime - _time) / frequency) : static_cast<float>(1.0f / 60.0f);
+	_time = currentTime;
 
 	UpdateMousePosAndButtons();
 	UpdateMouseCursor();
@@ -736,7 +736,7 @@ bool Gui::ShowMenu(Game& game)
 				}
 			});
 
-			auto menu_item = [&game](const auto& label, const std::filesystem::path& path) {
+			auto menuItem = [&game](const auto& label, const std::filesystem::path& path) {
 				if (ImGui::MenuItem(label.data()))
 				{
 					game.LoadMap(path);
@@ -750,13 +750,13 @@ bool Gui::ShowMenu(Game& game)
 			ImGui::MenuItem("Story Islands", nullptr, false, false);
 			for (auto& level : campaigns)
 			{
-				menu_item(level->GetName(), level->GetScriptPath());
+				menuItem(level->GetName(), level->GetScriptPath());
 			}
 			ImGui::Separator();
 			ImGui::MenuItem("Playground Islands", nullptr, false, false);
 			for (auto& level : playgrounds)
 			{
-				menu_item(level->GetName(), level->GetScriptPath());
+				menuItem(level->GetName(), level->GetScriptPath());
 			}
 
 			ImGui::EndMenu();
@@ -768,7 +768,7 @@ bool Gui::ShowMenu(Game& game)
 		{
 			if (ImGui::SliderFloat("Time of Day", &config.timeOfDay, 0.0f, 24.0f, "%.3f"))
 			{
-				Game::instance()->SetTime(fmodf(config.timeOfDay, 24.0f));
+				Game::Instance()->SetTime(fmodf(config.timeOfDay, 24.0f));
 			}
 
 			ImGui::Text("Sky Type Index %f", game.GetSky().GetCurrentSkyType());
@@ -820,19 +820,19 @@ bool Gui::ShowMenu(Game& game)
 			if (ImGui::BeginMenu("Game Speed"))
 			{
 				float multiplier = game.GetGameSpeed();
-				ImGui::Text("Scaled game duration: %.3fms (%.3f Hz)", multiplier * Game::kTurnDuration.count(),
-				            1000.0f / (multiplier * Game::kTurnDuration.count()));
+				ImGui::Text("Scaled game duration: %.3fms (%.3f Hz)", multiplier * Game::k_TurnDuration.count(),
+				            1000.0f / (multiplier * Game::k_TurnDuration.count()));
 				if (ImGui::MenuItem("Slow"))
 				{
-					game.SetGameSpeed(Game::kTurnDurationMultiplierSlow);
+					game.SetGameSpeed(Game::k_TurnDurationMultiplierSlow);
 				}
 				if (ImGui::MenuItem("Normal"))
 				{
-					game.SetGameSpeed(Game::kTurnDurationMultiplierNormal);
+					game.SetGameSpeed(Game::k_TurnDurationMultiplierNormal);
 				}
 				if (ImGui::MenuItem("Fast"))
 				{
-					game.SetGameSpeed(Game::kTurnDurationMultiplierFast);
+					game.SetGameSpeed(Game::k_TurnDurationMultiplierFast);
 				}
 				if (ImGui::SliderFloat("Multiplier", &multiplier, 1.0f / 10.0f, 10.0f, "%.3f", ImGuiSliderFlags_Logarithmic))
 				{
@@ -881,11 +881,11 @@ void Gui::RenderArrow(const std::string& name, const ImVec2& pos, const ImVec2& 
 	ImGui::SetNextWindowSize(size);
 	if (ImGui::Begin((name + " Frame").c_str(), nullptr, boxOverlayFlags))
 	{
-		std::string str_id = name + " Arrow";
+		std::string strId = name + " Arrow";
 		ImGuiWindow* window = ImGui::GetCurrentWindow();
 		if (!window->SkipItems)
 		{
-			const ImGuiID id = window->GetID(str_id.c_str());
+			const ImGuiID id = window->GetID(strId.c_str());
 			const ImRect bb(window->DC.CursorPos, ImVec2(window->DC.CursorPos.x + size.x, window->DC.CursorPos.y + size.y));
 			if (ImGui::ItemAdd(bb, id))
 			{
@@ -907,13 +907,13 @@ void Gui::RenderArrow(const std::string& name, const ImVec2& pos, const ImVec2& 
 	ImGui::PopStyleVar(); // ImGuiStyleVar_WindowPadding
 }
 
-bool boxIntersect(const glm::vec4& box_1, const glm::vec4& box_2)
+bool boxIntersect(const glm::vec4& box1, const glm::vec4& box2)
 {
 	// where z is width and y is height
-	return box_1.x - box_2.x < box_2.z && //
-	       box_2.x - box_1.x < box_1.z && //
-	       box_1.y - box_2.y < box_2.w && //
-	       box_2.y - box_1.y < box_1.w;
+	return box1.x - box2.x < box2.z && //
+	       box2.x - box1.x < box1.z && //
+	       box1.y - box2.y < box2.w && //
+	       box2.y - box1.y < box1.w;
 }
 
 bool fitBox(float minY, const std::vector<glm::vec4>& coveredAreas, glm::vec4& box)
@@ -1065,9 +1065,9 @@ void Gui::ShowVillagerNames(const Game& game)
 		}
 
 		// 3.5 was measured in vanilla but it is possible that it is configurable
-		float max_distance = 3.5f;
+		float maxDistance = 3.5f;
 		const glm::vec3 relativePosition = (camera.GetPosition() - transform.position) / 100.0f;
-		if (glm::dot(relativePosition, relativePosition) > max_distance * max_distance)
+		if (glm::dot(relativePosition, relativePosition) > maxDistance * maxDistance)
 		{
 			return;
 		}
@@ -1085,7 +1085,7 @@ void Gui::ShowVillagerNames(const Game& game)
 		const std::string stateHelpText = "TODO: STATE HELP TEXT";
 		std::string details =
 		    fmt::format("{}\nA:{} L:{}%, H:{}%", stateHelpText, villager.age, villager.health, villager.hunger);
-		const auto& actionSystem = LivingActionSystem::instance();
+		const auto& actionSystem = LivingActionSystem::Instance();
 		if (config.debugVillagerStates)
 		{
 			details += fmt::format(
@@ -1095,9 +1095,10 @@ void Gui::ShowVillagerNames(const Game& game)
 			    "Previous State: {}\n"
 			    "Turns until next state change: {}\n"
 			    "Turns since last state change: {}",
-			    VillagerStateStrings.at(static_cast<size_t>(actionSystem.VillagerGetState(action, LivingAction::Index::Top))),
-			    VillagerStateStrings.at(static_cast<size_t>(actionSystem.VillagerGetState(action, LivingAction::Index::Final))),
-			    VillagerStateStrings.at(
+			    k_VillagerStateStrings.at(static_cast<size_t>(actionSystem.VillagerGetState(action, LivingAction::Index::Top))),
+			    k_VillagerStateStrings.at(
+			        static_cast<size_t>(actionSystem.VillagerGetState(action, LivingAction::Index::Final))),
+			    k_VillagerStateStrings.at(
 			        static_cast<size_t>(actionSystem.VillagerGetState(action, LivingAction::Index::Previous))),
 			    action.turnsUntilStateChange, action.turnsSinceStateChange);
 		}
@@ -1113,33 +1114,33 @@ void Gui::ShowVillagerNames(const Game& game)
 				ImGui::InputInt("Health", reinterpret_cast<int*>(&villager.health));
 				ImGui::InputInt("Age", reinterpret_cast<int*>(&villager.age));
 				ImGui::InputInt("Hunger", reinterpret_cast<int*>(&villager.hunger));
-				ImGui::Combo("Life Stage", &villager.lifeStage, Villager::LifeStageStrs);
-				ImGui::Combo("Sex", &villager.sex, Villager::SexStrs);
-				ImGui::Combo("Tribe", &villager.tribe, TribeStrs);
-				ImGui::Combo("Villager Number", &villager.number, VillagerRoleStrs);
-				ImGui::Combo("Task", &villager.task, Villager::TaskStrs);
+				ImGui::Combo("Life Stage", &villager.lifeStage, Villager::k_LifeStageStrs);
+				ImGui::Combo("Sex", &villager.sex, Villager::k_SexStrs);
+				ImGui::Combo("Tribe", &villager.tribe, k_TribeStrs);
+				ImGui::Combo("Villager Number", &villager.number, k_VillagerRoleStrs);
+				ImGui::Combo("Task", &villager.task, Villager::k_TaskStrs);
 
 				size_t index = 0;
-				for (const auto& str : LivingAction::IndexStrings)
+				for (const auto& str : LivingAction::k_IndexStrings)
 				{
-					if (ImGui::BeginCombo(str.data(), VillagerStateStrings
+					if (ImGui::BeginCombo(str.data(), k_VillagerStateStrings
 					                                      .at(static_cast<size_t>(actionSystem.VillagerGetState(
 					                                          action, static_cast<LivingAction::Index>(index))))
 					                                      .data()))
 					{
 						size_t n = 0;
-						for (const auto& stateStr : VillagerStateStrings)
+						for (const auto& stateStr : k_VillagerStateStrings)
 						{
-							const bool is_selected = static_cast<size_t>(actionSystem.VillagerGetState(
-							                             action, static_cast<LivingAction::Index>(index))) == n;
-							if (ImGui::Selectable(stateStr.data(), is_selected))
+							const bool isSelected = static_cast<size_t>(actionSystem.VillagerGetState(
+							                            action, static_cast<LivingAction::Index>(index))) == n;
+							if (ImGui::Selectable(stateStr.data(), isSelected))
 							{
 								actionSystem.VillagerSetState(action, static_cast<LivingAction::Index>(index),
 								                              static_cast<VillagerStates>(n), true);
 							}
 
 							// Set the initial focus when opening the combo (scrolling + keyboard navigation focus)
-							if (is_selected)
+							if (isSelected)
 							{
 								ImGui::SetItemDefaultFocus();
 							}

--- a/src/Gui/Gui.h
+++ b/src/Gui/Gui.h
@@ -31,10 +31,10 @@ namespace ImGui
 #define IMGUI_FLAGS_ALPHA_BLEND UINT8_C(0x01)
 
 // Helper function for passing bgfx::TextureHandle to ImGui::Image.
-inline void Image(bgfx::TextureHandle _handle, uint8_t _flags, uint8_t _mip, const ImVec2& _size,
-                  const ImVec2& _uv0 = ImVec2(0.0f, 0.0f), const ImVec2& _uv1 = ImVec2(1.0f, 1.0f),
-                  const ImVec4& _tintCol = ImVec4(1.0f, 1.0f, 1.0f, 1.0f),
-                  const ImVec4& _borderCol = ImVec4(0.0f, 0.0f, 0.0f, 0.0f))
+inline void Image(bgfx::TextureHandle handle, uint8_t flags, uint8_t mip, const ImVec2& size,
+                  const ImVec2& cuv0 = ImVec2(0.0f, 0.0f), const ImVec2& cuv1 = ImVec2(1.0f, 1.0f),
+                  const ImVec4& tintCol = ImVec4(1.0f, 1.0f, 1.0f, 1.0f),
+                  const ImVec4& borderCol = ImVec4(0.0f, 0.0f, 0.0f, 0.0f))
 {
 	union
 	{
@@ -46,28 +46,28 @@ inline void Image(bgfx::TextureHandle _handle, uint8_t _flags, uint8_t _mip, con
 		} s;
 		ImTextureID ptr;
 	} texture;
-	texture.s.handle = _handle;
-	texture.s.flags = _flags;
-	texture.s.mip = _mip;
+	texture.s.handle = handle;
+	texture.s.flags = flags;
+	texture.s.mip = mip;
 
 	// Do y-flip
-	auto uv0 = _uv0;
-	auto uv1 = _uv1;
+	auto uv0 = cuv0;
+	auto uv1 = cuv1;
 	if (bgfx::getRendererType() == bgfx::RendererType::OpenGL || bgfx::getRendererType() == bgfx::RendererType::OpenGLES)
 	{
 		uv0.y = 1.0f - uv0.y;
 		uv1.y = 1.0f - uv1.y;
 	}
 
-	Image(texture.ptr, _size, uv0, uv1, _tintCol, _borderCol);
+	Image(texture.ptr, size, uv0, uv1, tintCol, borderCol);
 }
 
 // Helper function for passing bgfx::TextureHandle to ImGui::Image.
-inline void Image(bgfx::TextureHandle _handle, const ImVec2& _size, const ImVec2& _uv0 = ImVec2(0.0f, 0.0f),
-                  const ImVec2& _uv1 = ImVec2(1.0f, 1.0f), const ImVec4& _tintCol = ImVec4(1.0f, 1.0f, 1.0f, 1.0f),
-                  const ImVec4& _borderCol = ImVec4(0.0f, 0.0f, 0.0f, 0.0f))
+inline void Image(bgfx::TextureHandle handle, const ImVec2& size, const ImVec2& uv0 = ImVec2(0.0f, 0.0f),
+                  const ImVec2& uv1 = ImVec2(1.0f, 1.0f), const ImVec4& tintCol = ImVec4(1.0f, 1.0f, 1.0f, 1.0f),
+                  const ImVec4& borderCol = ImVec4(0.0f, 0.0f, 0.0f, 0.0f))
 {
-	Image(_handle, IMGUI_FLAGS_ALPHA_BLEND, 0, _size, _uv0, _uv1, _tintCol, _borderCol);
+	Image(handle, IMGUI_FLAGS_ALPHA_BLEND, 0, size, uv0, uv1, tintCol, borderCol);
 }
 
 } // namespace ImGui
@@ -86,7 +86,7 @@ class DebugWindow;
 class Gui
 {
 public:
-	static std::unique_ptr<Gui> create(const GameWindow* window, graphics::RenderPass viewId, float scale);
+	static std::unique_ptr<Gui> Create(const GameWindow* window, graphics::RenderPass viewId, float scale);
 
 	virtual ~Gui();
 

--- a/src/Gui/LHVMViewer.cpp
+++ b/src/Gui/LHVMViewer.cpp
@@ -27,7 +27,7 @@ const ImVec4 Disassembly_ColorKeyword = ImVec4(0.976f, 0.149f, 0.447f, 1.0f);
 const ImVec4 Disassembly_ColorVariable = ImVec4(0.972f, 0.972f, 0.949f, 1.0f);
 const ImVec4 Disassembly_ColorConstant = ImVec4(0.682f, 0.505f, 1.0f, 1.0f);
 
-static const std::array<std::string, 464> Function_Names = {
+static const std::array<std::string, 464> k_FunctionNames = {
     "NONE",
     "SET_CAMERA_POSITION",
     "SET_CAMERA_FOCUS",
@@ -540,9 +540,9 @@ void LHVMViewer::Draw(Game& game)
 
 		if (ImGui::BeginTabItem("Data"))
 		{
-			static MemoryEditor lhvm_data_editor;
+			static MemoryEditor lhvmDataEditor;
 			auto& data = lhvm.GetData();
-			lhvm_data_editor.DrawContents(reinterpret_cast<void*>(data.data()), data.size(), 0);
+			lhvmDataEditor.DrawContents(reinterpret_cast<void*>(data.data()), data.size(), 0);
 
 			ImGui::EndTabItem();
 		}
@@ -559,13 +559,13 @@ void LHVMViewer::ProcessEventAlways([[maybe_unused]] const SDL_Event& event) {}
 
 void LHVMViewer::DrawScriptsTab(const openblack::LHVM::LHVM& lhvm)
 {
-	static auto vector_getter = [](void* vec, int idx, const char** out_text) {
+	static auto vectorGetter = [](void* vec, int idx, const char** outText) {
 		auto& vector = *static_cast<std::vector<std::string>*>(vec);
 		if (idx < 0 || idx >= static_cast<int>(vector.size()))
 		{
 			return false;
 		}
-		*out_text = vector.at(idx).c_str();
+		*outText = vector.at(idx).c_str();
 		return true;
 	};
 
@@ -613,12 +613,12 @@ void LHVMViewer::DrawScriptsTab(const openblack::LHVM::LHVM& lhvm)
 
 		if (ImGui::BeginTabItem("Local Variables"))
 		{
-			auto script_vars = script.GetVariables();
+			auto scriptVars = script.GetVariables();
 
-			static int selected_var = 0;
+			static int selectedVar = 0;
 			ImGui::PushItemWidth(-1);
-			ImGui::ListBox("", &selected_var, vector_getter, static_cast<void*>(&script_vars),
-			               static_cast<int>(script_vars.size()), 21);
+			ImGui::ListBox("", &selectedVar, vectorGetter, static_cast<void*>(&scriptVars), static_cast<int>(scriptVars.size()),
+			               21);
 			ImGui::EndTabItem();
 		}
 
@@ -699,21 +699,21 @@ void LHVMViewer::DrawScriptDisassembly(const openblack::LHVM::LHVM& lhvm, openbl
 		case LHVM::VMInstruction::Opcode::CALL:
 			ImGui::TextColored(Disassembly_ColorKeyword, "CALL");
 			ImGui::SameLine();
-			ImGui::TextColored(Disassembly_ColorFuncName, "%s", Function_Names.at(instruction.GetData()).c_str());
+			ImGui::TextColored(Disassembly_ColorFuncName, "%s", k_FunctionNames.at(instruction.GetData()).c_str());
 			break;
 		case LHVM::VMInstruction::Opcode::RUN:
 		{
-			auto const& run_script = lhvm.GetScripts().at(instruction.GetData() - 1);
+			auto const& runScript = lhvm.GetScripts().at(instruction.GetData() - 1);
 
 			ImGui::TextColored(Disassembly_ColorKeyword, "RUN");
 			ImGui::SameLine();
-			if (ImGui::TextButtonColored(Disassembly_ColorFuncName, run_script.GetName().c_str()))
+			if (ImGui::TextButtonColored(Disassembly_ColorFuncName, runScript.GetName().c_str()))
 			{
 				SelectScript(instruction.GetData());
 			}
 
 			ImGui::SameLine();
-			ImGui::TextColored(Disassembly_ColorComment, "// expecting %d parameters", run_script.GetParameterCount());
+			ImGui::TextColored(Disassembly_ColorComment, "// expecting %d parameters", runScript.GetParameterCount());
 
 			break;
 		}

--- a/src/Gui/LHVMViewer.cpp
+++ b/src/Gui/LHVMViewer.cpp
@@ -521,7 +521,9 @@ void LHVMViewer::Draw(Game& game)
 			for (size_t i = 0; i < variables.size(); i++)
 			{
 				if (ImGui::Selectable(variables[i].c_str(), selected == i))
+				{
 					selected = i;
+				}
 			}
 
 			ImGui::EndChild();
@@ -576,7 +578,9 @@ void LHVMViewer::DrawScriptsTab(const openblack::LHVM::LHVM& lhvm)
 	for (auto const& script : scripts)
 	{
 		if (ImGui::Selectable(script.GetName().c_str(), script.GetScriptID() == _selectedScriptID))
+		{
 			SelectScript(script.GetScriptID());
+		}
 
 		if (_scrollToSelected && _selectedScriptID == script.GetScriptID())
 		{
@@ -654,10 +658,14 @@ void LHVMViewer::DrawScriptDisassembly(const openblack::LHVM::LHVM& lhvm, openbl
 			ImGui::SameLine();
 
 			if (instruction.GetAccess() == LHVM::VMInstruction::Access::VARIABLE)
+			{
 				DrawVariable(lhvm, script, instruction.GetData());
+			}
 			else if (instruction.GetAccess() == LHVM::VMInstruction::Access::STACK)
+			{
 				ImGui::TextColored(Disassembly_ColorConstant, "%s",
 				                   DataToString(instruction.GetData(), instruction.GetDataType()).c_str());
+			}
 
 			break;
 
@@ -672,13 +680,21 @@ void LHVMViewer::DrawScriptDisassembly(const openblack::LHVM::LHVM& lhvm, openbl
 			break;
 		case LHVM::VMInstruction::Opcode::ADD:
 			if (instruction.GetDataType() == LHVM::VMInstruction::DataType::INT)
+			{
 				ImGui::TextColored(Disassembly_ColorKeyword, "ADDI");
+			}
 			else if (instruction.GetDataType() == LHVM::VMInstruction::DataType::FLOAT)
+			{
 				ImGui::TextColored(Disassembly_ColorKeyword, "ADDF");
+			}
 			else if (instruction.GetDataType() == LHVM::VMInstruction::DataType::VECTOR)
+			{
 				ImGui::TextColored(Disassembly_ColorKeyword, "ADDV");
+			}
 			else
+			{
 				ImGui::TextColored(Disassembly_ColorKeyword, "ADD");
+			}
 			break;
 		case LHVM::VMInstruction::Opcode::CALL:
 			ImGui::TextColored(Disassembly_ColorKeyword, "CALL");
@@ -692,7 +708,9 @@ void LHVMViewer::DrawScriptDisassembly(const openblack::LHVM::LHVM& lhvm, openbl
 			ImGui::TextColored(Disassembly_ColorKeyword, "RUN");
 			ImGui::SameLine();
 			if (ImGui::TextButtonColored(Disassembly_ColorFuncName, run_script.GetName().c_str()))
+			{
 				SelectScript(instruction.GetData());
+			}
 
 			ImGui::SameLine();
 			ImGui::TextColored(Disassembly_ColorComment, "// expecting %d parameters", run_script.GetParameterCount());
@@ -711,7 +729,9 @@ void LHVMViewer::DrawScriptDisassembly(const openblack::LHVM::LHVM& lhvm, openbl
 		}
 
 		if (instruction.GetOpcode() == LHVM::VMInstruction::Opcode::END)
+		{
 			break;
+		}
 	}
 
 	ImGui::EndChild();
@@ -752,7 +772,7 @@ std::string LHVMViewer::DataToString(uint32_t data, openblack::LHVM::VMInstructi
 		return std::to_string(f2u.f) + "f";
 	}
 	case LHVM::VMInstruction::DataType::BOOLEAN:
-		return data ? "true" : "false";
+		return data != 0 ? "true" : "false";
 	default:
 		return std::to_string(data) + " (unk type)";
 	}

--- a/src/Gui/LHVMViewer.h
+++ b/src/Gui/LHVMViewer.h
@@ -36,8 +36,8 @@ private:
 	void SelectScript(uint32_t idx);
 
 	uint32_t _selectedScriptID {1};
-	uint32_t _scrollToSelected {false};
-	uint32_t _resetScriptDisassemblyScroll {false};
+	bool _scrollToSelected {false};
+	bool _resetScriptDisassemblyScroll {false};
 };
 
 } // namespace openblack::gui

--- a/src/Gui/MeshViewer.cpp
+++ b/src/Gui/MeshViewer.cpp
@@ -51,9 +51,9 @@ void MeshViewer::Draw([[maybe_unused]] Game& game)
 	                   ImGuiInputTextFlags_CharsHexadecimal);
 	uint32_t hoverIndex;
 	ImGuiBitField::BitField("Mesh flag bit-field filter", &_meshFlagFilter, &hoverIndex);
-	if (ImGui::IsItemHovered() && hoverIndex < L3DMeshFlagNames.size())
+	if (ImGui::IsItemHovered() && hoverIndex < k_L3DMeshFlagNames.size())
 	{
-		ImGui::SetTooltip("%s", L3DMeshFlagNames.at(hoverIndex).data());
+		ImGui::SetTooltip("%s", k_L3DMeshFlagNames.at(hoverIndex).data());
 	}
 
 	ImGui::BeginChild("meshes", ImVec2(fontSize * 15.0f, 0));
@@ -92,7 +92,7 @@ void MeshViewer::Draw([[maybe_unused]] Game& game)
 	{
 		int32_t offset = 0;
 		int32_t newLines = 1;
-		for (uint32_t flag = 1; const auto& name : L3DMeshFlagNames)
+		for (uint32_t flag = 1; const auto& name : k_L3DMeshFlagNames)
 		{
 			if ((mesh->GetFlags() & flag) != 0)
 			{
@@ -211,17 +211,17 @@ void MeshViewer::Update([[maybe_unused]] Game& game, const Renderer& renderer)
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
-	bgfx::setViewTransform(static_cast<bgfx::ViewId>(_viewId), &view, &perspective);
+	bgfx::setViewTransform(static_cast<bgfx::ViewId>(k_ViewId), &view, &perspective);
 
-	_frameBuffer->Bind(_viewId);
+	_frameBuffer->Bind(k_ViewId);
 	// TODO(bwrsandman): The setting of viewport and clearing should probably be
 	// done in framebuffer bind
 	static const uint32_t clearColor = 0x274659ff;
-	bgfx::setViewClear(static_cast<bgfx::ViewId>(_viewId), BGFX_CLEAR_COLOR | BGFX_CLEAR_DEPTH, clearColor, 1.0f, 0);
+	bgfx::setViewClear(static_cast<bgfx::ViewId>(k_ViewId), BGFX_CLEAR_COLOR | BGFX_CLEAR_DEPTH, clearColor, 1.0f, 0);
 	uint16_t width;
 	uint16_t height;
 	_frameBuffer->GetSize(width, height);
-	bgfx::setViewRect(static_cast<bgfx::ViewId>(_viewId), 0, 0, width, height);
+	bgfx::setViewRect(static_cast<bgfx::ViewId>(k_ViewId), 0, 0, width, height);
 
 	// clang-format off
 	uint64_t state = 0u
@@ -237,7 +237,7 @@ void MeshViewer::Update([[maybe_unused]] Game& game, const Renderer& renderer)
 	{
 		const auto identity = glm::mat4(1.0f);
 		Renderer::L3DMeshSubmitDesc desc = {};
-		desc.viewId = _viewId;
+		desc.viewId = k_ViewId;
 		desc.program = objectShader;
 		desc.state = state;
 		desc.modelMatrices = &identity;
@@ -270,7 +270,7 @@ void MeshViewer::Update([[maybe_unused]] Game& game, const Renderer& renderer)
 			bgfx::setTransform(glm::value_ptr(model));
 			_boundingBox->GetVertexBuffer().Bind();
 			bgfx::setState(BGFX_STATE_DEFAULT | BGFX_STATE_PT_LINES, 0);
-			bgfx::submit(static_cast<bgfx::ViewId>(_viewId), debugShader->GetRawHandle());
+			bgfx::submit(static_cast<bgfx::ViewId>(k_ViewId), debugShader->GetRawHandle());
 		}
 	}
 }

--- a/src/Gui/MeshViewer.h
+++ b/src/Gui/MeshViewer.h
@@ -43,7 +43,7 @@ protected:
 	void ProcessEventAlways(const SDL_Event& event) override;
 
 private:
-	static constexpr graphics::RenderPass _viewId = graphics::RenderPass::MeshViewer;
+	static constexpr graphics::RenderPass k_ViewId = graphics::RenderPass::MeshViewer;
 	entt::id_type _selectedMesh;
 	int _selectedSubMesh {0};
 	std::optional<entt::id_type> _selectedAnimation;

--- a/src/Gui/Profiler.cpp
+++ b/src/Gui/Profiler.cpp
@@ -102,25 +102,25 @@ void openblack::gui::Profiler::Draw(Game& game)
 	ImGuiWidgetFlameGraph::PlotFlame(
 	    "CPU",
 	    [](float* startTimestamp, float* endTimestamp, ImU8* level, const char** caption, const void* data, int idx) -> void {
-		    auto entry = reinterpret_cast<const openblack::Profiler::Entry*>(data);
-		    auto& stage = entry->_stages.at(idx);
-		    if (startTimestamp)
+		    const auto* entry = reinterpret_cast<const openblack::Profiler::Entry*>(data);
+		    const auto& stage = entry->_stages.at(idx);
+		    if (startTimestamp != nullptr)
 		    {
 			    std::chrono::duration<float, std::milli> fltStart = stage._start - entry->_frameStart;
 			    *startTimestamp = fltStart.count();
 		    }
-		    if (endTimestamp)
+		    if (endTimestamp != nullptr)
 		    {
 			    *endTimestamp = stage._end.time_since_epoch().count() / 1e6f;
 
 			    std::chrono::duration<float, std::milli> fltEnd = stage._end - entry->_frameStart;
 			    *endTimestamp = fltEnd.count();
 		    }
-		    if (level)
+		    if (level != nullptr)
 		    {
 			    *level = stage._level;
 		    }
-		    if (caption)
+		    if (caption != nullptr)
 		    {
 			    *caption = openblack::Profiler::stageNames.at(idx).data();
 		    }
@@ -130,22 +130,22 @@ void openblack::gui::Profiler::Draw(Game& game)
 	ImGuiWidgetFlameGraph::PlotFlame(
 	    "GPU",
 	    [](float* startTimestamp, float* endTimestamp, ImU8* level, const char** caption, const void* data, int idx) -> void {
-		    auto stats = reinterpret_cast<const bgfx::Stats*>(data);
-		    if (startTimestamp)
+		    const auto* stats = reinterpret_cast<const bgfx::Stats*>(data);
+		    if (startTimestamp != nullptr)
 		    {
 			    *startTimestamp = static_cast<float>(1000.0 * (stats->viewStats[idx].gpuTimeBegin - stats->gpuTimeBegin) /
 			                                         static_cast<double>(stats->gpuTimerFreq));
 		    }
-		    if (endTimestamp)
+		    if (endTimestamp != nullptr)
 		    {
 			    *endTimestamp = static_cast<float>(1000.0 * (stats->viewStats[idx].gpuTimeEnd - stats->gpuTimeBegin) /
 			                                       static_cast<double>(stats->gpuTimerFreq));
 		    }
-		    if (level)
+		    if (level != nullptr)
 		    {
 			    *level = 0;
 		    }
-		    if (caption)
+		    if (caption != nullptr)
 		    {
 			    *caption = stats->viewStats[idx].name;
 		    }
@@ -168,7 +168,9 @@ void openblack::gui::Profiler::Draw(Game& game)
 			ImGui::SetCursorPosX(cursorX + indentSize * stage._level);
 			ImGui::Text("    %s: %0.3f", openblack::Profiler::stageNames.at(i).data(), duration.count());
 			if (stage._level == 0)
+			{
 				frameDuration -= duration;
+			}
 			++i;
 		}
 		ImGui::Text("    Unaccounted: %0.3f", frameDuration.count());

--- a/src/Gui/Profiler.h
+++ b/src/Gui/Profiler.h
@@ -33,21 +33,21 @@ private:
 	template <typename T, uint8_t N>
 	struct CircularBuffer
 	{
-		static constexpr uint8_t _bufferSize = N;
-		std::array<T, N> _values;
-		uint8_t _offset = 0;
+		static constexpr uint8_t k_BufferSize = N;
+		std::array<T, N> values;
+		uint8_t offset = 0;
 
-		[[nodiscard]] T back() const
+		[[nodiscard]] T Back() const
 		{
 			// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index): perf sensitive
-			return _values[_offset];
+			return values[offset];
 		}
-		void pushBack(T value)
+		void PushBack(T value)
 		{
 
 			// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index): perf sensitive
-			_values[_offset] = value;
-			_offset = (_offset + 1u) % _values.size();
+			values[offset] = value;
+			offset = (offset + 1u) % values.size();
 		}
 	};
 	CircularBuffer<float, 100> _times;

--- a/src/InfoConstants.cpp
+++ b/src/InfoConstants.cpp
@@ -17,7 +17,7 @@ VillagerInfo GVillagerInfo::Find(Tribe tribe, VillagerNumber villagerNumber)
 {
 	bool found = false;
 	auto result = VillagerInfo::None;
-	for (size_t i = 0; const auto& villager : Game::instance()->GetInfoConstants().villager)
+	for (size_t i = 0; const auto& villager : Game::Instance()->GetInfoConstants().villager)
 	{
 		if (villager.tribeType == tribe && villager.villagerNumber == villagerNumber)
 		{
@@ -31,15 +31,15 @@ VillagerInfo GVillagerInfo::Find(Tribe tribe, VillagerNumber villagerNumber)
 		return result;
 	}
 
-	throw std::runtime_error(std::string("Could not find info for ") + TribeStrs.at(static_cast<size_t>(tribe)).data() + " + " +
-	                         VillagerNumberStrs.at(static_cast<size_t>(villagerNumber)).data());
+	throw std::runtime_error(std::string("Could not find info for ") + k_TribeStrs.at(static_cast<size_t>(tribe)).data() +
+	                         " + " + k_VillagerNumberStrs.at(static_cast<size_t>(villagerNumber)).data());
 }
 
 AbodeInfo GAbodeInfo::Find(const std::string& name)
 {
-	for (size_t i = 0; const auto& abode : Game::instance()->GetInfoConstants().abode)
+	for (size_t i = 0; const auto& abode : Game::Instance()->GetInfoConstants().abode)
 	{
-		const auto tribeName = TribeStrs.at(static_cast<uint8_t>(abode.tribeType));
+		const auto tribeName = k_TribeStrs.at(static_cast<uint8_t>(abode.tribeType));
 		const auto abodeName = std::string(abode.debugString.data());
 		if (std::string(tribeName.data()) + "_" + abodeName == name)
 		{
@@ -55,7 +55,7 @@ AbodeInfo GAbodeInfo::Find(Tribe tribe, AbodeNumber abodeNumber)
 {
 	bool found = false;
 	auto result = AbodeInfo::None;
-	for (size_t i = 0; const auto& abode : Game::instance()->GetInfoConstants().abode)
+	for (size_t i = 0; const auto& abode : Game::Instance()->GetInfoConstants().abode)
 	{
 		if ((abode.tribeType == tribe || abode.tribeType == Tribe::NONE) && abode.abodeNumber == abodeNumber)
 		{
@@ -69,13 +69,13 @@ AbodeInfo GAbodeInfo::Find(Tribe tribe, AbodeNumber abodeNumber)
 		return result;
 	}
 
-	throw std::runtime_error(std::string("Could not find info for ") + TribeStrs.at(static_cast<size_t>(tribe)).data() + " + " +
-	                         AbodeNumberStrs.at(static_cast<size_t>(abodeNumber)).data());
+	throw std::runtime_error(std::string("Could not find info for ") + k_TribeStrs.at(static_cast<size_t>(tribe)).data() +
+	                         " + " + k_AbodeNumberStrs.at(static_cast<size_t>(abodeNumber)).data());
 }
 
 FeatureInfo GFeatureInfo::Find(const std::string& name)
 {
-	for (size_t i = 0; const auto& feature : Game::instance()->GetInfoConstants().feature)
+	for (size_t i = 0; const auto& feature : Game::Instance()->GetInfoConstants().feature)
 	{
 		if (name == feature.debugString.data())
 		{
@@ -88,7 +88,7 @@ FeatureInfo GFeatureInfo::Find(const std::string& name)
 
 AnimatedStaticInfo GAnimatedStaticInfo::Find(const std::string& name)
 {
-	for (size_t i = 0; const auto& as : Game::instance()->GetInfoConstants().animatedStatic)
+	for (size_t i = 0; const auto& as : Game::Instance()->GetInfoConstants().animatedStatic)
 	{
 		if (name == as.debugString.data())
 		{

--- a/src/InfoConstants.h
+++ b/src/InfoConstants.h
@@ -315,85 +315,85 @@ struct GSpecialVillagerInfo
 struct CreatureDevelopmentPhaseEntry
 {
 	std::array<char, 0x30> name;
-	float field_0x30;
-	float field_0x34;
-	float field_0x38;
-	uint32_t field_0x3c;
-	uint32_t field_0x40;
-	uint32_t field_0x44;
-	uint32_t field_0x48;
-	uint32_t field_0x4c;
-	uint32_t field_0x50;
-	uint32_t field_0x54;
-	uint32_t field_0x58;
-	uint32_t field_0x5c;
-	uint32_t field_0x60;
-	uint32_t field_0x64;
-	uint32_t field_0x68;
-	uint32_t field_0x6c;
-	uint32_t field_0x70;
+	float field0x30;
+	float field0x34;
+	float field0x38;
+	uint32_t field0x3c;
+	uint32_t field0x40;
+	uint32_t field0x44;
+	uint32_t field0x48;
+	uint32_t field0x4c;
+	uint32_t field0x50;
+	uint32_t field0x54;
+	uint32_t field0x58;
+	uint32_t field0x5c;
+	uint32_t field0x60;
+	uint32_t field0x64;
+	uint32_t field0x68;
+	uint32_t field0x6c;
+	uint32_t field0x70;
 };
 
 struct CreatureInitialDesireInfo
 {
-	uint32_t field_0x0;
-	uint32_t field_0x4;
-	uint32_t field_0x8;
-	uint32_t field_0xc;
-	uint32_t field_0x10;
-	uint32_t field_0x14;
-	uint32_t field_0x18;
-	uint32_t field_0x1c;
-	uint32_t field_0x20;
-	uint32_t field_0x24;
-	uint32_t field_0x28;
-	uint32_t field_0x2c;
-	uint32_t field_0x30;
-	uint32_t field_0x34;
-	uint32_t field_0x38;
-	float field_0x3c;
-	float field_0x40;
-	float field_0x44;
-	float field_0x48;
-	float field_0x4c;
-	float field_0x50;
-	float field_0x54;
-	float field_0x58;
-	uint32_t field_0x5c;
-	float field_0x60;
-	float field_0x64;
-	float field_0x68;
-	uint32_t field_0x6c;
-	std::array<char, 0x40> field_0x70;
-	std::array<char, 0x40> field_0xb0;
-	std::array<char, 0x40> field_0xf0;
-	std::array<char, 0x40> field_0x130;
-	std::array<char, 0x40> field_0x170;
+	uint32_t field0x0;
+	uint32_t field0x4;
+	uint32_t field0x8;
+	uint32_t field0xc;
+	uint32_t field0x10;
+	uint32_t field0x14;
+	uint32_t field0x18;
+	uint32_t field0x1c;
+	uint32_t field0x20;
+	uint32_t field0x24;
+	uint32_t field0x28;
+	uint32_t field0x2c;
+	uint32_t field0x30;
+	uint32_t field0x34;
+	uint32_t field0x38;
+	float field0x3c;
+	float field0x40;
+	float field0x44;
+	float field0x48;
+	float field0x4c;
+	float field0x50;
+	float field0x54;
+	float field0x58;
+	uint32_t field0x5c;
+	float field0x60;
+	float field0x64;
+	float field0x68;
+	uint32_t field0x6c;
+	std::array<char, 0x40> field0x70;
+	std::array<char, 0x40> field0xb0;
+	std::array<char, 0x40> field0xf0;
+	std::array<char, 0x40> field0x130;
+	std::array<char, 0x40> field0x170;
 };
 
 struct CreatureActionKnownAboutEntry
 {
-	std::array<char, 0x40> field_0x0;
-	uint32_t field_0x40;
-	uint32_t field_0x44;
-	float field_0x48;
-	uint32_t field_0x4c;
-	uint32_t field_0x50;
-	uint32_t field_0x54;
+	std::array<char, 0x40> field0x0;
+	uint32_t field0x40;
+	uint32_t field0x44;
+	float field0x48;
+	uint32_t field0x4c;
+	uint32_t field0x50;
+	uint32_t field0x54;
 };
 
 struct CreatureDesireAttributeEntry
 {
-	uint32_t field_0x0;
-	uint32_t field_0x4;
-	uint32_t field_0x8;
-	uint32_t field_0xc;
-	uint32_t field_0x10;
-	uint32_t field_0x14;
-	uint32_t field_0x18;
-	uint32_t field_0x1c;
-	uint32_t field_0x20;
-	uint32_t field_0x24;
+	uint32_t field0x0;
+	uint32_t field0x4;
+	uint32_t field0x8;
+	uint32_t field0xc;
+	uint32_t field0x10;
+	uint32_t field0x14;
+	uint32_t field0x18;
+	uint32_t field0x1c;
+	uint32_t field0x20;
+	uint32_t field0x24;
 };
 
 struct GMultiMapFixedInfo: GObjectInfo
@@ -516,20 +516,20 @@ struct GCitadelInfo: GContainerInfo
 
 struct CreatureDevelopmentDurationEntry
 {
-	int field_0x0;
-	int field_0x4;
-	int field_0x8;
-	int field_0xc;
-	int field_0x10;
-	int field_0x14;
-	int field_0x18;
-	int field_0x1c;
-	int field_0x20;
-	int field_0x24;
-	int field_0x28;
-	int field_0x2c;
-	int field_0x30;
-	int field_0x34;
+	int field0x0;
+	int field0x4;
+	int field0x8;
+	int field0xc;
+	int field0x10;
+	int field0x14;
+	int field0x18;
+	int field0x1c;
+	int field0x20;
+	int field0x24;
+	int field0x28;
+	int field0x2c;
+	int field0x30;
+	int field0x34;
 };
 
 struct GTownInfo: GContainerInfo
@@ -750,29 +750,29 @@ struct GClimateRainInfo
 	float november;
 	float december;
 	float midnight;
-	float one_O_Clock;
-	float two_O_Clock;
-	float three_O_Clock;
-	float four_O_Clock;
-	float five_O_Clock;
-	float six_O_Clock;
-	float seven_O_Clock;
-	float height_O_Clock;
-	float nine_O_Clock;
-	float ten_O_Clock;
-	float eleven_O_Clock;
+	float oneOClock;
+	float twoOClock;
+	float threeOClock;
+	float fourOClock;
+	float fiveOClock;
+	float sixOClock;
+	float sevenOClock;
+	float heightOClock;
+	float nineOClock;
+	float tenOClock;
+	float elevenOClock;
 	float midday;
-	float thirdten_O_Clock;
-	float fourten_O_Clock;
-	float fiveten_O_Clock;
-	float sixten_O_Clock;
-	float seventen_O_Clock;
-	float heightten_O_Clock;
-	float nineten_O_Clock;
-	float twenty_O_Clock;
-	float twentyone_O_Clock;
-	float twentytwo_O_Clock;
-	float twentitree_O_Clock;
+	float thirdtenOClock;
+	float fourtenOClock;
+	float fivetenOClock;
+	float sixtenOClock;
+	float seventenOClock;
+	float heighttenOClock;
+	float ninetenOClock;
+	float twentyOClock;
+	float twentyoneOClock;
+	float twentytwoOClock;
+	float twentitreeOClock;
 	float natureRainDesire;
 };
 struct GCreaturePenInfo: GCitadelPartInfo
@@ -785,9 +785,9 @@ struct GCreaturePenInfo: GCitadelPartInfo
 
 struct GScriptOpposingCreature
 {
-	uint32_t field_0x0;
-	uint32_t field_0x4;
-	uint32_t field_0x8;
+	uint32_t field0x0;
+	uint32_t field0x4;
+	uint32_t field0x8;
 };
 
 struct GTotemStatueInfo: GMultiMapFixedInfo
@@ -797,23 +797,23 @@ struct GTotemStatueInfo: GMultiMapFixedInfo
 
 struct CreatureDesireForType
 {
-	float field_0x0;
-	float field_0x4;
-	float field_0x8;
-	float field_0xc;
-	float field_0x10;
-	float field_0x14;
-	float field_0x18;
-	float field_0x1c;
-	float field_0x20;
-	float field_0x24;
-	float field_0x28;
-	float field_0x2c;
-	float field_0x30;
-	float field_0x34;
-	float field_0x38;
-	float field_0x3c;
-	float field_0x40;
+	float field0x0;
+	float field0x4;
+	float field0x8;
+	float field0xc;
+	float field0x10;
+	float field0x14;
+	float field0x18;
+	float field0x1c;
+	float field0x20;
+	float field0x24;
+	float field0x28;
+	float field0x2c;
+	float field0x30;
+	float field0x34;
+	float field0x38;
+	float field0x3c;
+	float field0x40;
 };
 
 struct GVortexInfo
@@ -856,7 +856,7 @@ struct GSpeedThreshold
 
 struct GCreatureInfo: GLivingInfo
 {
-	std::array<uint8_t, 416> field_0x1e4;
+	std::array<uint8_t, 416> field0x1e4;
 };
 
 struct GMagicRadiusSpellInfo: GMagicInfo
@@ -874,40 +874,40 @@ struct GMagicStormAndTornadoInfo: GMagicRadiusSpellInfo
 
 struct GHelpSpritesGuidance
 {
-	uint32_t field_0x0;
-	uint32_t field_0x4;
-	uint32_t field_0x8;
-	uint32_t field_0xc;
-	uint32_t field_0x10;
-	uint32_t field_0x14;
-	uint32_t field_0x18;
-	uint32_t field_0x1c;
-	uint32_t field_0x20;
-	uint32_t field_0x24;
-	uint32_t field_0x28;
-	uint32_t field_0x2c;
-	uint32_t field_0x30;
-	uint32_t field_0x34;
-	uint32_t field_0x38;
-	uint32_t field_0x3c;
-	uint32_t field_0x40;
-	uint32_t field_0x44;
-	uint32_t field_0x48;
-	uint32_t field_0x4c;
-	uint32_t field_0x50;
-	uint32_t field_0x54;
-	uint32_t field_0x58;
-	uint32_t field_0x5c;
-	uint32_t field_0x60;
-	uint32_t field_0x64;
-	uint32_t field_0x68;
-	uint32_t field_0x6c;
-	uint32_t field_0x70;
-	uint32_t field_0x74;
-	uint32_t field_0x78;
-	uint32_t field_0x7c;
-	uint32_t field_0x80;
-	uint32_t field_0x84;
+	uint32_t field0x0;
+	uint32_t field0x4;
+	uint32_t field0x8;
+	uint32_t field0xc;
+	uint32_t field0x10;
+	uint32_t field0x14;
+	uint32_t field0x18;
+	uint32_t field0x1c;
+	uint32_t field0x20;
+	uint32_t field0x24;
+	uint32_t field0x28;
+	uint32_t field0x2c;
+	uint32_t field0x30;
+	uint32_t field0x34;
+	uint32_t field0x38;
+	uint32_t field0x3c;
+	uint32_t field0x40;
+	uint32_t field0x44;
+	uint32_t field0x48;
+	uint32_t field0x4c;
+	uint32_t field0x50;
+	uint32_t field0x54;
+	uint32_t field0x58;
+	uint32_t field0x5c;
+	uint32_t field0x60;
+	uint32_t field0x64;
+	uint32_t field0x68;
+	uint32_t field0x6c;
+	uint32_t field0x70;
+	uint32_t field0x74;
+	uint32_t field0x78;
+	uint32_t field0x7c;
+	uint32_t field0x80;
+	uint32_t field0x84;
 };
 
 struct GFeatureInfo: GMultiMapFixedInfo
@@ -956,13 +956,13 @@ struct GWallSectionInfo: GFeatureInfo
 
 struct GArrowInfo: GMobileObjectInfo
 {
-	uint32_t field_0x104;
-	uint32_t field_0x108;
-	uint32_t field_0x10c;
-	uint32_t field_0x110;
-	uint32_t field_0x114;
-	uint32_t field_0x118;
-	uint32_t field_0x11c;
+	uint32_t field0x104;
+	uint32_t field0x108;
+	uint32_t field0x10c;
+	uint32_t field0x110;
+	uint32_t field0x114;
+	uint32_t field0x118;
+	uint32_t field0x11c;
 };
 
 struct GFieldInfo: GMultiMapFixedInfo
@@ -999,12 +999,12 @@ struct GShowNeedsInfo: GObjectInfo
 
 struct GTerrainMaterialInfo
 {
-	SoundSurfaceType SurfaceSound;
+	SoundSurfaceType surfaceSound;
 	int immersion;
 	float surfaceFriction;
 	std::array<char, 0x30> debugString;
-	HelpText HelpStartEnum;
-	HelpText HelpEndEnum;
+	HelpText helpStartEnum;
+	HelpText helpEndEnum;
 	glm::uvec3 tornadoDustColorRGB;
 	std::array<TreeInfo, 4> magicTreeTypes;
 };
@@ -1033,40 +1033,40 @@ struct GMagicForestInfo: GMagicInfo
 
 struct GVillagerStateTableInfo
 {
-	uint32_t field_0x0;
-	int field_0x4;
-	float field_0x8;
-	int field_0xc;
-	int field_0x10;
-	uint32_t field_0x14;
-	uint32_t field_0x18;
-	uint32_t field_0x1c;
-	int field_0x20;
-	uint32_t field_0x24;
+	uint32_t field0x0;
+	int field0x4;
+	float field0x8;
+	int field0xc;
+	int field0x10;
+	uint32_t field0x14;
+	uint32_t field0x18;
+	uint32_t field0x1c;
+	int field0x20;
+	uint32_t field0x24;
 	std::array<char, 0x80> name;
-	int field_0xa8;
-	uint32_t field_0xac;
-	uint32_t field_0xb0;
-	uint32_t field_0xb4;
-	int field_0xb8;
-	uint32_t field_0xbc;
-	int field_0xc0;
-	int field_0xc4;
-	float field_0xc8;
-	float field_0xcc;
-	uint32_t field_0xd0;
-	uint32_t field_0xd4;
-	uint32_t field_0xd8;
-	int field_0xdc;
-	uint32_t field_0xe0;
-	uint32_t field_0xe4;
-	uint32_t field_0xe8;
-	uint32_t field_0xec;
-	uint32_t field_0xf0;
-	uint32_t field_0xf4;
-	float field_0xf8;
-	uint32_t field_0xfc;
-	uint32_t field_0x100;
+	int field0xa8;
+	uint32_t field0xac;
+	uint32_t field0xb0;
+	uint32_t field0xb4;
+	int field0xb8;
+	uint32_t field0xbc;
+	int field0xc0;
+	int field0xc4;
+	float field0xc8;
+	float field0xcc;
+	uint32_t field0xd0;
+	uint32_t field0xd4;
+	uint32_t field0xd8;
+	int field0xdc;
+	uint32_t field0xe0;
+	uint32_t field0xe4;
+	uint32_t field0xe8;
+	uint32_t field0xec;
+	uint32_t field0xf0;
+	uint32_t field0xf4;
+	float field0xf8;
+	uint32_t field0xfc;
+	uint32_t field0x100;
 };
 
 struct GVillagerInfo: GLivingInfo
@@ -1164,36 +1164,36 @@ struct GVillagerInfo: GLivingInfo
 
 struct CreatureDesireActionEntry
 {
-	uint32_t field_0x0;
-	uint32_t field_0x4;
-	uint32_t field_0x8;
-	uint32_t field_0xc;
-	uint32_t field_0x10;
-	uint32_t field_0x14;
-	uint32_t field_0x18;
-	uint32_t field_0x1c;
-	uint32_t field_0x20;
-	uint32_t field_0x24;
-	uint32_t field_0x28;
-	uint32_t field_0x2c;
-	uint32_t field_0x30;
-	uint32_t field_0x34;
-	uint32_t field_0x38;
-	uint32_t field_0x3c;
-	uint32_t field_0x40;
-	uint32_t field_0x44;
-	uint32_t field_0x48;
-	uint32_t field_0x4c;
-	uint32_t field_0x50;
-	uint32_t field_0x54;
-	uint32_t field_0x58;
-	uint32_t field_0x5c;
-	uint32_t field_0x60;
-	uint32_t field_0x64;
-	uint32_t field_0x68;
-	uint32_t field_0x6c;
-	uint32_t field_0x70;
-	uint32_t field_0x74;
+	uint32_t field0x0;
+	uint32_t field0x4;
+	uint32_t field0x8;
+	uint32_t field0xc;
+	uint32_t field0x10;
+	uint32_t field0x14;
+	uint32_t field0x18;
+	uint32_t field0x1c;
+	uint32_t field0x20;
+	uint32_t field0x24;
+	uint32_t field0x28;
+	uint32_t field0x2c;
+	uint32_t field0x30;
+	uint32_t field0x34;
+	uint32_t field0x38;
+	uint32_t field0x3c;
+	uint32_t field0x40;
+	uint32_t field0x44;
+	uint32_t field0x48;
+	uint32_t field0x4c;
+	uint32_t field0x50;
+	uint32_t field0x54;
+	uint32_t field0x58;
+	uint32_t field0x5c;
+	uint32_t field0x60;
+	uint32_t field0x64;
+	uint32_t field0x68;
+	uint32_t field0x6c;
+	uint32_t field0x70;
+	uint32_t field0x74;
 };
 
 struct GMagicTeleportInfo: GMagicInfo
@@ -1203,22 +1203,22 @@ struct GMagicTeleportInfo: GMagicInfo
 
 struct GPlaytimeInfo
 {
-	ObjectType AssociatedObject;
-	float Priority;
-	AbodeNumber AssociatedStructure;
-	AbodeNumber AssociatedAbodeNumber;
-	DanceInfo AssociatedDance;
+	ObjectType associatedObject;
+	float priority;
+	AbodeNumber associatedStructure;
+	AbodeNumber associatedAbodeNumber;
+	DanceInfo associatedDance;
 };
 
 struct CreatureMagicActionKnownAboutEntry: CreatureActionKnownAboutEntry
 {
-	uint32_t field_0x58;
-	float field_0x5c;
+	uint32_t field0x58;
+	float field0x5c;
 };
 
 struct CreatureSourceBoundsInfo
 {
-	glm::vec3 field_0x0;
+	glm::vec3 field0x0;
 };
 
 struct GPlayerInfo
@@ -1272,17 +1272,17 @@ struct GMagicFlockGroundInfo: GMagicInfo
 
 struct GAnimalStateTableInfo
 {
-	uint32_t field_0x0;
-	int field_0x4;
-	float field_0x8;
-	uint32_t field_0xc;
-	uint32_t field_0x10;
-	uint32_t field_0x14;
-	uint32_t field_0x18;
-	uint32_t field_0x1c;
-	uint32_t field_0x20;
+	uint32_t field0x0;
+	int field0x4;
+	float field0x8;
+	uint32_t field0xc;
+	uint32_t field0x10;
+	uint32_t field0x14;
+	uint32_t field0x18;
+	uint32_t field0x1c;
+	uint32_t field0x20;
 	std::array<char, 0x80> name;
-	uint32_t field_0xa4;
+	uint32_t field0xa4;
 };
 
 struct GLeashSelectorInfo: GObjectInfo
@@ -1292,23 +1292,23 @@ struct GLeashSelectorInfo: GObjectInfo
 
 struct CreatureInitialSourceInfo
 {
-	float field_0x0;
-	float field_0x4;
-	float field_0x8;
-	float field_0xc;
-	float field_0x10;
-	float field_0x14;
-	float field_0x18;
-	float field_0x1c;
-	float field_0x20;
-	float field_0x24;
-	float field_0x28;
-	float field_0x2c;
-	float field_0x30;
-	float field_0x34;
-	float field_0x38;
-	float field_0x3c;
-	float field_0x40;
+	float field0x0;
+	float field0x4;
+	float field0x8;
+	float field0xc;
+	float field0x10;
+	float field0x14;
+	float field0x18;
+	float field0x1c;
+	float field0x20;
+	float field0x24;
+	float field0x28;
+	float field0x2c;
+	float field0x30;
+	float field0x34;
+	float field0x38;
+	float field0x3c;
+	float field0x40;
 };
 
 struct GMagicWaterInfo: GMagicInfo
@@ -1382,29 +1382,29 @@ struct GTreeInfo: GSingleMapFixedInfo
 
 struct DifferentCreatureInfo
 {
-	float field_0x0;
-	float field_0x4;
-	float field_0x8;
-	float field_0xc;
-	float field_0x10;
-	float field_0x14;
-	float field_0x18;
-	float field_0x1c;
-	float field_0x20;
-	float field_0x24;
-	float field_0x28;
-	float field_0x2c;
-	float field_0x30;
-	float field_0x34;
-	float field_0x38;
-	float field_0x3c;
-	float field_0x40;
-	float field_0x44;
-	float field_0x48;
-	uint32_t field_0x4c;
-	float field_0x50;
-	float field_0x54;
-	float field_0x58;
+	float field0x0;
+	float field0x4;
+	float field0x8;
+	float field0xc;
+	float field0x10;
+	float field0x14;
+	float field0x18;
+	float field0x1c;
+	float field0x20;
+	float field0x24;
+	float field0x28;
+	float field0x2c;
+	float field0x30;
+	float field0x34;
+	float field0x38;
+	float field0x3c;
+	float field0x40;
+	float field0x44;
+	float field0x48;
+	uint32_t field0x4c;
+	float field0x50;
+	float field0x54;
+	float field0x58;
 };
 
 struct GEffectInfo
@@ -1512,42 +1512,42 @@ struct GPFootballInfo: GMultiMapFixedInfo
 
 struct GSpellSeedInfo: GObjectInfo
 {
-	uint32_t field_0xf0;
-	uint32_t field_0xf4;
-	uint32_t field_0xf8;
-	uint32_t field_0xfc;
-	uint32_t field_0x100;
-	uint32_t field_0x104;
-	uint32_t field_0x108;
-	uint32_t field_0x10c;
-	uint32_t field_0x110;
-	uint32_t field_0x114;
-	uint32_t field_0x118;
-	uint32_t field_0x11c;
-	uint32_t field_0x120;
-	uint32_t field_0x124;
-	uint32_t field_0x128;
-	uint32_t field_0x12c;
-	uint32_t field_0x130;
-	float field_0x134;
-	float field_0x138;
-	float field_0x13c;
-	float field_0x140;
-	float field_0x144;
-	uint32_t field_0x148;
-	uint32_t field_0x14c;
-	float field_0x150;
-	float field_0x154;
-	uint32_t field_0x158;
-	float field_0x15c;
-	uint32_t field_0x160;
-	uint32_t field_0x164;
-	uint32_t field_0x168;
-	uint32_t field_0x16c;
-	uint32_t field_0x170;
-	uint32_t field_0x174;
-	uint32_t field_0x178;
-	uint32_t field_0x17c;
+	uint32_t field0xf0;
+	uint32_t field0xf4;
+	uint32_t field0xf8;
+	uint32_t field0xfc;
+	uint32_t field0x100;
+	uint32_t field0x104;
+	uint32_t field0x108;
+	uint32_t field0x10c;
+	uint32_t field0x110;
+	uint32_t field0x114;
+	uint32_t field0x118;
+	uint32_t field0x11c;
+	uint32_t field0x120;
+	uint32_t field0x124;
+	uint32_t field0x128;
+	uint32_t field0x12c;
+	uint32_t field0x130;
+	float field0x134;
+	float field0x138;
+	float field0x13c;
+	float field0x140;
+	float field0x144;
+	uint32_t field0x148;
+	uint32_t field0x14c;
+	float field0x150;
+	float field0x154;
+	uint32_t field0x158;
+	float field0x15c;
+	uint32_t field0x160;
+	uint32_t field0x164;
+	uint32_t field0x168;
+	uint32_t field0x16c;
+	uint32_t field0x170;
+	uint32_t field0x174;
+	uint32_t field0x178;
+	uint32_t field0x17c;
 };
 
 struct GCitadelHeartInfo: GCitadelPartInfo
@@ -1613,63 +1613,63 @@ struct GFieldTypeInfo: GMultiMapFixedInfo
 
 struct CreatureActionInfo
 {
-	float field_0x0;
-	float field_0x4;
-	float field_0x8;
-	uint32_t field_0xc;
-	float field_0x10;
+	float field0x0;
+	float field0x4;
+	float field0x8;
+	uint32_t field0xc;
+	float field0x10;
 	std::array<char, 0x20> name;
-	uint32_t field_0x34;
-	uint32_t field_0x38;
-	uint32_t field_0x3c;
-	uint32_t field_0x40;
-	uint32_t field_0x44;
-	uint32_t field_0x48;
-	uint32_t field_0x4c;
-	uint32_t field_0x50;
-	uint32_t field_0x54;
-	uint32_t field_0x58;
-	uint32_t field_0x5c;
-	uint32_t field_0x60;
-	uint32_t field_0x64;
-	uint32_t field_0x68;
-	uint32_t field_0x6c;
-	uint32_t field_0x70;
-	uint32_t field_0x74;
-	uint32_t field_0x78;
-	uint32_t field_0x7c;
-	uint32_t field_0x80;
-	uint32_t field_0x84;
-	uint32_t field_0x88;
-	uint32_t field_0x8c;
-	uint32_t field_0x90;
-	uint32_t field_0x94;
-	uint32_t field_0x98;
-	uint32_t field_0x9c;
-	uint32_t field_0xa0;
-	uint32_t field_0xa4;
-	uint32_t field_0xa8;
-	uint32_t field_0xac;
-	uint32_t field_0xb0;
-	uint32_t field_0xb4;
-	uint32_t field_0xb8;
-	uint32_t field_0xbc;
-	float field_0xc0;
-	float field_0xc4;
-	uint32_t field_0xc8;
-	float field_0xcc;
-	float field_0xd0;
-	float field_0xd4;
-	uint32_t field_0xd8;
-	uint32_t field_0xdc;
-	uint32_t field_0xe0;
-	uint32_t field_0xe4;
-	float field_0xe8;
-	float field_0xec;
-	uint32_t field_0xf0;
-	uint32_t field_0xf4;
-	uint32_t field_0xf8;
-	uint32_t field_0xfc;
+	uint32_t field0x34;
+	uint32_t field0x38;
+	uint32_t field0x3c;
+	uint32_t field0x40;
+	uint32_t field0x44;
+	uint32_t field0x48;
+	uint32_t field0x4c;
+	uint32_t field0x50;
+	uint32_t field0x54;
+	uint32_t field0x58;
+	uint32_t field0x5c;
+	uint32_t field0x60;
+	uint32_t field0x64;
+	uint32_t field0x68;
+	uint32_t field0x6c;
+	uint32_t field0x70;
+	uint32_t field0x74;
+	uint32_t field0x78;
+	uint32_t field0x7c;
+	uint32_t field0x80;
+	uint32_t field0x84;
+	uint32_t field0x88;
+	uint32_t field0x8c;
+	uint32_t field0x90;
+	uint32_t field0x94;
+	uint32_t field0x98;
+	uint32_t field0x9c;
+	uint32_t field0xa0;
+	uint32_t field0xa4;
+	uint32_t field0xa8;
+	uint32_t field0xac;
+	uint32_t field0xb0;
+	uint32_t field0xb4;
+	uint32_t field0xb8;
+	uint32_t field0xbc;
+	float field0xc0;
+	float field0xc4;
+	uint32_t field0xc8;
+	float field0xcc;
+	float field0xd0;
+	float field0xd4;
+	uint32_t field0xd8;
+	uint32_t field0xdc;
+	uint32_t field0xe0;
+	uint32_t field0xe4;
+	float field0xe8;
+	float field0xec;
+	uint32_t field0xf0;
+	uint32_t field0xf4;
+	uint32_t field0xf8;
+	uint32_t field0xfc;
 };
 
 struct GSpellSystemInfo
@@ -1696,46 +1696,46 @@ struct GFishFarmInfo: GMultiMapFixedInfo
 
 struct CreatureDesireDependency
 {
-	uint32_t field_0x0;
-	float field_0x4;
-	float field_0x8;
-	float field_0xc;
-	uint32_t field_0x10;
-	uint32_t field_0x14;
-	uint32_t field_0x18;
-	uint32_t field_0x1c;
-	uint32_t field_0x20;
-	uint32_t field_0x24;
-	uint32_t field_0x28;
-	uint32_t field_0x2c;
-	uint32_t field_0x30;
-	uint32_t field_0x34;
-	uint32_t field_0x38;
-	uint32_t field_0x3c;
-	float field_0x40;
-	uint32_t field_0x44;
-	uint32_t field_0x48;
-	uint32_t field_0x4c;
-	uint32_t field_0x50;
-	uint32_t field_0x54;
-	uint32_t field_0x58;
-	float field_0x5c;
-	float field_0x60;
-	float field_0x64;
-	float field_0x68;
-	float field_0x6c;
-	float field_0x70;
-	float field_0x74;
-	float field_0x78;
-	float field_0x7c;
-	float field_0x80;
-	float field_0x84;
-	float field_0x88;
-	float field_0x8c;
-	float field_0x90;
-	float field_0x94;
-	uint32_t field_0x98;
-	uint32_t field_0x9c;
+	uint32_t field0x0;
+	float field0x4;
+	float field0x8;
+	float field0xc;
+	uint32_t field0x10;
+	uint32_t field0x14;
+	uint32_t field0x18;
+	uint32_t field0x1c;
+	uint32_t field0x20;
+	uint32_t field0x24;
+	uint32_t field0x28;
+	uint32_t field0x2c;
+	uint32_t field0x30;
+	uint32_t field0x34;
+	uint32_t field0x38;
+	uint32_t field0x3c;
+	float field0x40;
+	uint32_t field0x44;
+	uint32_t field0x48;
+	uint32_t field0x4c;
+	uint32_t field0x50;
+	uint32_t field0x54;
+	uint32_t field0x58;
+	float field0x5c;
+	float field0x60;
+	float field0x64;
+	float field0x68;
+	float field0x6c;
+	float field0x70;
+	float field0x74;
+	float field0x78;
+	float field0x7c;
+	float field0x80;
+	float field0x84;
+	float field0x88;
+	float field0x8c;
+	float field0x90;
+	float field0x94;
+	uint32_t field0x98;
+	uint32_t field0x9c;
 };
 
 struct GPFootballPositionInfo: GFootballPositionInfo
@@ -1745,18 +1745,18 @@ struct GPFootballPositionInfo: GFootballPositionInfo
 struct CreatureMimicInfo
 {
 	std::array<char, 0x80> name;
-	float field_0x80;
-	uint32_t field_0x84;
-	uint32_t field_0x88;
-	uint32_t field_0x8c;
-	uint32_t field_0x90;
-	uint32_t field_0x94;
-	uint32_t field_0x98;
-	uint32_t field_0x9c;
-	uint32_t field_0xa0;
-	uint32_t field_0xa4;
-	uint32_t field_0xa8;
-	uint32_t field_0xac;
+	float field0x80;
+	uint32_t field0x84;
+	uint32_t field0x88;
+	uint32_t field0x8c;
+	uint32_t field0x90;
+	uint32_t field0x94;
+	uint32_t field0x98;
+	uint32_t field0x9c;
+	uint32_t field0xa0;
+	uint32_t field0xa4;
+	uint32_t field0xa8;
+	uint32_t field0xac;
 };
 
 struct GPrayerSiteInfo: GFeatureInfo
@@ -1771,13 +1771,13 @@ struct HelpSpiritInfo: GLivingInfo
 
 struct CreatureDesireSourceTable
 {
-	uint32_t field_0x0;
-	uint32_t field_0x4;
-	float field_0x8;
-	float field_0xc;
-	float field_0x10;
-	std::array<char, 0x40> field_0x14;
-	std::array<char, 0x40> field_0x54;
+	uint32_t field0x0;
+	uint32_t field0x4;
+	float field0x8;
+	float field0xc;
+	float field0x10;
+	std::array<char, 0x40> field0x14;
+	std::array<char, 0x40> field0x54;
 };
 
 struct GSpellIconInfo: GMultiMapFixedInfo
@@ -1868,14 +1868,14 @@ struct InfoConstants
 	std::array<GAlignmentInfo, 7> alignment;
 	std::array<ReactionInfo, 41> reaction;
 	std::array<CreatureActionInfo, 328> creatureAction;
-	std::array<CreatureDesireActionEntry, 40> creatureDesireAction_1;
-	std::array<CreatureDesireActionEntry, 17> creatureDesireAction_2;
-	std::array<CreatureDesireActionEntry, 40> creatureDesireAction_3;
+	std::array<CreatureDesireActionEntry, 40> creatureDesireAction1;
+	std::array<CreatureDesireActionEntry, 17> creatureDesireAction2;
+	std::array<CreatureDesireActionEntry, 40> creatureDesireAction3;
 	std::array<CreatureDesireDependency, 40> creatureDesireDependency;
 	std::array<CreatureInitialDesireInfo, 40> creatureInitialDesire;
 	std::array<CreatureDesireSourceTable, 61> desireSourceTable;
-	std::array<CreatureInitialSourceInfo, 61> creatureInitialSource_1;
-	std::array<CreatureInitialSourceInfo, 61> creatureInitialSource_2;
+	std::array<CreatureInitialSourceInfo, 61> creatureInitialSource1;
+	std::array<CreatureInitialSourceInfo, 61> creatureInitialSource2;
 	std::array<CreatureSourceBoundsInfo, 61> creatureSourceBounds;
 	std::array<CreatureDesireAttributeEntry, 40> creatureDesireAttributeEntry;
 	std::array<CreatureActionKnownAboutEntry, 6> creatireActionKnownAboutEntry;

--- a/src/LHScriptX/CommandSignature.h
+++ b/src/LHScriptX/CommandSignature.h
@@ -85,9 +85,11 @@ private:
 
 	union
 	{
+		// NOLINTNEXTLINE(readability-identifier-naming): float is a reserved name
 		float _float;
+		// NOLINTNEXTLINE(readability-identifier-naming)
 		int32_t _number;
-		// NOLINTNEXTLINE(modernize-avoid-c-arrays): array won't work in union
+		// NOLINTNEXTLINE(modernize-avoid-c-arrays, readability-identifier-naming): array won't work in union
 		float _vector[3];
 	} _value;
 	std::string _string;

--- a/src/LHScriptX/FeatureScriptCommands.cpp
+++ b/src/LHScriptX/FeatureScriptCommands.cpp
@@ -42,12 +42,6 @@ using namespace openblack::lhscriptx;
 using namespace openblack::ecs::archetypes;
 using namespace openblack::ecs::components;
 
-// alias parameter types for signature list readability
-const constexpr ParameterType TString = ParameterType::String;
-const constexpr ParameterType TNumber = ParameterType::Number;
-const constexpr ParameterType TFloat = ParameterType::Float;
-const constexpr ParameterType TVector = ParameterType::Vector;
-
 namespace
 {
 template <class C, size_t size>
@@ -62,9 +56,9 @@ std::unordered_map<std::string_view, C> makeLookup(std::array<std::string_view, 
 	return table;
 }
 
-const auto playerLookup = makeLookup<PlayerNames>(PlayerNamesStrs);
-const auto tribeLookup = makeLookup<Tribe>(TribeStrs);
-const auto villagerNumberLookup = makeLookup<VillagerNumber>(VillagerNumberStrs);
+const auto k_PlayerLookup = makeLookup<PlayerNames>(k_PlayerNamesStrs);
+const auto k_TribeLookup = makeLookup<Tribe>(k_TribeStrs);
+const auto k_VillagerNumberLookup = makeLookup<VillagerNumber>(k_VillagerNumberStrs);
 
 std::tuple<Tribe, VillagerNumber> GetVillagerTribeAndNumber(const std::string& villagerTribeWithType)
 {
@@ -74,8 +68,8 @@ std::tuple<Tribe, VillagerNumber> GetVillagerTribeAndNumber(const std::string& v
 
 	try
 	{
-		const auto tribe = tribeLookup.at(tribeStr);
-		const auto role = villagerNumberLookup.at(roleStr);
+		const auto tribe = k_TribeLookup.at(tribeStr);
+		const auto role = k_VillagerNumberLookup.at(roleStr);
 		return std::make_tuple(tribe, role);
 	}
 	catch (...)
@@ -86,7 +80,7 @@ std::tuple<Tribe, VillagerNumber> GetVillagerTribeAndNumber(const std::string& v
 
 } // namespace
 
-const std::array<const ScriptCommandSignature, 106> FeatureScriptCommands::Signatures = {{
+const std::array<const ScriptCommandSignature, 106> FeatureScriptCommands::k_Signatures = {{
     CREATE_COMMAND_BINDING("SET_A_TOWNS_INFLUENCE_MULTIPLIER", SetATownInfluenceMultiplier),
     CREATE_COMMAND_BINDING("CREATE_MIST", CreateMist),
     CREATE_COMMAND_BINDING("CREATE_PATH", CreatePath),
@@ -211,16 +205,16 @@ void FeatureScriptCommands::SetATownInfluenceMultiplier(int32_t townId, float mu
 	                    townId, multiplier);
 }
 
-void FeatureScriptCommands::CreateMist(glm::vec3 position, float param_2, int32_t param_3, float param_4, float param_5)
+void FeatureScriptCommands::CreateMist(glm::vec3 position, float param2, int32_t param3, float param4, float param5)
 {
 	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {}({}, {}, {}, {}, {}) not implemented.",
-	                    __FILE__, __LINE__, __func__, glm::to_string(position), param_2, param_3, param_4, param_5);
+	                    __FILE__, __LINE__, __func__, glm::to_string(position), param2, param3, param4, param5);
 }
 
-void FeatureScriptCommands::CreatePath(int32_t param_1, int32_t param_2, int32_t param_3, int32_t param_4)
+void FeatureScriptCommands::CreatePath(int32_t param1, int32_t param2, int32_t param3, int32_t param4)
 {
 	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {}({}, {}, {}, {}) not implemented.", __FILE__,
-	                    __LINE__, __func__, param_1, param_2, param_3, param_4);
+	                    __LINE__, __func__, param1, param2, param3, param4);
 }
 
 void FeatureScriptCommands::CreateTown(int32_t townId, glm::vec3 position, const std::string& playerOwner,
@@ -232,7 +226,7 @@ void FeatureScriptCommands::CreateTown(int32_t townId, glm::vec3 position, const
 	PlayerNames player;
 	try
 	{
-		player = playerLookup.at(playerOwner);
+		player = k_PlayerLookup.at(playerOwner);
 	}
 	catch (...)
 	{
@@ -242,7 +236,7 @@ void FeatureScriptCommands::CreateTown(int32_t townId, glm::vec3 position, const
 	Tribe tribe;
 	try
 	{
-		tribe = tribeLookup.at(tribeType);
+		tribe = k_TribeLookup.at(tribeType);
 	}
 	catch (...)
 	{
@@ -254,7 +248,7 @@ void FeatureScriptCommands::CreateTown(int32_t townId, glm::vec3 position, const
 
 void FeatureScriptCommands::SetTownBelief(int32_t townId, const std::string& playerOwner, float belief)
 {
-	auto& registry = Game::instance()->GetEntityRegistry();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 	auto& registryContext = registry.Context();
 
 	Town& town = registry.Get<Town>(registryContext.towns.at(townId));
@@ -314,30 +308,30 @@ void FeatureScriptCommands::CreateNewTownSpell(int32_t townId, const std::string
 	                    __func__, townId, spellName);
 }
 
-void FeatureScriptCommands::CreateTownCentreSpellIcon(int32_t param_1, const std::string& param_2)
+void FeatureScriptCommands::CreateTownCentreSpellIcon(int32_t param1, const std::string& param2)
 {
 	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {}({}, {}) not implemented.", __FILE__, __LINE__,
-	                    __func__, param_1, param_2);
+	                    __func__, param1, param2);
 }
 
-void FeatureScriptCommands::CreateSpellIcon(glm::vec3 position, const std::string& param_2, int32_t param_3, int32_t param_4,
-                                            int32_t param_5)
+void FeatureScriptCommands::CreateSpellIcon(glm::vec3 position, const std::string& param2, int32_t param3, int32_t param4,
+                                            int32_t param5)
 {
 	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {}({}, {}, {}, {}, {}) not implemented.",
-	                    __FILE__, __LINE__, __func__, glm::to_string(position), param_2, param_3, param_4, param_5);
+	                    __FILE__, __LINE__, __func__, glm::to_string(position), param2, param3, param4, param5);
 }
 
-void FeatureScriptCommands::CreatePlannedSpellIcon(int32_t param_1, glm::vec3 position, const std::string& param_3,
-                                                   int32_t param_4, int32_t param_5, int32_t param_6)
+void FeatureScriptCommands::CreatePlannedSpellIcon(int32_t param1, glm::vec3 position, const std::string& param3,
+                                                   int32_t param4, int32_t param5, int32_t param6)
 {
 	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {}({}, {}, {}, {}, {}, {}) not implemented.",
-	                    __FILE__, __LINE__, __func__, param_1, glm::to_string(position), param_3, param_4, param_5, param_6);
+	                    __FILE__, __LINE__, __func__, param1, glm::to_string(position), param3, param4, param5, param6);
 }
 
-void FeatureScriptCommands::CreateVillager(glm::vec3 param_1, glm::vec3 param_2, const std::string& param_3)
+void FeatureScriptCommands::CreateVillager(glm::vec3 param1, glm::vec3 param2, const std::string& param3)
 {
 	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {}({}, {}, {}) not implemented.", __FILE__,
-	                    __LINE__, __func__, glm::to_string(param_1), glm::to_string(param_2), param_3);
+	                    __LINE__, __func__, glm::to_string(param1), glm::to_string(param2), param3);
 }
 
 void FeatureScriptCommands::CreateTownVillager(int32_t townId, glm::vec3 position, const std::string& villagerType, int32_t age)
@@ -346,10 +340,10 @@ void FeatureScriptCommands::CreateTownVillager(int32_t townId, glm::vec3 positio
 	                    __LINE__, __func__, townId, glm::to_string(position), villagerType, age);
 }
 
-void FeatureScriptCommands::CreateSpecialTownVillager(int32_t param_1, glm::vec3 position, int32_t param_3, int32_t param_4)
+void FeatureScriptCommands::CreateSpecialTownVillager(int32_t param1, glm::vec3 position, int32_t param3, int32_t param4)
 {
 	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {}({}, {}, {}, {}) not implemented.", __FILE__,
-	                    __LINE__, __func__, param_1, glm::to_string(position), param_3, param_4);
+	                    __LINE__, __func__, param1, glm::to_string(position), param3, param4);
 }
 
 void FeatureScriptCommands::CreateVillagerPos(glm::vec3 abodePosition, glm::vec3 position, const std::string& tribeAndNumber,
@@ -525,10 +519,10 @@ void FeatureScriptCommands::HeightChange([[maybe_unused]] glm::vec3 position, in
 	// __func__);
 }
 
-void FeatureScriptCommands::CreateCreature(glm::vec3 position, int32_t param_2, int32_t param_3)
+void FeatureScriptCommands::CreateCreature(glm::vec3 position, int32_t param2, int32_t param3)
 {
 	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "LHScriptX: {}:{}: Function {}({}, {}, {}) not implemented.", __FILE__,
-	                    __LINE__, __func__, glm::to_string(position), param_2, param_3);
+	                    __LINE__, __func__, glm::to_string(position), param2, param3);
 }
 
 void FeatureScriptCommands::CreateCreatureFromFile(const std::string& playerName, int32_t creatureType,
@@ -546,7 +540,7 @@ void FeatureScriptCommands::CreateFlock(int32_t, glm::vec3, glm::vec3, int32_t, 
 
 void FeatureScriptCommands::LoadLandscape(const std::string& path)
 {
-	Game::instance()->LoadLandscape(path);
+	Game::Instance()->LoadLandscape(path);
 }
 
 void FeatureScriptCommands::Version([[maybe_unused]] float version)
@@ -562,7 +556,7 @@ void FeatureScriptCommands::CreateArea([[maybe_unused]] glm::vec3 position, floa
 
 void FeatureScriptCommands::StartCameraPos(glm::vec3 position)
 {
-	auto& camera = Game::instance()->GetCamera();
+	auto& camera = Game::Instance()->GetCamera();
 	const glm::vec3 offset(0.0f, 10.0f, 0.0f);
 	camera.SetPosition(position + offset);
 }
@@ -641,7 +635,7 @@ void FeatureScriptCommands::BrushSize(float, float)
 
 void FeatureScriptCommands::CreateStream(int32_t streamId)
 {
-	auto& registry = Game::instance()->GetEntityRegistry();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 	auto& registryContext = registry.Context();
 	const auto entity = registry.Create();
 
@@ -651,7 +645,7 @@ void FeatureScriptCommands::CreateStream(int32_t streamId)
 
 void FeatureScriptCommands::CreateStreamPoint(int32_t streamId, glm::vec3 position)
 {
-	auto& registry = Game::instance()->GetEntityRegistry();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 	auto& registryContext = registry.Context();
 
 	Stream& stream = registry.Get<Stream>(registryContext.streams.at(streamId));
@@ -672,7 +666,7 @@ void FeatureScriptCommands::CreateArena([[maybe_unused]] glm::vec3 position, flo
 
 void FeatureScriptCommands::CreateFootpath(int32_t footpathId)
 {
-	auto& registry = Game::instance()->GetEntityRegistry();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 	const auto entity = registry.Create();
 	registry.Assign<Footpath>(entity);
 	auto& registryContext = registry.Context();
@@ -681,7 +675,7 @@ void FeatureScriptCommands::CreateFootpath(int32_t footpathId)
 
 void FeatureScriptCommands::CreateFootpathNode(int footpathId, glm::vec3 position)
 {
-	auto& registry = Game::instance()->GetEntityRegistry();
+	auto& registry = Game::Instance()->GetEntityRegistry();
 	auto& registryContext = registry.Context();
 	auto& footpath = registry.Get<Footpath>(registryContext.footpaths.at(footpathId));
 	footpath.nodes.emplace_back(Footpath::Node {position});
@@ -695,7 +689,7 @@ void FeatureScriptCommands::LinkFootpath(int32_t footpathId)
 	                    __func__, footpathId);
 }
 
-void FeatureScriptCommands::CreateBonfire(glm::vec3 position, float rotation, [[maybe_unused]] float param_3, float scale)
+void FeatureScriptCommands::CreateBonfire(glm::vec3 position, float rotation, [[maybe_unused]] float param3, float scale)
 {
 	CreateMobileStatic(position, MobileStaticInfo::Bonfire, rotation, scale);
 }
@@ -707,7 +701,7 @@ void FeatureScriptCommands::CreateBase([[maybe_unused]] glm::vec3 position, int3
 }
 
 void FeatureScriptCommands::CreateNewFeature(glm::vec3 position, const std::string& type, int32_t rotation, int32_t scale,
-                                             [[maybe_unused]] int32_t param_5)
+                                             [[maybe_unused]] int32_t param5)
 {
 	FeatureArchetype::Create(position, GFeatureInfo::Find(type), rotation * 0.001f, scale * 0.001f);
 }

--- a/src/LHScriptX/FeatureScriptCommands.h
+++ b/src/LHScriptX/FeatureScriptCommands.h
@@ -22,11 +22,11 @@ namespace openblack::lhscriptx
 class FeatureScriptCommands
 {
 public:
-	static const std::array<const ScriptCommandSignature, 106> Signatures;
+	static const std::array<const ScriptCommandSignature, 106> k_Signatures;
 
 	static void SetATownInfluenceMultiplier(int32_t townId, float mult);
-	static void CreateMist(glm::vec3 position, float param_2, int32_t param_3, float param_4, float param_5);
-	static void CreatePath(int32_t param_1, int32_t param_2, int32_t param_3, int32_t param_4);
+	static void CreateMist(glm::vec3 position, float param2, int32_t param3, float param4, float param5);
+	static void CreatePath(int32_t param1, int32_t param2, int32_t param3, int32_t param4);
 	static void CreateTown(int32_t townId, glm::vec3 position, const std::string& playerOwner, int32_t notUsed,
 	                       const std::string& tribeType);
 	static void SetTownBelief(int32_t townId, const std::string& playerOwner, float belief);
@@ -105,9 +105,9 @@ public:
 	static void CreateFootpath(int32_t footpathId);
 	static void CreateFootpathNode(int footpathId, glm::vec3 position);
 	static void LinkFootpath(int32_t footpathId);
-	static void CreateBonfire(glm::vec3 position, float rotation, float param_3, float scale);
+	static void CreateBonfire(glm::vec3 position, float rotation, float param3, float scale);
 	static void CreateBase(glm::vec3 position, int32_t);
-	static void CreateNewFeature(glm::vec3 position, const std::string& type, int32_t rotation, int32_t scale, int32_t param_5);
+	static void CreateNewFeature(glm::vec3 position, const std::string& type, int32_t rotation, int32_t scale, int32_t param5);
 	static void SetInteractDesire(float);
 	static void ToggleComputerPlayer(const std::string&, int32_t);
 	static void SetComputerPlayerCreatureLike(const std::string&, const std::string&);

--- a/src/LHScriptX/FeatureScriptCommands.h
+++ b/src/LHScriptX/FeatureScriptCommands.h
@@ -90,7 +90,7 @@ public:
 	static void TownNeedsPos(int32_t townId, glm::vec3 position);
 	static void CreateFurniture(glm::vec3 position, int32_t, float);
 	static void CreateBigForest(glm::vec3 position, BigForestInfo type, float rotation, float scale);
-	static void CreateNewBigForest(glm::vec3 position, BigForestInfo type, int32_t param_3, float rotation, float scale);
+	static void CreateNewBigForest(glm::vec3 position, BigForestInfo type, int32_t unknown, float rotation, float scale);
 	static void CreateInfluenceRing(glm::vec3 position, int32_t, float, int32_t);
 	static void CreateWeatherClimate(int32_t, int32_t, glm::vec3, float, float);
 	static void CreateWeatherClimateRain(int32_t, float, int32_t, int32_t, int32_t);

--- a/src/LHScriptX/Lexer.cpp
+++ b/src/LHScriptX/Lexer.cpp
@@ -27,7 +27,9 @@ Token Lexer::GetToken()
 	while (true)
 	{
 		if (current_ == end_)
+		{
 			return Token::MakeEOFToken();
+		}
 
 		unsigned char cc = *current_;
 		switch (cc)
@@ -37,7 +39,10 @@ Token Lexer::GetToken()
 			if (*(current_ + 1) == '/')
 			{
 				// Skip line
-				while (*current_ != '\n' && current_ != end_) current_++;
+				while (*current_ != '\n' && current_ != end_)
+				{
+					current_++;
+				}
 			}
 			break;
 		case ' ':
@@ -46,7 +51,10 @@ Token Lexer::GetToken()
 			current_++;
 
 			// skip over whitespace quickly
-			while (*current_ == ' ' || *current_ == '\t' || *current_ == '\r') current_++;
+			while (*current_ == ' ' || *current_ == '\t' || *current_ == '\r')
+			{
+				current_++;
+			}
 			break;
 		case '\n':
 			current_++;
@@ -56,7 +64,10 @@ Token Lexer::GetToken()
 		// not sure if it's **** or just *, this can be drastically improved on
 		// though
 		case '*':
-			while (*current_ != '\n') current_++;
+			while (*current_ != '\n')
+			{
+				current_++;
+			}
 			break;
 
 		// handle potential rem/REM
@@ -65,7 +76,10 @@ Token Lexer::GetToken()
 			// todo: potential out of bounds here:
 			if ((current_[1] == 'e' || current_[1] == 'E') && (current_[2] == 'm' || current_[2] == 'M'))
 			{
-				while (*current_ != '\n') current_++;
+				while (*current_ != '\n')
+				{
+					current_++;
+				}
 				break;
 			}
 			return gatherIdentifer();
@@ -176,7 +190,9 @@ Token Lexer::gatherIdentifer()
 		if ((cc < 'A' || cc > 'Z') && (cc < 'a' || cc > 'z') && cc != '_' && (cc < '0' || cc > '9'))
 		{
 			if ((cc >= ' ' && cc < 0x7f) || cc == '\t' || cc == '\r' || cc == '\n')
+			{
 				break;
+			}
 
 			throw LexerException("invalid character " + std::string(1, cc) + "in identifer");
 		}
@@ -203,7 +219,7 @@ Token Lexer::gatherNumber()
 	// consume all digits and .
 	while (hasMore())
 	{
-		if (std::isdigit(*current_))
+		if (std::isdigit(*current_) != 0)
 		{
 			current_++;
 		}
@@ -222,13 +238,17 @@ Token Lexer::gatherNumber()
 	{
 		float value = std::stof(std::string(number_start, current_));
 		if (is_neg)
+		{
 			value = -value;
+		}
 		return Token::MakeFloatToken(value);
 	}
 
 	int value = std::stoi(std::string(number_start, current_));
 	if (is_neg)
+	{
 		value = -value;
+	}
 	return Token::MakeIntegerToken(value);
 }
 
@@ -237,7 +257,10 @@ Token Lexer::gatherString()
 	auto string_start = ++current_;
 
 	// todo: we should check for unterminated strings
-	while (hasMore() && *current_ != '"') current_++;
+	while (hasMore() && *current_ != '"')
+	{
+		current_++;
+	}
 
 	return Token::MakeStringToken(std::string(string_start, current_++));
 }

--- a/src/LHScriptX/Lexer.h
+++ b/src/LHScriptX/Lexer.h
@@ -60,7 +60,7 @@ public:
 		Operator,
 	};
 
-	[[nodiscard]] Type GetType() const { return this->type_; }
+	[[nodiscard]] Type GetType() const { return this->_type; }
 
 	static Token MakeInvalidToken() { return Token(Type::Invalid); }
 	static Token MakeEOFToken() { return Token(Type::EndOfFile); }
@@ -68,64 +68,64 @@ public:
 	static Token MakeIdentifierToken(const std::string& value)
 	{
 		Token tok(Type::Identifier);
-		tok.s_ = value;
+		tok._s = value;
 		return tok;
 	}
 	static Token MakeStringToken(const std::string& value)
 	{
 		Token tok(Type::String);
-		tok.s_ = value;
+		tok._s = value;
 		return tok;
 	}
 	static Token MakeIntegerToken(int value)
 	{
 		Token tok(Type::Integer);
-		tok.u_.integerValue = value;
+		tok._u.integerValue = value;
 		return tok;
 	}
 	static Token MakeFloatToken(float value)
 	{
 		Token tok(Type::Float);
-		tok.u_.floatValue = value;
+		tok._u.floatValue = value;
 		return tok;
 	}
 	static Token MakeOperatorToken(Operator op)
 	{
 		Token tok(Type::Operator);
-		tok.u_.op = op;
+		tok._u.op = op;
 		return tok;
 	}
 
-	[[nodiscard]] bool IsInvalid() const { return this->type_ == Type::Invalid; }
-	[[nodiscard]] bool IsEOF() const { return this->type_ == Type::EndOfFile; }
-	[[nodiscard]] bool IsIdentifier() const { return this->type_ == Type::Identifier; }
-	[[nodiscard]] bool IsString() const { return this->type_ == Type::String; }
-	[[nodiscard]] bool IsOP(Operator op) const { return this->type_ == Type::Operator && this->u_.op == op; }
+	[[nodiscard]] bool IsInvalid() const { return this->_type == Type::Invalid; }
+	[[nodiscard]] bool IsEOF() const { return this->_type == Type::EndOfFile; }
+	[[nodiscard]] bool IsIdentifier() const { return this->_type == Type::Identifier; }
+	[[nodiscard]] bool IsString() const { return this->_type == Type::String; }
+	[[nodiscard]] bool IsOP(Operator op) const { return this->_type == Type::Operator && this->_u.op == op; }
 
 	// todo: assert check the type for each of these?
-	[[nodiscard]] const std::string& StringValue() const { return this->s_; }
-	[[nodiscard]] const std::string& Identifier() const { return this->s_; }
-	[[nodiscard]] const int* IntegerValue() const { return &this->u_.integerValue; }
-	[[nodiscard]] const float* FloatValue() const { return &this->u_.floatValue; }
-	[[nodiscard]] Operator Op() const { return this->u_.op; }
+	[[nodiscard]] const std::string& StringValue() const { return this->_s; }
+	[[nodiscard]] const std::string& Identifier() const { return this->_s; }
+	[[nodiscard]] const int* IntegerValue() const { return &this->_u.integerValue; }
+	[[nodiscard]] const float* FloatValue() const { return &this->_u.floatValue; }
+	[[nodiscard]] Operator Op() const { return this->_u.op; }
 
 	// print the token for debugging
 	void Print(FILE* file) const;
 
 private:
 	explicit Token(Type type)
-	    : type_(type)
+	    : _type(type)
 	{
 	}
 
-	Type type_;
+	Type _type;
 	union
 	{
 		int integerValue;
 		float floatValue;
 		Operator op;
-	} u_;
-	std::string s_;
+	} _u;
+	std::string _s;
 };
 
 class Lexer
@@ -136,19 +136,19 @@ public:
 	Token GetToken();
 
 private:
-	[[nodiscard]] size_t remaining() const noexcept { return static_cast<size_t>(end_ - current_); }
+	[[nodiscard]] size_t Remaining() const noexcept { return static_cast<size_t>(_end - _current); }
 
-	[[nodiscard]] bool hasMore() const noexcept { return current_ != end_; }
+	[[nodiscard]] bool HasMore() const noexcept { return _current != _end; }
 
-	Token gatherIdentifer();
-	Token gatherNumber();
-	Token gatherString();
+	Token GatherIdentifer();
+	Token GatherNumber();
+	Token GatherString();
 
-	std::string source_;
-	std::string::iterator current_;
-	std::string::iterator end_;
+	std::string _source;
+	std::string::iterator _current;
+	std::string::iterator _end;
 
-	int currentLine_ {1};
+	int _currentLine {1};
 };
 
 } // namespace openblack::lhscriptx

--- a/src/LHScriptX/MapScriptCommands.cpp
+++ b/src/LHScriptX/MapScriptCommands.cpp
@@ -18,12 +18,12 @@
 using namespace openblack::lhscriptx;
 
 // alias parameter types for signature list readability
-const constexpr ParameterType TString = ParameterType::String;
-const constexpr ParameterType TNumber = ParameterType::Number;
-const constexpr ParameterType TFloat = ParameterType::Float;
-const constexpr ParameterType TVector = ParameterType::Vector;
+const constexpr ParameterType k_TString = ParameterType::String;
+const constexpr ParameterType k_TNumber = ParameterType::Number;
+const constexpr ParameterType k_TFloat = ParameterType::Float;
+const constexpr ParameterType k_TVector = ParameterType::Vector;
 
-const std::array<const ScriptCommandSignature, 20> MapScriptCommands::Signatures = {{
+const std::array<const ScriptCommandSignature, 20> MapScriptCommands::k_Signatures = {{
     CREATE_COMMAND_BINDING("SET_NO_PLAYERS", MapScriptCommands::SetNoPlayers),
     CREATE_COMMAND_BINDING("LOAD_TRIBE_DANCE", MapScriptCommands::LoadTribeDance),
     CREATE_COMMAND_BINDING("SET_DATE", MapScriptCommands::SetDate),
@@ -70,13 +70,13 @@ void MapScriptCommands::SetTime(int32_t, int32_t, int32_t)
 	                       std::to_string(__LINE__));
 }
 
-void MapScriptCommands::SetTurnsPerYear([[maybe_unused]] int32_t turns_per_year)
+void MapScriptCommands::SetTurnsPerYear([[maybe_unused]] int32_t turnsPerYear)
 {
 	throw std::logic_error(std::string {} + "Function " + __func__ + " not implemented. " + __FILE__ + ":" +
 	                       std::to_string(__LINE__));
 }
 
-void MapScriptCommands::SetGameTickTime([[maybe_unused]] int32_t game_tick_time)
+void MapScriptCommands::SetGameTickTime([[maybe_unused]] int32_t gameTickTime)
 {
 	throw std::logic_error(std::string {} + "Function " + __func__ + " not implemented. " + __FILE__ + ":" +
 	                       std::to_string(__LINE__));

--- a/src/LHScriptX/MapScriptCommands.h
+++ b/src/LHScriptX/MapScriptCommands.h
@@ -21,14 +21,14 @@ namespace openblack::lhscriptx
 class MapScriptCommands
 {
 public:
-	static const std::array<const ScriptCommandSignature, 20> Signatures;
+	static const std::array<const ScriptCommandSignature, 20> k_Signatures;
 
 	static void SetNoPlayers(int32_t number);
 	static void LoadTribeDance(glm::vec3 position, int32_t);
 	static void SetDate(int32_t, int32_t, int32_t);
 	static void SetTime(int32_t, int32_t, int32_t);
-	static void SetTurnsPerYear(int32_t turns_per_year);
-	static void SetGameTickTime(int32_t game_tick_time);
+	static void SetTurnsPerYear(int32_t turnsPerYear);
+	static void SetGameTickTime(int32_t gameTickTime);
 	static void LoadFeatureScript(glm::vec3);
 	static void PauseGame();
 	static void CreateCreature(int32_t, int32_t, int32_t, int32_t);

--- a/src/LHScriptX/Script.cpp
+++ b/src/LHScriptX/Script.cpp
@@ -9,6 +9,7 @@
 
 #include "Script.h"
 
+#include <algorithm>
 #include <iostream>
 
 #include <glm/vec2.hpp>
@@ -36,11 +37,15 @@ void Script::Load(const std::string& source)
 			const std::string identifier = token->Identifier();
 
 			if (!isCommand(identifier))
+			{
 				throw std::runtime_error("unknown command: " + identifier);
+			}
 
 			token = this->advanceToken(lexer);
 			if (!token->IsOP(Operator::LeftParentheses))
+			{
 				throw std::runtime_error("expected ( after identifier " + identifier);
+			}
 
 			std::vector<Token> args;
 
@@ -56,14 +61,18 @@ void Script::Load(const std::string& source)
 					// consume the ,
 					token = this->advanceToken(lexer);
 					if (!token->IsOP(Operator::Comma))
+					{
 						break;
+					}
 
 					this->advanceToken(lexer);
 				}
 			}
 
 			if (!token->IsOP(Operator::RightParentheses))
+			{
 				throw std::runtime_error("missing )");
+			}
 
 			// move token to whatever is after ')'
 			this->advanceToken(lexer);
@@ -77,12 +86,9 @@ void Script::Load(const std::string& source)
 
 bool Script::isCommand(const std::string& identifier) const
 {
-	// this could be done a lot better
-	for (const auto& signature : FeatureScriptCommands::Signatures)
-		if (signature.name.data() == identifier)
-			return true;
-
-	return false;
+	// TODO(handsomematt): this could be done a lot better
+	return std::any_of(FeatureScriptCommands::Signatures.cbegin(), FeatureScriptCommands::Signatures.cend(),
+	                   [&identifier](const auto& s) { return s.name.data() == identifier; });
 }
 
 ScriptCommandParameter GetParameter(Token& argument)
@@ -138,14 +144,18 @@ void Script::runCommand(const std::string& identifier, const std::vector<Token>&
 	for (const auto& signature : FeatureScriptCommands::Signatures)
 	{
 		if (signature.name.data() != identifier)
+		{
 			continue;
+		}
 
 		command_signature = &signature;
 		break;
 	}
 
 	if (command_signature == nullptr)
+	{
 		throw std::runtime_error("Missing script command signature");
+	}
 
 	// Turn tokens into parameters
 	auto parameters = ScriptCommandParameters();
@@ -191,7 +201,9 @@ void Script::runCommand(const std::string& identifier, const std::vector<Token>&
 const Token* Script::peekToken(Lexer& lexer)
 {
 	if (token_.IsInvalid())
+	{
 		token_ = lexer.GetToken();
+	}
 	return &token_;
 }
 

--- a/src/LHScriptX/Script.h
+++ b/src/LHScriptX/Script.h
@@ -33,7 +33,7 @@ class Script
 public:
 	explicit Script(Game* game)
 	    : _game(game)
-	    , token_(Token::MakeInvalidToken())
+	    , _token(Token::MakeInvalidToken())
 	{
 	}
 
@@ -47,16 +47,16 @@ private:
 	// void processCommand(const std::string& command, std::vector<std::string>
 	// parameters);
 
-	[[nodiscard]] bool isCommand(const std::string& identifier) const;
-	void runCommand(const std::string& identifier, const std::vector<Token>& args);
+	[[nodiscard]] bool IsCommand(const std::string& identifier) const;
+	void RunCommand(const std::string& identifier, const std::vector<Token>& args);
 
-	const Token* peekToken(Lexer&);
-	const Token* advanceToken(Lexer&);
+	const Token* PeekToken(Lexer&);
+	const Token* AdvanceToken(Lexer&);
 
 	// Game instance
 	Game* _game;
 	// The current token.
-	Token token_;
+	Token _token;
 };
 
 } // namespace openblack::lhscriptx

--- a/src/LHScriptX/ScriptingBindingUtils.h
+++ b/src/LHScriptX/ScriptingBindingUtils.h
@@ -18,30 +18,30 @@ namespace openblack::lhscriptx
 {
 
 template <class T>
-static ParameterType ParameterTypeStaticLookUpRegular;
+constexpr static ParameterType k_ParameterTypeStaticLookUpRegular = ParameterType::String;
 
 template <>
-inline ParameterType ParameterTypeStaticLookUpRegular<glm::vec3> = ParameterType::Vector;
+constexpr inline ParameterType k_ParameterTypeStaticLookUpRegular<glm::vec3> = ParameterType::Vector;
 
 template <>
-inline ParameterType ParameterTypeStaticLookUpRegular<const std::string&> = ParameterType::String;
+constexpr inline ParameterType k_ParameterTypeStaticLookUpRegular<const std::string&> = ParameterType::String;
 
 template <>
-inline ParameterType ParameterTypeStaticLookUpRegular<float> = ParameterType::Float;
+constexpr inline ParameterType k_ParameterTypeStaticLookUpRegular<float> = ParameterType::Float;
 
 template <>
-inline ParameterType ParameterTypeStaticLookUpRegular<int32_t> = ParameterType::Number;
+constexpr inline ParameterType k_ParameterTypeStaticLookUpRegular<int32_t> = ParameterType::Number;
 
 template <typename T>
 inline typename std::enable_if_t<!std::is_enum<T>::value, ParameterType> GetParamType()
 {
-	return ParameterTypeStaticLookUpRegular<T>;
+	return k_ParameterTypeStaticLookUpRegular<T>;
 }
 
 template <typename T>
 inline typename std::enable_if_t<std::is_enum<T>::value, ParameterType> GetParamType()
 {
-	return ParameterTypeStaticLookUpRegular<std::underlying_type_t<T>>;
+	return k_ParameterTypeStaticLookUpRegular<std::underlying_type_t<T>>;
 }
 
 template <class T>

--- a/src/Parsers/InfoFile.cpp
+++ b/src/Parsers/InfoFile.cpp
@@ -26,7 +26,7 @@ bool InfoFile::LoadFromFile(const std::filesystem::path& path, InfoConstants& in
 	try
 	{
 		pack::PackFile pack;
-		pack.Open(Game::instance()->GetFileSystem().FindPath(path));
+		pack.Open(Game::Instance()->GetFileSystem().FindPath(path));
 		data = pack.GetBlock("Info");
 		if (data.size() != sizeof(InfoConstants))
 		{

--- a/src/Parsers/InfoFile.h
+++ b/src/Parsers/InfoFile.h
@@ -12,7 +12,8 @@
 #include <filesystem>
 #include <optional>
 
-#include <InfoConstants.h>
+// NOLINTBEGIN(readability-identifier-naming): Naming comes from vanilla, this we maintain the style
+#include "InfoConstants.h"
 
 namespace openblack
 {

--- a/src/Profiler.cpp
+++ b/src/Profiler.cpp
@@ -14,27 +14,27 @@
 void openblack::Profiler::Begin(Stage stage)
 {
 	assert(_currentLevel < 255);
-	auto& entry = _entries.at(_currentEntry)._stages.at(static_cast<uint8_t>(stage));
-	entry._level = _currentLevel;
+	auto& entry = _entries.at(_currentEntry).stages.at(static_cast<uint8_t>(stage));
+	entry.level = _currentLevel;
 	_currentLevel++;
-	entry._start = std::chrono::system_clock::now();
-	entry._finalized = false;
+	entry.start = std::chrono::system_clock::now();
+	entry.finalized = false;
 }
 
 void openblack::Profiler::End(Stage stage)
 {
 	assert(_currentLevel > 0);
-	auto& entry = _entries.at(_currentEntry)._stages.at(static_cast<uint8_t>(stage));
-	assert(!entry._finalized);
+	auto& entry = _entries.at(_currentEntry).stages.at(static_cast<uint8_t>(stage));
+	assert(!entry.finalized);
 	_currentLevel--;
-	assert(entry._level == _currentLevel);
-	entry._end = std::chrono::system_clock::now();
-	entry._finalized = true;
+	assert(entry.level == _currentLevel);
+	entry.end = std::chrono::system_clock::now();
+	entry.finalized = true;
 }
 
 void openblack::Profiler::Frame()
 {
 	auto& prevEntry = _entries.at(_currentEntry);
-	_currentEntry = (_currentEntry + 1) % _bufferSize;
-	prevEntry._frameEnd = _entries.at(_currentEntry)._frameStart = std::chrono::system_clock::now();
+	_currentEntry = (_currentEntry + 1) % k_BufferSize;
+	prevEntry.frameEnd = _entries.at(_currentEntry).frameStart = std::chrono::system_clock::now();
 }

--- a/src/Profiler.h
+++ b/src/Profiler.h
@@ -53,7 +53,7 @@ public:
 		_count,
 	};
 
-	static constexpr std::array<std::string_view, static_cast<uint8_t>(Stage::_count)> stageNames = {
+	constexpr static std::array<std::string_view, static_cast<uint8_t>(Stage::_count)> k_StageNames = {
 	    "Physics Update",       //
 	    "Pathfinding Update",   //
 	    "Living Action Update", //
@@ -85,31 +85,31 @@ private:
 	struct ScopedSection
 	{
 		inline explicit ScopedSection(Profiler* profiler, Stage stage)
-		    : _profiler(profiler)
-		    , _stage(stage)
+		    : profiler(profiler)
+		    , stage(stage)
 		{
-			_profiler->Begin(_stage);
+			profiler->Begin(stage);
 		}
-		inline ~ScopedSection() { _profiler->End(_stage); }
+		inline ~ScopedSection() { profiler->End(stage); }
 
-		Profiler* const _profiler;
-		const Stage _stage;
+		Profiler* const profiler;
+		const Stage stage;
 	};
 
 public:
 	struct Scope
 	{
-		uint8_t _level;
-		std::chrono::system_clock::time_point _start;
-		std::chrono::system_clock::time_point _end;
-		bool _finalized = false;
+		uint8_t level;
+		std::chrono::system_clock::time_point start;
+		std::chrono::system_clock::time_point end;
+		bool finalized = false;
 	};
 
 	struct Entry
 	{
-		std::chrono::system_clock::time_point _frameStart;
-		std::chrono::system_clock::time_point _frameEnd;
-		std::array<Scope, static_cast<uint8_t>(Stage::_count)> _stages;
+		std::chrono::system_clock::time_point frameStart;
+		std::chrono::system_clock::time_point frameEnd;
+		std::array<Scope, static_cast<uint8_t>(Stage::_count)> stages;
 	};
 
 	void Frame();
@@ -117,13 +117,15 @@ public:
 	void End(Stage stage);
 	inline ScopedSection BeginScoped(Stage stage) { return ScopedSection(this, stage); }
 
-	[[nodiscard]] uint8_t GetEntryIndex(int8_t offset) const { return (_currentEntry + _bufferSize + offset) % _bufferSize; }
+	[[nodiscard]] uint8_t GetEntryIndex(int8_t offset) const { return (_currentEntry + k_BufferSize + offset) % k_BufferSize; }
 
-	static constexpr uint8_t _bufferSize = 100;
-	std::array<Entry, _bufferSize> _entries;
+	constexpr static uint8_t k_BufferSize = 100;
+	std::array<Entry, k_BufferSize>& GetEntries() { return _entries; }
+	[[nodiscard]] const std::array<Entry, k_BufferSize>& GetEntries() const { return _entries; }
 
 private:
-	uint8_t _currentEntry = _bufferSize - 1;
+	std::array<Entry, k_BufferSize> _entries;
+	uint8_t _currentEntry = k_BufferSize - 1;
 	uint8_t _currentLevel = 0;
 };
 

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -269,11 +269,11 @@ void Renderer::DrawSubMesh(const L3DMesh& mesh, const L3DSubMesh& subMesh, const
 		uint32_t skip = Mesh::SkipState::SkipNone;
 		if (!lastPreserveState)
 		{
-			if (desc.modelMatrices && desc.matrixCount > 0)
+			if (desc.modelMatrices != nullptr && desc.matrixCount > 0)
 			{
 				bgfx::setTransform(desc.modelMatrices, desc.matrixCount);
 			}
-			if (texture)
+			if (texture != nullptr)
 			{
 				desc.program->SetTextureSampler("s_diffuse", 0, *texture);
 			}
@@ -295,7 +295,7 @@ void Renderer::DrawSubMesh(const L3DMesh& mesh, const L3DSubMesh& subMesh, const
 		}
 
 		{
-			if (desc.instanceBuffer && (skip & Mesh::SkipState::SkipInstanceBuffer) == 0)
+			if (desc.instanceBuffer != nullptr && (skip & Mesh::SkipState::SkipInstanceBuffer) == 0)
 			{
 				bgfx::setInstanceDataBuffer(*desc.instanceBuffer, desc.instanceStart, desc.instanceCount);
 			}
@@ -343,7 +343,7 @@ void Renderer::DrawMesh(const L3DMesh& mesh, const L3DMeshSubmitDesc& desc, uint
 
 	for (auto it = subMeshes.begin(); it != subMeshes.end(); ++it)
 	{
-		const L3DSubMesh& subMesh = *it->get();
+		const L3DSubMesh& subMesh = **it;
 		if (!subMesh.isPhysics())
 		{
 			DrawSubMesh(mesh, subMesh, desc, std::next(it) != subMeshes.end());
@@ -386,7 +386,7 @@ void Renderer::DrawPass(const DrawSceneDesc& desc) const
 {
 	const auto& meshManager = Locator::resources::ref().GetMeshes();
 
-	if (desc.frameBuffer)
+	if (desc.frameBuffer != nullptr)
 	{
 		desc.frameBuffer->Bind(desc.viewId);
 	}
@@ -396,13 +396,13 @@ void Renderer::DrawPass(const DrawSceneDesc& desc) const
 
 	_shaderManager->SetCamera(desc.viewId, *desc.camera);
 
-	auto skyShader = _shaderManager->GetShader("Sky");
-	auto waterShader = _shaderManager->GetShader("Water");
-	auto terrainShader = _shaderManager->GetShader("Terrain");
-	auto debugShader = _shaderManager->GetShader("DebugLine");
-	auto spriteShader = _shaderManager->GetShader("Sprite");
-	auto debugShaderInstanced = _shaderManager->GetShader("DebugLineInstanced");
-	auto objectShaderInstanced = _shaderManager->GetShader("ObjectInstanced");
+	const auto* skyShader = _shaderManager->GetShader("Sky");
+	const auto* waterShader = _shaderManager->GetShader("Water");
+	const auto* terrainShader = _shaderManager->GetShader("Terrain");
+	const auto* debugShader = _shaderManager->GetShader("DebugLine");
+	const auto* spriteShader = _shaderManager->GetShader("Sprite");
+	const auto* debugShaderInstanced = _shaderManager->GetShader("DebugLineInstanced");
+	const auto* objectShaderInstanced = _shaderManager->GetShader("ObjectInstanced");
 
 	{
 		auto section = desc.profiler.BeginScoped(desc.viewId == RenderPass::Reflection ? Profiler::Stage::ReflectionDrawSky
@@ -458,7 +458,7 @@ void Renderer::DrawPass(const DrawSceneDesc& desc) const
 		                                                                               : Profiler::Stage::MainPassDrawIsland);
 		if (desc.drawIsland)
 		{
-			for (auto& block : desc.island.GetBlocks())
+			for (const auto& block : desc.island.GetBlocks())
 			{
 				auto texture = Locator::resources::ref().GetTextures().Handle(LandIsland::SmallBumpTextureId);
 

--- a/src/Resources/Loaders.cpp
+++ b/src/Resources/Loaders.cpp
@@ -58,7 +58,7 @@ entt::resource_handle<L3DMesh> L3DLoader::load(const std::filesystem::path& path
 }
 
 entt::resource_handle<graphics::Texture2D> Texture2DLoader::load(const std::string& name,
-                                                                 const pack::G3DTexture g3dTexture) const
+                                                                 const pack::G3DTexture& g3dTexture) const
 {
 	// some assumptions:
 	// - no mipmaps
@@ -68,13 +68,21 @@ entt::resource_handle<graphics::Texture2D> Texture2DLoader::load(const std::stri
 	auto texture2D = std::make_shared<graphics::Texture2D>(name);
 	graphics::Format internalFormat;
 	if (g3dTexture.ddsHeader.format.fourCC.data() == std::string("DXT1"))
+	{
 		internalFormat = graphics::Format::BlockCompression1;
+	}
 	else if (g3dTexture.ddsHeader.format.fourCC.data() == std::string("DXT3"))
+	{
 		internalFormat = graphics::Format::BlockCompression2;
+	}
 	else if (g3dTexture.ddsHeader.format.fourCC.data() == std::string("DXT5"))
+	{
 		internalFormat = graphics::Format::BlockCompression3;
+	}
 	else
+	{
 		throw std::runtime_error("Unsupported compressed texture format");
+	}
 
 	texture2D->Create(static_cast<uint16_t>(g3dTexture.ddsHeader.width), static_cast<uint16_t>(g3dTexture.ddsHeader.height), 1,
 	                  internalFormat, graphics::Wrapping::Repeat, g3dTexture.ddsData.data(),

--- a/src/Resources/Loaders.cpp
+++ b/src/Resources/Loaders.cpp
@@ -42,7 +42,7 @@ entt::resource_handle<L3DMesh> L3DLoader::load(const std::filesystem::path& path
 	}
 	else if (pathExt == ".zzz")
 	{
-		auto stream = Game::instance()->GetFileSystem().Open(path, FileMode::Read);
+		auto stream = Game::Instance()->GetFileSystem().Open(path, FileMode::Read);
 		uint32_t decompressedSize = 0;
 		stream->Read(reinterpret_cast<uint32_t*>(&decompressedSize), sizeof(decompressedSize));
 		auto buffer = std::vector<uint8_t>(stream->Size() - sizeof(decompressedSize));
@@ -96,7 +96,7 @@ entt::resource_handle<graphics::Texture2D> Texture2DLoader::load(const std::file
 	bool found = false;
 	const std::array<uint16_t, 6> resolutions = {{256, 40, 32, 14, 12, 6}};
 
-	const auto data = Game::instance()->GetFileSystem().ReadAll(rawTexturePath);
+	const auto data = Game::Instance()->GetFileSystem().ReadAll(rawTexturePath);
 	graphics::Format format = graphics::Format::R8;
 	uint16_t width = 0;
 	uint16_t height = 0;

--- a/src/Resources/Loaders.h
+++ b/src/Resources/Loaders.h
@@ -38,7 +38,7 @@ struct L3DLoader final: BaseLoader<L3DLoader, L3DMesh>
 struct Texture2DLoader final: BaseLoader<Texture2DLoader, graphics::Texture2D>
 {
 	[[nodiscard]] entt::resource_handle<graphics::Texture2D> load(const std::string& name,
-	                                                              const pack::G3DTexture g3dTexture) const;
+	                                                              const pack::G3DTexture& g3dTexture) const;
 	[[nodiscard]] entt::resource_handle<graphics::Texture2D> load(const std::filesystem::path& rawTexturePath) const;
 };
 

--- a/src/Serializer/FotFile.cpp
+++ b/src/Serializer/FotFile.cpp
@@ -41,13 +41,13 @@ void FotFile::Load(const std::filesystem::path& path)
 	{
 		const auto entity = registry.Create();
 		auto& footpathEntt = registry.Assign<ecs::components::Footpath>(entity);
-		footpathEntt.nodes.reserve(footpath._nodes.size());
-		for (const auto& node : footpath._nodes)
+		footpathEntt.nodes.reserve(footpath.nodes.size());
+		for (const auto& node : footpath.nodes)
 		{
 			glm::vec3 position = glm::vec3 {
-			    10.0f * node._coords.x / static_cast<float>(0xFFFF),
-			    node._coords.altitude,
-			    10.0f * node._coords.z / static_cast<float>(0xFFFF),
+			    10.0f * node.coords.x / static_cast<float>(0xFFFF),
+			    node.coords.altitude,
+			    10.0f * node.coords.z / static_cast<float>(0xFFFF),
 			};
 
 			// This bit is mainly for visualization, it could be that using these offsets causes uses for path planning
@@ -62,7 +62,7 @@ void FotFile::Load(const std::filesystem::path& path)
 	for (const auto& save : footpathLinkSaves)
 	{
 		std::vector<ecs::components::Footpath::Id> linkFootpathEntities;
-		for (const auto& footpath : save._link._footpaths)
+		for (const auto& footpath : save.link.footpaths)
 		{
 			// Save links have duplicates to entries in footpaths
 			const auto footpathListItr = std::find(footpaths.cbegin(), footpaths.cend(), footpath);
@@ -71,9 +71,9 @@ void FotFile::Load(const std::filesystem::path& path)
 			linkFootpathEntities.push_back(footpathEntities[footpathIndex]);
 		}
 		glm::vec3 position = glm::vec3 {
-		    10.0f * save._coords.x / static_cast<float>(0xFFFF),
-		    save._coords.altitude,
-		    10.0f * save._coords.z / static_cast<float>(0xFFFF),
+		    10.0f * save.coords.x / static_cast<float>(0xFFFF),
+		    save.coords.altitude,
+		    10.0f * save.coords.z / static_cast<float>(0xFFFF),
 		};
 		const auto entity = registry.Create();
 		registry.Assign<ecs::components::FootpathLink>(entity, position, std::move(linkFootpathEntities));

--- a/src/Serializer/GameThingSerializer.cpp
+++ b/src/Serializer/GameThingSerializer.cpp
@@ -112,16 +112,13 @@ std::shared_ptr<GameThingSerializer::GameThing> GameThingSerializer::Deserialize
 
 		return thing;
 	}
-	else if (index > _cache.size())
+	if (index > _cache.size())
 	{
 		assert(false); // weird case
 		return nullptr;
 	}
-	else
-	{
-		// referring to a previously seen entry
-		return _cache[index - 1];
-	}
+	// referring to a previously seen entry
+	return _cache[index - 1];
 }
 
 template <typename T>

--- a/src/Serializer/GameThingSerializer.h
+++ b/src/Serializer/GameThingSerializer.h
@@ -28,6 +28,7 @@ namespace openblack::serializer
 
 enum class GameThingType : uint32_t
 {
+	Invalid = 0x0,
 	Footpath = 0x1,
 	FootpathLink = 0x2,
 	FootpathNode = 0x3,
@@ -35,15 +36,15 @@ enum class GameThingType : uint32_t
 };
 
 template <typename T>
-inline GameThingType GameThingTypeEnum;
+static const GameThingType k_GameThingTypeEnum = GameThingType::Invalid;
 
 class GameThingSerializer
 {
 public:
 	struct GameThing
 	{
-		uint32_t _unknown1;
-		uint8_t _unknown2;
+		uint32_t unknown1;
+		uint8_t unknown2;
 
 		virtual ~GameThing() = default;
 
@@ -54,8 +55,8 @@ public:
 
 	struct FootpathNode final: GameThing
 	{
-		MapCoords _coords;
-		uint8_t _unknown;
+		MapCoords coords;
+		uint8_t unknown;
 
 		bool Deserialize(GameThingSerializer& deserializer) override;
 		bool operator==(const FootpathNode& rhs) const;
@@ -64,8 +65,8 @@ public:
 
 	struct Footpath final: GameThing
 	{
-		std::vector<FootpathNode> _nodes;
-		uint32_t _unknown;
+		std::vector<FootpathNode> nodes;
+		uint32_t unknown;
 
 		bool Deserialize(GameThingSerializer& deserializer) override;
 		bool operator==(const Footpath& rhs) const;
@@ -74,15 +75,15 @@ public:
 
 	struct FootpathLink final: GameThing
 	{
-		std::vector<Footpath> _footpaths;
+		std::vector<Footpath> footpaths;
 
 		bool Deserialize(GameThingSerializer& deserializer) override;
 	};
 
 	struct FootpathLinkSave final: GameThing
 	{
-		MapCoords _coords;
-		FootpathLink _link;
+		MapCoords coords;
+		FootpathLink link;
 
 		bool Deserialize(GameThingSerializer& deserializer) override;
 	};
@@ -94,7 +95,7 @@ public:
 
 	void ReadChecksum();
 
-	std::shared_ptr<GameThing> DeserializeOne(std::optional<GameThingType> required_type = std::nullopt);
+	std::shared_ptr<GameThing> DeserializeOne(std::optional<GameThingType> requiredType = std::nullopt);
 	template <typename T>
 	std::vector<T> DeserializeList();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,7 @@
 
 #include "Game.h"
 
-bool parseOptions(int argc, char** argv, openblack::Arguments& args, int& return_code)
+bool parseOptions(int argc, char** argv, openblack::Arguments& args, int& returnCode)
 {
 	cxxopts::Options options("openblack", "Open source reimplementation of the game Black & White (2001).");
 
@@ -32,7 +32,7 @@ bool parseOptions(int argc, char** argv, openblack::Arguments& args, int& return
 #endif
 
 	std::string loggingSubsystems = "all";
-	for (const auto& system : openblack::LoggingSubsystemStrs)
+	for (const auto& system : openblack::k_LoggingSubsystemStrs)
 	{
 		loggingSubsystems += std::string(", ") + system.data();
 	}
@@ -60,7 +60,7 @@ bool parseOptions(int argc, char** argv, openblack::Arguments& args, int& return
 		if (result["help"].as<bool>())
 		{
 			std::cout << options.help() << std::endl;
-			return_code = EXIT_SUCCESS;
+			returnCode = EXIT_SUCCESS;
 			return false;
 		}
 		static const std::map<std::string_view, bgfx::RendererType::Enum> rendererLookup = {
@@ -115,7 +115,7 @@ bool parseOptions(int argc, char** argv, openblack::Arguments& args, int& return
 			throw cxxopts::option_not_exists_exception(result["window-mode"].as<std::string>());
 		}
 
-		std::array<spdlog::level::level_enum, openblack::LoggingSubsystemStrs.size()> logLevels;
+		std::array<spdlog::level::level_enum, openblack::k_LoggingSubsystemStrs.size()> logLevels;
 		{
 			std::map<std::string, spdlog::level::level_enum> logLevelMap;
 			logLevelMap.insert_or_assign("all", spdlog::level::debug);
@@ -132,7 +132,7 @@ bool parseOptions(int argc, char** argv, openblack::Arguments& args, int& return
 			{
 				level = all;
 			}
-			for (size_t i = 0; const auto& str : openblack::LoggingSubsystemStrs)
+			for (size_t i = 0; const auto& str : openblack::k_LoggingSubsystemStrs)
 			{
 				const auto iter = logLevelMap.find(str.data());
 				if (iter != logLevelMap.cend())
@@ -184,7 +184,7 @@ bool parseOptions(int argc, char** argv, openblack::Arguments& args, int& return
 		std::cerr << err.what() << std::endl;
 		std::cerr << options.help() << std::endl;
 
-		return_code = EXIT_FAILURE;
+		returnCode = EXIT_FAILURE;
 		return false;
 	}
 
@@ -204,10 +204,10 @@ int main(int argc, char* argv[]) noexcept
 	try
 	{
 		openblack::Arguments args;
-		int return_code = EXIT_FAILURE;
-		if (!parseOptions(argc, argv, args, return_code))
+		int returnCode = EXIT_FAILURE;
+		if (!parseOptions(argc, argv, args, returnCode))
 		{
-			return return_code;
+			return returnCode;
 		}
 		auto game = std::make_unique<openblack::Game>(std::move(args));
 		if (!game->Initialize())

--- a/test/mock/gen_info.cpp
+++ b/test/mock/gen_info.cpp
@@ -20,7 +20,7 @@ struct Arguments
 	std::filesystem::path outFilename;
 };
 
-bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
+bool parseOptions(int argc, char** argv, Arguments& args, int& returnCode)
 {
 	cxxopts::Options options("gen_info", "Generate Mock info.dat file.");
 
@@ -38,7 +38,7 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 		if (result["help"].as<bool>())
 		{
 			std::cout << options.help() << std::endl;
-			return_code = EXIT_SUCCESS;
+			returnCode = EXIT_SUCCESS;
 			return false;
 		}
 		if (result["output-file"].count() > 0)
@@ -49,14 +49,14 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 		else
 		{
 			std::cerr << options.help() << std::endl;
-			return_code = EXIT_FAILURE;
+			returnCode = EXIT_FAILURE;
 			return false;
 		}
 	}
 	catch (cxxopts::OptionParseException& err)
 	{
 		std::cerr << err.what() << std::endl;
-		return_code = EXIT_FAILURE;
+		returnCode = EXIT_FAILURE;
 		return false;
 	}
 }
@@ -64,10 +64,10 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 int main(int argc, char* argv[]) noexcept
 {
 	Arguments args;
-	int return_code = EXIT_SUCCESS;
-	if (!parseOptions(argc, argv, args, return_code))
+	int returnCode = EXIT_SUCCESS;
+	if (!parseOptions(argc, argv, args, returnCode))
 	{
-		return return_code;
+		return returnCode;
 	}
 
 	openblack::InfoConstants constants;
@@ -77,7 +77,7 @@ int main(int argc, char* argv[]) noexcept
 	for (uint8_t i = 0; i < 6; ++i)
 	{
 		auto& abode = constants.abode[i];
-		auto abodeDebugName = std::string("ABODE_") + openblack::AbodeNumberStrs[i].data();
+		auto abodeDebugName = std::string("ABODE_") + openblack::k_AbodeNumberStrs[i].data();
 		abode.abodeNumber = static_cast<openblack::AbodeNumber>(i);
 		std::memcpy(abode.debugString.data(), abodeDebugName.c_str(), abodeDebugName.length());
 		abode.meshId = static_cast<openblack::MeshId>(static_cast<uint32_t>(openblack::MeshId::BuildingCeltic1) + i);


### PR DESCRIPTION
I've added the following checks with some exceptions. Some of the exceptions should be removed in follow-up PRs.
* `modernize-use-using`: For modern and easier to read code. We already follow this.
* `cppcoreguidelines-avoid-non-const-global-variables`: To be threadsafe and cache friendly globals should be const. Current issue with the global instance for game.
*  `readability-*`: To enforce consistent and readable code

### Caught bugs
* There was an out of bounds access to the country materials array in LandBlock.cpp
* Caught a suspicious exception object created but not thrown: #422