### PR TITLE
clang-tidy: bugprone-*

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,4 +11,10 @@ Checks: >-
   misc-*,
   -misc-non-private-member-variables-in-classes,
   -misc-redundant-expression,
+  bugprone-*,
+  -bugprone-reserved-identifier,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-narrowing-conversions,
+  -bugprone-lambda-function-name,
+  -bugprone-implicit-widening-of-multiplication-result,
 # WarningsAsErrors: '*'

--- a/apps/anmtool/anmtool.cpp
+++ b/apps/anmtool/anmtool.cpp
@@ -103,7 +103,7 @@ struct Arguments
 	} write;
 };
 
-int WriteFile(const Arguments::Write& args)
+int WriteFile(const Arguments::Write& args) noexcept
 {
 	openblack::anm::ANMFile anm {};
 
@@ -129,28 +129,35 @@ int WriteFile(const Arguments::Write& args)
 	return EXIT_SUCCESS;
 }
 
-bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
+bool parseOptions(int argc, char** argv, Arguments& args, int& return_code) noexcept
 {
 	cxxopts::Options options("anmtool", "Inspect and extract files from LionHead ANM files.");
 
-	// clang-format off
-  options.add_options()
-    ("h,help", "Display this help message.")
-    ("subcommand", "Subcommand.", cxxopts::value<std::string>())
-    ;
-  options.positional_help("[read|write] [OPTION...]");
-  options.add_options()
-    ("H,header", "Print Header Contents.", cxxopts::value<std::vector<std::filesystem::path>>())
-    ("l,list-keyframes", "List Keyframes.", cxxopts::value<std::vector<std::filesystem::path>>())
-    ("k,keyframe-content", "View Keyframe Contents", cxxopts::value<std::vector<std::filesystem::path>>())
-    ;
-  options.add_options("write from and to glTF format")
-    ("o,output", "Output file (required).", cxxopts::value<std::filesystem::path>())
-    ("i,input-mesh", "Input file (required).", cxxopts::value<std::filesystem::path>())
-    ;
-	// clang-format on
+	try
+	{
+		options.add_options()                                            //
+		    ("h,help", "Display this help message.")                     //
+		    ("subcommand", "Subcommand.", cxxopts::value<std::string>()) //
+		    ;
+		options.positional_help("[read|write] [OPTION...]");
+		options.add_options()                                                                                      //
+		    ("H,header", "Print Header Contents.", cxxopts::value<std::vector<std::filesystem::path>>())           //
+		    ("l,list-keyframes", "List Keyframes.", cxxopts::value<std::vector<std::filesystem::path>>())          //
+		    ("k,keyframe-content", "View Keyframe Contents", cxxopts::value<std::vector<std::filesystem::path>>()) //
+		    ;
+		options.add_options("write from and to glTF format")                                    //
+		    ("o,output", "Output file (required).", cxxopts::value<std::filesystem::path>())    //
+		    ("i,input-mesh", "Input file (required).", cxxopts::value<std::filesystem::path>()) //
+		    ;
 
-	options.parse_positional({"subcommand"});
+		options.parse_positional({"subcommand"});
+	}
+	catch (const std::exception& e)
+	{
+		std::cerr << e.what() << '\n';
+		return_code = EXIT_FAILURE;
+		return false;
+	}
 
 	try
 	{
@@ -203,7 +210,7 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 			}
 		}
 	}
-	catch (cxxopts::OptionParseException& err)
+	catch (const std::exception& err)
 	{
 		std::cerr << err.what() << std::endl;
 	}
@@ -213,7 +220,7 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 	return false;
 }
 
-int main(int argc, char* argv[])
+int main(int argc, char* argv[]) noexcept
 {
 	Arguments args;
 	int return_code = EXIT_SUCCESS;
@@ -251,7 +258,7 @@ int main(int argc, char* argv[])
 				break;
 			}
 		}
-		catch (std::runtime_error& err)
+		catch (std::exception& err)
 		{
 			std::cerr << err.what() << std::endl;
 			return_code |= EXIT_FAILURE;

--- a/apps/lndtool/lndtool.cpp
+++ b/apps/lndtool/lndtool.cpp
@@ -349,7 +349,7 @@ struct Arguments
 	} write;
 };
 
