### PR TITLE
Do clang-tidy checks in a dedicated build step

### DIFF
--- a/.github/workflows/ci-vcpkg.yml
+++ b/.github/workflows/ci-vcpkg.yml
@@ -149,9 +149,9 @@ jobs:
           clang_tidy_version: 12
           apt_packages: g++-10 # g++-9 doesn't support all of c++20 like spans
           exclude: "*ShaderIncluder.h"
-          # If there are any comments, fail the check
-          #- if: steps.review.outputs.total_comments > 0
-          #  run: exit 1
+      - name: If there are any comments, fail the check
+        if: steps.review.outputs.total_comments > 0
+        run: exit 1
 
   run:
     needs: build

--- a/.github/workflows/ci-vcpkg.yml
+++ b/.github/workflows/ci-vcpkg.yml
@@ -62,7 +62,7 @@ jobs:
         uses: lukka/run-cmake@v10
         with:
           configurePreset: 'ninja-multi-vcpkg'
-          configurePresetCmdString: "[`--preset`, `$[env.CONFIGURE_PRESET_NAME]`, `-DOPENBLACK_CLANG_TIDY_CHECKS=ON`, `-DOPENBLACK_WARNINGS_AS_ERRORS=ON`]"
+          configurePresetCmdString: "[`--preset`, `$[env.CONFIGURE_PRESET_NAME]`, `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`, `-DOPENBLACK_WARNINGS_AS_ERRORS=ON`]"
         env:
           CC: ${{matrix.cc}}
           CXX: ${{matrix.cxx}}
@@ -71,7 +71,7 @@ jobs:
         uses: lukka/run-cmake@v10
         with:
           configurePreset: 'ninja-multi-vcpkg'
-          configurePresetCmdString: "[`--preset`, `$[env.CONFIGURE_PRESET_NAME]`, `-DOPENBLACK_CLANG_TIDY_CHECKS=ON`, `-DOPENBLACK_WARNINGS_AS_ERRORS=ON`]"
+          configurePresetCmdString: "[`--preset`, `$[env.CONFIGURE_PRESET_NAME]`, `-DOPENBLACK_WARNINGS_AS_ERRORS=ON`]"
           buildPreset: 'ninja-multi-vcpkg-debug'
           testPreset: 'ninja-multi-vcpkg-debug'
         env:
@@ -82,12 +82,23 @@ jobs:
         uses: lukka/run-cmake@v10
         with:
           configurePreset: 'ninja-multi-vcpkg'
-          configurePresetCmdString: "[`--preset`, `$[env.CONFIGURE_PRESET_NAME]`, `-DOPENBLACK_CLANG_TIDY_CHECKS=ON`, `-DOPENBLACK_WARNINGS_AS_ERRORS=ON`]"
+          configurePresetCmdString: "[`--preset`, `$[env.CONFIGURE_PRESET_NAME]`, `-DOPENBLACK_WARNINGS_AS_ERRORS=ON`]"
           buildPreset: 'ninja-multi-vcpkg-release'
           testPreset: 'ninja-multi-vcpkg-release'
         env:
           CC: ${{matrix.cc}}
           CXX: ${{matrix.cxx}}
+
+      - name: Upload compile database and system includes
+        uses: actions/upload-artifact@v3
+        if: startsWith(matrix.os, 'ubuntu')
+        with:
+          name: openblack-compile-database
+          path: |
+            cmake-build-presets/ninja-multi-vcpkg/include
+            cmake-build-presets/ninja-multi-vcpkg/vcpkg_installed/x64-linux/include
+            cmake-build-presets/ninja-multi-vcpkg/compile_commands.json
+          if-no-files-found: error
 
       - name: Upload compiled openblack and tools
         uses: actions/upload-artifact@v3
@@ -111,6 +122,36 @@ jobs:
     env:
       CC: ${{ matrix.cc }}
       CXX: ${{ matrix.cxx }}
+
+  clang-tidy:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.event_name, 'pull_request')
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          submodules: recursive
+      - name: Download generated compile database
+        uses: actions/download-artifact@v3
+        with:
+          name: openblack-compile-database
+          path: cmake-build-presets/ninja-multi-vcpkg
+      - name: Add base repo to git config
+        run: git remote add upstream ${{ github.event.pull_request.base.repo.html_url }}
+        if: startsWith(github.event_name, 'pull_request')
+      - uses: ZedThree/clang-tidy-review@v0.8.4
+        id: review
+        with:
+          build_dir: cmake-build-presets/ninja-multi-vcpkg
+          config_file: '.clang-tidy'
+          clang_tidy_version: 12
+          apt_packages: g++-10 # g++-9 doesn't support all of c++20 like spans
+          exclude: "*ShaderIncluder.h"
+          # If there are any comments, fail the check
+          #- if: steps.review.outputs.total_comments > 0
+          #  run: exit 1
 
   run:
     needs: build

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,7 +88,7 @@ set_target_properties(openblack_lib PROPERTIES LINKER_LANGUAGE CXX)
 target_include_directories(
   openblack_lib PUBLIC ${CMAKE_CURRENT_LIST_DIR}
                        ${BULLET_INCLUDE_DIR}
-                       ${CMAKE_CURRENT_BINARY_DIR}/../include)
+                       ${CMAKE_BINARY_DIR}/include)
 if (NOT VCPKG_TARGET_ANDROID)
   target_include_directories(openblack_lib PUBLIC ${BULLET_ROOT_DIR}/${BULLET_INCLUDE_DIR})
 endif()


### PR DESCRIPTION
Building with clang tidy checks (`-DOPENBLACK_CLANG_TIDY_CHECKS=ON`) increases build times dramatically.
It some cases it goes from 2 minutes to 20 minutes.

This PR allows the build step to export compilation commands which can be used directly by clang-tidy to gain insight about specific files and how the compile.

A clang-tidy check step has been added using `ZedThree/clang-tidy-review` which downloads compile commands and headers from vcpkg and checks the changed source them after the regular build step has succeeded.

This provides a quicker way to see if a build succeeds which would be of a higher priority than if the style is good.
The job doesn't run in a matrix and takes about 10 minutes on a medium sized change.
The job provides comments in the PRs (see #443).
The job is also smart enough to filter the warnings to changed files and lines only.