### PR TITLE
ci system deps: Add clang for clang-tidy

### DIFF
--- a/.github/workflows/ci-system-deps.yml
+++ b/.github/workflows/ci-system-deps.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Install dependencies and configure system
         run: |
-          pacman -Syu --noconfirm --noprogressbar --needed git cmake mesa libx11 fmt spdlog sdl2 glm bullet minizip cxxopts
+          pacman -Syu --noconfirm --noprogressbar --needed clang git cmake mesa libx11 fmt spdlog sdl2 glm bullet minizip cxxopts
           sed -E -i "s|#? ?MAKEFLAGS=.*|MAKEFLAGS=-j$(nproc)|" /etc/makepkg.conf
           useradd builduser -p ""
           printf 'builduser ALL=(ALL) ALL\n' >> /etc/sudoers


### PR DESCRIPTION
On arch linux the clang-tidy version is 13.0.1 which has more checks