-int WriteFile(const Arguments::Write& args)
+int WriteFile(const Arguments::Write& args) noexcept
 {
 	openblack::lnd::LNDFile lnd {};
 
@@ -451,35 +451,43 @@ int WriteFile(const Arguments::Write& args)
 	return EXIT_SUCCESS;
 }
 
-bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
+bool parseOptions(int argc, char** argv, Arguments& args, int& return_code) noexcept
 {
 	cxxopts::Options options("lndtool", "Inspect and extract files from LionHead LND files.");
 
-	// clang-format off
-	options.add_options()
-		("h,help", "Display this help message.")
-		("subcommand", "Subcommand.", cxxopts::value<std::string>())
-	;
-	options.positional_help("[read|write] [OPTION...]");
-	options.add_options("read")
-		("H,header", "Print Header Contents.", cxxopts::value<std::vector<std::filesystem::path>>())
-		("l,low-resolution-textures", "Print Low Resolution Texture Contents.", cxxopts::value<std::vector<std::filesystem::path>>())
-		("b,blocks", "Print Block Contents.", cxxopts::value<std::vector<std::filesystem::path>>())
-		("c,country", "Print Country Contents.", cxxopts::value<std::vector<std::filesystem::path>>())
-		("m,material", "Print Material Contents.", cxxopts::value<std::vector<std::filesystem::path>>())
-		("x,extra", "Print Extra Content.", cxxopts::value<std::vector<std::filesystem::path>>())
-		("u,unaccounted", "Print Unaccounted bytes Content.", cxxopts::value<std::vector<std::filesystem::path>>())
-	;
-	options.add_options("write")
-		("o,output", "Output file (required).", cxxopts::value<std::filesystem::path>())
-		("terrain-type", "Type of terrain (required).", cxxopts::value<uint16_t>())
-		("noise-map", "File with R8 bytes for noise map.", cxxopts::value<std::filesystem::path>())
-		("bump-map", "File with R8 bytes for bump map.", cxxopts::value<std::filesystem::path>())
-		("material-array", "Files with RGB5A1 bytes for material array (comma-separated).", cxxopts::value<std::vector<std::filesystem::path>>())
-	;
-	// clang-format on
+	try
+	{
+		options.add_options()("h,help", "Display this help message.")    //
+		    ("subcommand", "Subcommand.", cxxopts::value<std::string>()) //
+		    ;
+		options.positional_help("[read|write] [OPTION...]");
+		options.add_options("read")                                                                                     //
+		    ("H,header", "Print Header Contents.", cxxopts::value<std::vector<std::filesystem::path>>())                //
+		    ("l,low-resolution-textures", "Print Low Resolution Texture Contents.",                                     //
+		     cxxopts::value<std::vector<std::filesystem::path>>())                                                      //
+		    ("b,blocks", "Print Block Contents.", cxxopts::value<std::vector<std::filesystem::path>>())                 //
+		    ("c,country", "Print Country Contents.", cxxopts::value<std::vector<std::filesystem::path>>())              //
+		    ("m,material", "Print Material Contents.", cxxopts::value<std::vector<std::filesystem::path>>())            //
+		    ("x,extra", "Print Extra Content.", cxxopts::value<std::vector<std::filesystem::path>>())                   //
+		    ("u,unaccounted", "Print Unaccounted bytes Content.", cxxopts::value<std::vector<std::filesystem::path>>()) //
+		    ;
+		options.add_options("write")                                                                    //
+		    ("o,output", "Output file (required).", cxxopts::value<std::filesystem::path>())            //
+		    ("terrain-type", "Type of terrain (required).", cxxopts::value<uint16_t>())                 //
+		    ("noise-map", "File with R8 bytes for noise map.", cxxopts::value<std::filesystem::path>()) //
+		    ("bump-map", "File with R8 bytes for bump map.", cxxopts::value<std::filesystem::path>())   //
+		    ("material-array", "Files with RGB5A1 bytes for material array (comma-separated).",         //
+		     cxxopts::value<std::vector<std::filesystem::path>>())                                      //
+		    ;
 
-	options.parse_positional({"subcommand"});
+		options.parse_positional({"subcommand"});
+	}
+	catch (const std::exception& e)
+	{
+		std::cerr << e.what() << '\n';
+		return_code = EXIT_FAILURE;
+		return false;
+	}
 
 	try
 	{
@@ -565,7 +573,7 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 			}
 		}
 	}
