### PR TITLE
Additional Clang-tidy checks (simple)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,4 +8,7 @@ Checks: >-
   cppcoreguidelines-pro-bounds-constant-array-index,
   performance-*,
   -performance-unnecessary-value-param,
+  misc-*,
+  -misc-non-private-member-variables-in-classes,
+  -misc-redundant-expression,
 # WarningsAsErrors: '*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,7 +3,6 @@ Checks: >-
   -*,
   clang-analyzer-*,
   modernize-*,
-  -modernize-use-equals-default,
   -modernize-use-trailing-return-type,
   -modernize-use-using,
   cppcoreguidelines-pro-bounds-constant-array-index,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,4 +6,6 @@ Checks: >-
   -modernize-use-trailing-return-type,
   -modernize-use-using,
   cppcoreguidelines-pro-bounds-constant-array-index,
+  performance-*,
+  -performance-unnecessary-value-param,
 # WarningsAsErrors: '*'

--- a/src/3D/L3DSubMesh.cpp
+++ b/src/3D/L3DSubMesh.cpp
@@ -39,7 +39,7 @@ L3DSubMesh::L3DSubMesh(L3DMesh& mesh)
 {
 }
 
-L3DSubMesh::~L3DSubMesh() {}
+L3DSubMesh::~L3DSubMesh() = default;
 
 bool L3DSubMesh::Load(const l3d::L3DFile& l3d, uint32_t meshIndex)
 {

--- a/src/Common/Queue.h
+++ b/src/Common/Queue.h
@@ -23,8 +23,8 @@ using EventHandler = std::function<void(const Event&)>;
 class IEventQueue
 {
 public:
-	IEventQueue() {};
-	virtual ~IEventQueue() {};
+	IEventQueue() = default;
+	virtual ~IEventQueue() = default;
 };
 
 template <class T>

--- a/src/Common/Queue.h
+++ b/src/Common/Queue.h
@@ -41,7 +41,7 @@ public:
 	{
 		_instance.push_back(event);
 
-		for (auto handler : _handlers)
+		for (const auto& handler : _handlers)
 		{
 			handler(_instance.front());
 		}

--- a/src/ECS/Components/Stream.h
+++ b/src/ECS/Components/Stream.h
@@ -25,6 +25,7 @@ struct Stream
 {
 	using Id = int;
 
+	// NOLINTNEXTLINE(misc-no-recursion): lint error, this isn't a function
 	class Node
 	{
 	public:

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -277,6 +277,7 @@ bool Game::GameLogicLoop()
 	const auto currentTime = std::chrono::steady_clock::now();
 	const auto delta = currentTime - _lastGameLoopTime;
 	const auto turnDuration = kTurnDuration * _gameSpeedMultiplier;
+	// NOLINTNEXTLINE(modernize-use-nullptr): clang-tidy bug
 	if (delta < turnDuration)
 	{
 		return false;

--- a/src/Game.h
+++ b/src/Game.h
@@ -118,8 +118,6 @@ public:
 
 	struct Config
 	{
-		Config() {}
-
 		bool wireframe {false};
 		bool showVillagerNames {false};
 		bool debugVillagerNames {false};

--- a/src/GameWindow.cpp
+++ b/src/GameWindow.cpp
@@ -108,6 +108,7 @@ void GameWindow::GetNativeHandles(void*& nativeWindow, void*& nativeDisplay) con
 			win_impl = wl_egl_window_create(surface, width, height);
 			SDL_SetWindowData(_window.get(), "wl_egl_window", win_impl);
 		}
+		// NOLINTNEXTLINE(performance-no-int-to-ptr)
 		nativeWindow = reinterpret_cast<void*>(win_impl);
 		nativeDisplay = wmi.info.wl.display;
 	}
@@ -116,6 +117,7 @@ void GameWindow::GetNativeHandles(void*& nativeWindow, void*& nativeDisplay) con
 #if defined(SDL_VIDEO_DRIVER_X11)
 	    if (wmi.subsystem == SDL_SYSWM_X11)
 	{
+		// NOLINTNEXTLINE(performance-no-int-to-ptr)
 		nativeWindow = reinterpret_cast<void*>(wmi.info.x11.window);
 		nativeDisplay = wmi.info.x11.display;
 	}

--- a/src/Graphics/FrameBuffer.cpp
+++ b/src/Graphics/FrameBuffer.cpp
@@ -15,7 +15,7 @@
 
 using namespace openblack::graphics;
 
-FrameBuffer::FrameBuffer(const std::string& name, uint16_t width, uint16_t height, Format colorFormat,
+FrameBuffer::FrameBuffer(std::string&& name, uint16_t width, uint16_t height, Format colorFormat,
                          std::optional<Format> depthStencilFormat)
     : _name(std::move(name))
     , _handle(BGFX_INVALID_HANDLE)

--- a/src/Graphics/FrameBuffer.h
+++ b/src/Graphics/FrameBuffer.h
@@ -24,7 +24,7 @@ class FrameBuffer
 {
 public:
 	FrameBuffer() = delete;
-	FrameBuffer(const std::string& name, uint16_t width, uint16_t height, Format colorFormat,
+	FrameBuffer(std::string&& name, uint16_t width, uint16_t height, Format colorFormat,
 	            std::optional<Format> depthStencilFormat = {});
 	~FrameBuffer();
 

--- a/src/Graphics/ShaderManager.cpp
+++ b/src/Graphics/ShaderManager.cpp
@@ -119,7 +119,7 @@ void ShaderManager::LoadShaders()
 		assert(bgfx::isValid(vs));
 		auto fs = bgfx::createEmbeddedShader(s_embeddedShaders.data(), type, shader.fragmentShaderName.data());
 		assert(bgfx::isValid(fs));
-		_shaderPrograms[shader.name.data()] = new ShaderProgram(shader.name.data(), std::move(vs), std::move(fs));
+		_shaderPrograms[shader.name.data()] = new ShaderProgram(shader.name.data(), vs, fs);
 	}
 }
 

--- a/src/Graphics/ShaderProgram.cpp
+++ b/src/Graphics/ShaderProgram.cpp
@@ -18,7 +18,7 @@
 namespace openblack::graphics
 {
 
-ShaderProgram::ShaderProgram(const std::string& name, bgfx::ShaderHandle&& vertexShader, bgfx::ShaderHandle&& fragmentShader)
+ShaderProgram::ShaderProgram(const std::string& name, bgfx::ShaderHandle vertexShader, bgfx::ShaderHandle fragmentShader)
     : _name(name)
     , _program(BGFX_INVALID_HANDLE)
 {

--- a/src/Graphics/ShaderProgram.h
+++ b/src/Graphics/ShaderProgram.h
@@ -31,7 +31,7 @@ public:
 	};
 
 	ShaderProgram() = delete;
-	ShaderProgram(const std::string& name, bgfx::ShaderHandle&& vertexShader, bgfx::ShaderHandle&& fragmentShader);
+	ShaderProgram(const std::string& name, bgfx::ShaderHandle vertexShader, bgfx::ShaderHandle fragmentShader);
 	~ShaderProgram();
 
 	void SetTextureSampler(const char* samplerName, uint8_t bindPoint, const Texture2D& texture) const;

--- a/src/Gui/Console.cpp
+++ b/src/Gui/Console.cpp
@@ -300,7 +300,7 @@ void Console::Draw(Game& game)
 	ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(4, 1)); // Tighten spacing
 	if (copy_to_clipboard)
 		ImGui::LogToClipboard();
-	for (auto item : _items)
+	for (const auto& item : _items)
 	{
 		// Normally you would store more information in your item (e.g. make Items[] an array of structure, store color/type
 		// etc.)

--- a/src/Serializer/GameThingSerializer.h
+++ b/src/Serializer/GameThingSerializer.h
@@ -35,7 +35,7 @@ enum class GameThingType : uint32_t
 };
 
 template <typename T>
-GameThingType GameThingTypeEnum;
+inline GameThingType GameThingTypeEnum;
 
 class GameThingSerializer
 {


### PR DESCRIPTION
I've added the following checks with some exceptions. Some of the exceptions should be removed in follow-up PRs.
* `modernize-use-equals-default`: For modern and easier to read code. We already follow this except for one place
* `performance-*`: To catch unnecessary copies and useless moves.
* `misc-*`: To catch possible code misuse.