### PR TITLE
rendering: Fix invalid data access in entities draw

### DIFF
--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -522,7 +522,7 @@ void Renderer::DrawPass(const DrawSceneDesc& desc) const
 				}
 				else
 				{
-					const auto identity = glm::mat4(1.0f);
+					const static auto identity = glm::mat4(1.0f);
 					submitDesc.modelMatrices = &identity;
 					submitDesc.matrixCount = 1;
 				}


### PR DESCRIPTION
`submitDesc` was getting the address of a stack local const variable for the
identity matrix which becomes invalid when the scope ends.

This causes the `u_model[0]` matrix to be invalid at draw time for all
entities and it is seen in release.

Making the identity matrix static moves the data out of the scope and makes it
long-lived solving the problem.

Fixes #395