-	catch (cxxopts::OptionParseException& err)
+	catch (const std::exception& err)
 	{
 		std::cerr << err.what() << std::endl;
 	}
@@ -575,7 +583,7 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 	return false;
 }
 
-int main(int argc, char* argv[])
+int main(int argc, char* argv[]) noexcept
 {
 	Arguments args;
 	int return_code = EXIT_SUCCESS;
@@ -625,7 +633,7 @@ int main(int argc, char* argv[])
 				break;
 			}
 		}
-		catch (std::runtime_error& err)
+		catch (std::exception& err)
 		{
 			std::cerr << err.what() << std::endl;
 			return_code |= EXIT_FAILURE;

--- a/apps/morphtool/morphtool.cpp
+++ b/apps/morphtool/morphtool.cpp
@@ -342,30 +342,39 @@ struct Arguments
 	} read;
 };
 
-bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
+bool parseOptions(int argc, char** argv, Arguments& args, int& return_code) noexcept
 {
 	cxxopts::Options options("morphtool", "Inspect and read data files from LionHead CBN and HBN files internal segment (use "
 	                                      "\"stdin\" if piping from packtool).");
 
-	// clang-format off
-	options.add_options()
-		("h,help", "Display this help message.")
-		("subcommand", "Subcommand.", cxxopts::value<std::string>())
-	;
-	options.positional_help("[read|write] [OPTION...]");
-	options.add_options()
-		("l,list-details", "Print Content Details.", cxxopts::value<std::vector<std::filesystem::path>>())
-		("H,header", "Print Header Contents.", cxxopts::value<std::vector<std::filesystem::path>>())
-		("d,spec-files-directory", "Directory of spec files (required).", cxxopts::value<std::filesystem::path>())
-		("s,list-animation-set", "List content of spec file.", cxxopts::value<std::vector<std::filesystem::path>>())
-		("b,show-base-animation-set", "Display animation data for the base animation.", cxxopts::value<std::vector<std::filesystem::path>>())
-		("V,show-variant-animation-sets", "Display animation data for the variant animations.", cxxopts::value<std::vector<std::filesystem::path>>())
-		("g,show-hair-groups", "Display hair group data.", cxxopts::value<std::vector<std::filesystem::path>>())
-		("e,show-extra-data", "Display extra data.", cxxopts::value<std::vector<std::filesystem::path>>())
-	;
-	// clang-format on
+	try
+	{
+		options.add_options()                                            //
+		    ("h,help", "Display this help message.")                     //
+		    ("subcommand", "Subcommand.", cxxopts::value<std::string>()) //
+		    ;
+		options.positional_help("[read|write] [OPTION...]");
+		options.add_options()                                                                                            //
+		    ("l,list-details", "Print Content Details.", cxxopts::value<std::vector<std::filesystem::path>>())           //
+		    ("H,header", "Print Header Contents.", cxxopts::value<std::vector<std::filesystem::path>>())                 //
+		    ("d,spec-files-directory", "Directory of spec files (required).", cxxopts::value<std::filesystem::path>())   //
+		    ("s,list-animation-set", "List content of spec file.", cxxopts::value<std::vector<std::filesystem::path>>()) //
+		    ("b,show-base-animation-set", "Display animation data for the base animation.",                              //
+		     cxxopts::value<std::vector<std::filesystem::path>>())                                                       //
+		    ("V,show-variant-animation-sets", "Display animation data for the variant animations.",                      //
+		     cxxopts::value<std::vector<std::filesystem::path>>())                                                       //
+		    ("g,show-hair-groups", "Display hair group data.", cxxopts::value<std::vector<std::filesystem::path>>())     //
+		    ("e,show-extra-data", "Display extra data.", cxxopts::value<std::vector<std::filesystem::path>>())           //
+		    ;
 
-	options.parse_positional({"subcommand"});
+		options.parse_positional({"subcommand"});
+	}
+	catch (const std::exception& e)
+	{
+		std::cerr << e.what() << '\n';
+		return_code = EXIT_FAILURE;
+		return false;
+	}
 
 	try
 	{
@@ -438,7 +447,7 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 			}
 		}
 	}
-	catch (cxxopts::OptionParseException& err)
+	catch (const std::exception& err)
 	{
 		std::cerr << err.what() << std::endl;
 	}
@@ -448,7 +457,7 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 	return false;
 }
 
