### PR TITLE
rendering: Convert RenderingSystem from Singleton to Locator

### DIFF
--- a/src/ECS/Registry.cpp
+++ b/src/ECS/Registry.cpp
@@ -9,6 +9,7 @@
 
 #include "Registry.h"
 
+#include "Locator.h"
 #include "Systems/RenderingSystem.h"
 
 namespace openblack::ecs
@@ -31,6 +32,6 @@ const RegistryContext& Registry::Context() const
 
 void Registry::SetDirty()
 {
-	systems::RenderingSystem::Instance().SetDirty();
+	Locator::rendereringSystem::ref().SetDirty();
 }
 } // namespace openblack::ecs

--- a/src/ECS/Systems/RenderingSystem.cpp
+++ b/src/ECS/Systems/RenderingSystem.cpp
@@ -24,17 +24,9 @@
 using namespace openblack::ecs::systems;
 using namespace openblack::ecs::components;
 
-RenderingSystem& RenderingSystem::Instance()
-{
-	static std::unique_ptr<RenderingSystem> instance;
-	if (instance == nullptr)
-	{
-		instance.reset(new RenderingSystem());
-	}
-	return *instance;
-}
+RenderingSystemInterface::~RenderingSystemInterface() = default;
 
-RenderingSystem::RenderingSystem() = default;
+RenderingSystem::~RenderingSystem() = default;
 
 void RenderingSystem::PrepareDrawDescs(bool drawBoundingBox)
 {

--- a/src/ECS/Systems/RenderingSystem.h
+++ b/src/ECS/Systems/RenderingSystem.h
@@ -69,17 +69,24 @@ struct RenderContext
 	bool hasBoundingBoxes {false};
 };
 
-class RenderingSystem
+class RenderingSystemInterface
 {
 public:
-	static RenderingSystem& Instance();
+	virtual void SetDirty() = 0;
+	virtual void PrepareDraw(bool drawBoundingBox, bool drawFootpaths, bool drawStreams) = 0;
+	virtual const RenderContext& GetContext() = 0;
+	virtual ~RenderingSystemInterface();
+};
 
-	void SetDirty();
-	void PrepareDraw(bool drawBoundingBox, bool drawFootpaths, bool drawStreams);
-	const RenderContext& GetContext() { return _renderContext; }
+class RenderingSystem final: public RenderingSystemInterface
+{
+public:
+	~RenderingSystem() override;
+	void SetDirty() override;
+	void PrepareDraw(bool drawBoundingBox, bool drawFootpaths, bool drawStreams) override;
+	const RenderContext& GetContext() override { return _renderContext; }
 
 private:
-	RenderingSystem();
 	void PrepareDrawDescs(bool drawBoundingBox);
 	void PrepareDrawUploadUniforms(bool drawBoundingBox);
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -152,6 +152,7 @@ Game::~Game()
 	resources.GetMeshes().Clear();
 	resources.GetTextures().Clear();
 	resources.GetAnimations().Clear();
+	Locator::rendereringSystem::reset();
 
 	_water.reset();
 	_sky.reset();
@@ -425,7 +426,8 @@ bool Game::Update()
 			auto updateEntities = _profiler->BeginScoped(Profiler::Stage::UpdateEntities);
 			if (_config.drawEntities)
 			{
-				RenderingSystem::Instance().PrepareDraw(_config.drawBoundingBoxes, _config.drawFootpaths, _config.drawStreams);
+				Locator::rendereringSystem::ref().PrepareDraw(_config.drawBoundingBoxes, _config.drawFootpaths,
+				                                              _config.drawStreams);
 			}
 		}
 	} // Update Uniforms
@@ -437,6 +439,7 @@ bool Game::Initialize()
 {
 	Locator::resources::set<resources::Resources>();
 	Locator::rng::set<RandomNumberManagerProduction>();
+	Locator::rendereringSystem::set<RenderingSystem>();
 	auto& resources = Locator::resources::ref();
 	auto& meshManager = resources.GetMeshes();
 	auto& textureManager = resources.GetTextures();

--- a/src/Locator.h
+++ b/src/Locator.h
@@ -12,6 +12,7 @@
 #include <entt/locator/locator.hpp>
 
 #include "Common/RandomNumberManager.h"
+#include "ECS/Systems/RenderingSystem.h"
 #include "Resources/Resources.h"
 
 namespace openblack
@@ -21,5 +22,6 @@ struct Locator
 {
 	using resources = entt::service_locator<resources::ResourcesInterface>;
 	using rng = entt::service_locator<RandomNumberManagerInterface>;
+	using rendereringSystem = entt::service_locator<ecs::systems::RenderingSystemInterface>;
 };
 } // namespace openblack

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -505,7 +505,7 @@ void Renderer::DrawPass(const DrawSceneDesc& desc) const
 				| BGFX_STATE_MSAA
 			;
 			// clang-format on
-			const auto& renderCtx = RenderingSystem::Instance().GetContext();
+			const auto& renderCtx = Locator::rendereringSystem::ref().GetContext();
 
 			// Instance meshes
 			for (const auto& [meshId, placers] : renderCtx.instancedDrawDescs)


### PR DESCRIPTION
Fixes a crash when closing in Vulkan because the RenderingSystem wasn't freeing its resources.