-int main(int argc, char* argv[])
+int main(int argc, char* argv[]) noexcept
 {
 	Arguments args;
 	int return_code = EXIT_SUCCESS;
@@ -511,7 +520,7 @@ int main(int argc, char* argv[])
 				break;
 			}
 		}
-		catch (std::runtime_error& err)
+		catch (const std::exception& err)
 		{
 			std::cerr << err.what() << std::endl;
 			return_code |= EXIT_FAILURE;

--- a/apps/packtool/packtool.cpp
+++ b/apps/packtool/packtool.cpp
@@ -286,7 +286,7 @@ int ViewAnimation(openblack::pack::PackFile& pack, uint32_t index, const std::fi
 	return EXIT_SUCCESS;
 }
 
-int WriteRaw(const std::filesystem::path& outFilename, const std::vector<std::filesystem::path>& inFilenames)
+int WriteRaw(const std::filesystem::path& outFilename, const std::vector<std::filesystem::path>& inFilenames) noexcept
 {
 	openblack::pack::PackFile pack;
 
@@ -312,6 +312,11 @@ int WriteRaw(const std::filesystem::path& outFilename, const std::vector<std::fi
 			std::fprintf(stderr, "I/O error while reading \"%s\": %s\n", filename.string().c_str(), e.what());
 			return EXIT_FAILURE;
 		}
+		catch (const std::exception& e)
+		{
+			std::cerr << e.what() << std::endl;
+			return EXIT_FAILURE;
+		}
 
 		pack.CreateRawBlock(filename.filename().string(), std::move(data));
 	}
@@ -321,7 +326,7 @@ int WriteRaw(const std::filesystem::path& outFilename, const std::vector<std::fi
 	return EXIT_SUCCESS;
 }
 
-int WriteMeshFile(const std::filesystem::path& outFilename)
+int WriteMeshFile(const std::filesystem::path& outFilename) noexcept
 {
 	openblack::pack::PackFile pack;
 
@@ -334,7 +339,7 @@ int WriteMeshFile(const std::filesystem::path& outFilename)
 	return EXIT_SUCCESS;
 }
 
-int WriteAnimationFile(const std::filesystem::path& outFilename)
+int WriteAnimationFile(const std::filesystem::path& outFilename) noexcept
 {
 	openblack::pack::PackFile pack;
 
@@ -371,33 +376,42 @@ struct Arguments
 	std::filesystem::path outFilename;
 };
 
-bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
+bool parseOptions(int argc, char** argv, Arguments& args, int& return_code) noexcept
 {
 	cxxopts::Options options("packtool", "Inspect and extract files from LionHead pack files.");
 
-	// clang-format off
-	options.add_options()
-		("h,help", "Display this help message.")
-		("l,list-blocks", "List all blocks statistics.")
-		("b,view-bytes", "View raw byte content of block.")
-		("s,block", "List statistics of block.", cxxopts::value<std::string>())
-		("i,info-block", "List INFO block statistics.")
-		("B,body-block", "List Body block statistics.")
-		("M,meshes-block", "List MESHES block statistics.")
-		("m,mesh", "List mesh statistics.", cxxopts::value<uint32_t>())
-		("T,texture-block", "View texture block statistics.")
-		("t,texture", "View texture statistics.", cxxopts::value<std::string>())
-		("A,animation-block", "List animation block statistics.")
-		("a,animation", "List animation statistics.", cxxopts::value<uint32_t>())
-		("e,extract", "Extract contents of a block to filename (use \"stdout\" for piping to other tool).", cxxopts::value<std::filesystem::path>())
-		("w,write-raw", "Create Raw Data Pack.", cxxopts::value<std::filesystem::path>())
-		("write-mesh", "Create Mesh Pack.", cxxopts::value<std::filesystem::path>())
-		("write-animation", "Create Mesh Pack.", cxxopts::value<std::filesystem::path>())
-		("pack-files", "Pack Files.", cxxopts::value<std::vector<std::filesystem::path>>())
-	;
-	// clang-format on
-	options.parse_positional({"pack-files"});
-	options.positional_help("pack-files...");
+	try
+	{
+		options.add_options()                                                                                   //
+		    ("h,help", "Display this help message.")                                                            //
+		    ("l,list-blocks", "List all blocks statistics.")                                                    //
+		    ("b,view-bytes", "View raw byte content of block.")                                                 //
+		    ("s,block", "List statistics of block.", cxxopts::value<std::string>())                             //
+		    ("i,info-block", "List INFO block statistics.")                                                     //
+		    ("B,body-block", "List Body block statistics.")                                                     //
+		    ("M,meshes-block", "List MESHES block statistics.")                                                 //
+		    ("m,mesh", "List mesh statistics.", cxxopts::value<uint32_t>())                                     //
+		    ("T,texture-block", "View texture block statistics.")                                               //
+		    ("t,texture", "View texture statistics.", cxxopts::value<std::string>())                            //
+		    ("A,animation-block", "List animation block statistics.")                                           //
+		    ("a,animation", "List animation statistics.", cxxopts::value<uint32_t>())                           //
+		    ("e,extract", "Extract contents of a block to filename (use \"stdout\" for piping to other tool).", //
+		     cxxopts::value<std::filesystem::path>())                                                           //
+		    ("w,write-raw", "Create Raw Data Pack.", cxxopts::value<std::filesystem::path>())                   //
+		    ("write-mesh", "Create Mesh Pack.", cxxopts::value<std::filesystem::path>())                        //
+		    ("write-animation", "Create Mesh Pack.", cxxopts::value<std::filesystem::path>())                   //
+		    ("pack-files", "Pack Files.", cxxopts::value<std::vector<std::filesystem::path>>())                 //
+		    ;
+
+		options.parse_positional({"pack-files"});
+		options.positional_help("pack-files...");
+	}
+	catch (const std::exception& e)
+	{
+		std::cerr << e.what() << '\n';
+		return_code = EXIT_FAILURE;
+		return false;
+	}
 
 	try
 	{
@@ -521,7 +535,7 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 			return true;
 		}
 	}
-	catch (cxxopts::OptionParseException& err)
+	catch (const std::exception& err)
 	{
 		std::cerr << err.what() << std::endl;
 	}
@@ -531,7 +545,7 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 	return false;
 }
 
-int main(int argc, char* argv[])
+int main(int argc, char* argv[]) noexcept
 {
 	Arguments args;
 	int return_code = EXIT_SUCCESS;
@@ -603,7 +617,7 @@ int main(int argc, char* argv[])
 				break;
 			}
 		}
-		catch (std::runtime_error& err)
+		catch (std::exception& err)
 		{
 			std::cerr << err.what() << std::endl;
 			return_code |= EXIT_FAILURE;

--- a/components/l3d/include/L3DFile.h
+++ b/components/l3d/include/L3DFile.h
@@ -298,11 +298,11 @@ public:
 		return _vertexGroupSpans[submeshIndex];
 	}
 
-	void AddSubmesh(const L3DSubmeshHeader& header);
-	void AddPrimitives(const std::vector<L3DPrimitiveHeader>& headers);
-	void AddVertices(const std::vector<L3DVertex>& vertices);
-	void AddIndices(const std::vector<uint16_t>& indices);
-	void AddBones(const std::vector<L3DBone>& bones);
+	void AddSubmesh(const L3DSubmeshHeader& header) noexcept;
+	void AddPrimitives(const std::vector<L3DPrimitiveHeader>& headers) noexcept;
+	void AddVertices(const std::vector<L3DVertex>& vertices) noexcept;
+	void AddIndices(const std::vector<uint16_t>& indices) noexcept;
+	void AddBones(const std::vector<L3DBone>& bones) noexcept;
 };
 
 } // namespace openblack::l3d

--- a/components/l3d/src/L3DFile.cpp
+++ b/components/l3d/src/L3DFile.cpp
@@ -727,12 +727,12 @@ void L3DFile::Write(const std::filesystem::path& filepath)
 	WriteFile(stream);
 }
 
-void L3DFile::AddSubmesh(const L3DSubmeshHeader& header)
+void L3DFile::AddSubmesh(const L3DSubmeshHeader& header) noexcept
 {
 	_submeshHeaders.push_back(header);
 }
 
-void L3DFile::AddPrimitives(const std::vector<L3DPrimitiveHeader>& headers)
+void L3DFile::AddPrimitives(const std::vector<L3DPrimitiveHeader>& headers) noexcept
 {
 	auto size = _primitiveHeaders.size();
 	for (auto& header : headers)
@@ -742,7 +742,7 @@ void L3DFile::AddPrimitives(const std::vector<L3DPrimitiveHeader>& headers)
 	_primitiveSpans.emplace_back(&_primitiveHeaders[size], static_cast<uint32_t>(headers.size()));
 }
 
-void L3DFile::AddVertices(const std::vector<L3DVertex>& vertices)
+void L3DFile::AddVertices(const std::vector<L3DVertex>& vertices) noexcept
 {
 	auto size = _vertices.size();
 	for (auto& vertex : vertices)
@@ -752,7 +752,7 @@ void L3DFile::AddVertices(const std::vector<L3DVertex>& vertices)
 	_vertexSpans.emplace_back(&_vertices[static_cast<uint32_t>(size)], static_cast<uint32_t>(vertices.size()));
 }
 
-void L3DFile::AddIndices(const std::vector<uint16_t>& indices)
+void L3DFile::AddIndices(const std::vector<uint16_t>& indices) noexcept
 {
 	auto size = _indices.size();
 	for (auto& index : indices)
@@ -762,7 +762,7 @@ void L3DFile::AddIndices(const std::vector<uint16_t>& indices)
 	_indexSpans.emplace_back(&_indices[static_cast<uint32_t>(size)], static_cast<uint32_t>(indices.size()));
 }
 
-void L3DFile::AddBones(const std::vector<L3DBone>& bones)
+void L3DFile::AddBones(const std::vector<L3DBone>& bones) noexcept
 {
 	auto size = _boneSpans.size();
 	for (auto& bone : bones)

--- a/src/Dynamics/LandBlockBulletMeshInterface.h
+++ b/src/Dynamics/LandBlockBulletMeshInterface.h
@@ -37,13 +37,14 @@ public:
 	    : _vertices(vertex_count / stride)
 	    , _indices(vertex_count / stride)
 	{
-		for (uint16_t i = 0; i < _vertices.size(); ++i)
+		for (uint16_t i = 0; auto& v : _vertices)
 		{
 			auto vertex_base = reinterpret_cast<const float*>(&vertex_data[i * stride]);
-			_vertices[i][0] = vertex_base[0];
-			_vertices[i][1] = vertex_base[1];
-			_vertices[i][2] = vertex_base[2];
+			v[0] = vertex_base[0];
+			v[1] = vertex_base[1];
+			v[2] = vertex_base[2];
 			_indices[i] = i;
+			++i;
 		}
 	}
 

--- a/src/Enums.h
+++ b/src/Enums.h
@@ -3258,6 +3258,7 @@ constexpr uint32_t MakeSpeedState(float ms)
 	constexpr float ms1 = static_cast<float>(ms100) * 0.01f;
 	float scaled = ms * ms1;
 	// Speed needs to be positive. Round cast to int won't work in negative.
+	// NOLINTNEXTLINE(bugprone-incorrect-roundings): can't use lroundf in constexpr
 	return static_cast<uint32_t>(scaled + 0.5f);
 }
 
@@ -3302,6 +3303,7 @@ constexpr uint32_t MakeTurnAngleState(float degrees)
 	constexpr float a1 = static_cast<float>(a360) / 360.0f;
 	float scaled = degrees * a1;
 	// Speed needs to be positive. Round cast to int won't work in negative.
+	// NOLINTNEXTLINE(bugprone-incorrect-roundings): can't use lroundf in constexpr
 	return static_cast<uint32_t>(scaled + 0.5f);
 }
 

--- a/src/Game.h
+++ b/src/Game.h
@@ -58,10 +58,6 @@ class LHVM;
 namespace ecs
 {
 class Map;
-namespace components
-{
-struct Transform;
-}
 namespace systems
 {
 class DynamicsSystem;

--- a/src/Graphics/ShaderIncluder.h
+++ b/src/Graphics/ShaderIncluder.h
@@ -18,6 +18,7 @@
 #pragma warning( disable : 4003 )
 #endif
 
+// NOLINTNEXTLINE(bugprone-macro-parentheses): The / is not an operand and this is not a macro
 #define GENERATED_SHADERS_DIR generated/shaders/
 
 #ifndef SHADER_DIR

--- a/src/Gui/Console.cpp
+++ b/src/Gui/Console.cpp
@@ -122,7 +122,7 @@ int Console::InputTextCallback(ImGuiInputTextCallbackData* data)
 			int match_len = (int)(word_end - word_start);
 			for (;;)
 			{
-				int c = 0;
+				char c = 0;
 				bool all_candidates_matches = true;
 				for (size_t i = 0; i < candidates.size() && all_candidates_matches; i++)
 					if (i == 0)

--- a/src/Gui/Gui.cpp
+++ b/src/Gui/Gui.cpp
@@ -54,6 +54,7 @@
 
 // Turn off formatting because it adds spaces which break the stringifying
 // clang-format off
+// NOLINTNEXTLINE(bugprone-macro-parentheses)
 #define IMGUI_SHADER_DIR imgui/
 // clang-format on
 #define SHADER_NAME vs_imgui_image
@@ -431,17 +432,17 @@ void Gui::UpdateGamepads()
 	}
 
 	// Update gamepad inputs
-#define MAP_BUTTON(NAV_NO, BUTTON_NO)                                                                        \
-	{                                                                                                        \
-		io.NavInputs[NAV_NO] = (SDL_GameControllerGetButton(game_controller, BUTTON_NO) != 0) ? 1.0f : 0.0f; \
+#define MAP_BUTTON(NAV_NO, BUTTON_NO)                                                                            \
+	{                                                                                                            \
+		io.NavInputs[(NAV_NO)] = (SDL_GameControllerGetButton(game_controller, (BUTTON_NO)) != 0) ? 1.0f : 0.0f; \
 	}
-#define MAP_ANALOG(NAV_NO, AXIS_NO, V0, V1)                                                              \
-	{                                                                                                    \
-		float vn = (float)(SDL_GameControllerGetAxis(game_controller, AXIS_NO) - V0) / (float)(V1 - V0); \
-		if (vn > 1.0f)                                                                                   \
-			vn = 1.0f;                                                                                   \
-		if (vn > 0.0f && io.NavInputs[NAV_NO] < vn)                                                      \
-			io.NavInputs[NAV_NO] = vn;                                                                   \
+#define MAP_ANALOG(NAV_NO, AXIS_NO, V0, V1)                                                                      \
+	{                                                                                                            \
+		float vn = (float)(SDL_GameControllerGetAxis(game_controller, (AXIS_NO)) - (V0)) / (float)((V1) - (V0)); \
+		if (vn > 1.0f)                                                                                           \
+			vn = 1.0f;                                                                                           \
+		if (vn > 0.0f && io.NavInputs[(NAV_NO)] < vn)                                                            \
+			io.NavInputs[(NAV_NO)] = vn;                                                                         \
 	}
 	const int thumb_dead_zone = 8000;                            // SDL_gamecontroller.h suggests using this value.
 	MAP_BUTTON(ImGuiNavInput_Activate, SDL_CONTROLLER_BUTTON_A); // Cross / A

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -191,7 +191,7 @@ bool parseOptions(int argc, char** argv, openblack::Arguments& args, int& return
 	return true;
 }
 
-int main(int argc, char* argv[])
+int main(int argc, char* argv[]) noexcept
 {
 	// clang-format off
 	std::cout <<
@@ -201,10 +201,8 @@ int main(int argc, char* argv[])
 	    "\n";
 	// clang-format on
 
-#ifdef NDEBUG
 	try
 	{
-#endif
 		openblack::Arguments args;
 		int return_code = EXIT_FAILURE;
 		if (!parseOptions(argc, argv, args, return_code))
@@ -220,17 +218,13 @@ int main(int argc, char* argv[])
 		{
 			return EXIT_FAILURE;
 		}
-#ifdef NDEBUG
 	}
-	catch (std::runtime_error& e)
+	catch (std::exception& e)
 	{
-		// Only catch runtime_error as these should be user issues.
-		// Catching other types would just make debugging them more difficult.
-
+		std::cerr << e.what() << std::endl;
 		SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Fatal error", e.what(), nullptr);
 		return EXIT_FAILURE;
 	}
-#endif
 
 	return EXIT_SUCCESS;
 }

--- a/test/mock/gen_info.cpp
+++ b/test/mock/gen_info.cpp
@@ -61,7 +61,7 @@ bool parseOptions(int argc, char** argv, Arguments& args, int& return_code)
 	}
 }
 
-int main(int argc, char* argv[])
+int main(int argc, char* argv[]) noexcept
 {
 	Arguments args;
 	int return_code = EXIT_SUCCESS;


### PR DESCRIPTION
To catch possible bugs due to misuse, uncaught or thrown exceptions.

This change enforces that no exception can bubble up to the main function without being caught.