### PR TITLE
Android: Lint and build APKs

### DIFF
--- a/.github/workflows/ci-cross-compile.yml
+++ b/.github/workflows/ci-cross-compile.yml
@@ -94,36 +94,52 @@ jobs:
         os: [ ubuntu-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Install Linux dependencies
-        run: |
-          sudo apt update -y
-          sudo apt install -y libgl1-mesa-dev libglu1-mesa-dev
-        if: startsWith(matrix.os, 'ubuntu')
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '11'
-      - name: Run Gradle Configure CMake (Debug)
-        uses: gradle/gradle-build-action@v2
+      - uses: actions/download-artifact@v3
+        name: Download pre-compiled android-armeabi-v7a-vcpkg
         with:
-          arguments: --configuration-cache configureCMakeDebug
-          build-root-directory: android
-      - name: Run Gradle Configure CMake (Release)
-        uses: gradle/gradle-build-action@v2
+          name: openblack-android-armeabi-v7a-vcpkg-${{github.sha}}
+          path: android/app/src/main/jniLibs/armeabi-v7a
+      - uses: actions/download-artifact@v3
+        name: Download pre-compiled android-arm64-v8a-vcpkg
         with:
-          arguments: --configuration-cache configureCMakeRelWithDebInfo
-          build-root-directory: android
+          name: openblack-android-arm64-v8a-vcpkg-${{github.sha}}
+          path: android/app/src/main/jniLibs/arm64-v8a
+      - uses: actions/download-artifact@v3
+        name: Download pre-compiled android-x86-vcpkg
+        with:
+          name: openblack-android-x86-vcpkg-${{github.sha}}
+          path: android/app/src/main/jniLibs/x86
+      - uses: actions/download-artifact@v3
+        name: Download pre-compiled android-x86_64-vcpkg
+        with:
+          name: openblack-android-x86_64-vcpkg-${{github.sha}}
+          path: android/app/src/main/jniLibs/x86_64
+      - name: Move downloads around
+        shell: bash
+        run: |
+          mkdir -p android/app/src/main/jniLibs/{debug,release}/{armeabi-v7a,arm64-v8a,x86,x86_64}
+          mv android/app/src/main/jniLibs/armeabi-v7a/Debug/libopenblack_lib.so    android/app/src/main/jniLibs/debug/armeabi-v7a
+          mv android/app/src/main/jniLibs/armeabi-v7a/Release/libopenblack_lib.so  android/app/src/main/jniLibs/release/armeabi-v7a
+          mv android/app/src/main/jniLibs/arm64-v8a/Debug/libopenblack_lib.so      android/app/src/main/jniLibs/debug/arm64-v8a
+          mv android/app/src/main/jniLibs/arm64-v8a/Release/libopenblack_lib.so    android/app/src/main/jniLibs/release/arm64-v8a
+          mv android/app/src/main/jniLibs/x86/Debug/libopenblack_lib.so            android/app/src/main/jniLibs/debug/x86
+          mv android/app/src/main/jniLibs/x86/Release/libopenblack_lib.so          android/app/src/main/jniLibs/release/x86
+          mv android/app/src/main/jniLibs/x86_64/Debug/libopenblack_lib.so         android/app/src/main/jniLibs/debug/x86_64
+          mv android/app/src/main/jniLibs/x86_64/Release/libopenblack_lib.so       android/app/src/main/jniLibs/release/x86_64
+          find android/app/src/main/jniLibs 
       - name: Run Gradle Assemble (Debug)
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: assembleDebug
+          arguments: assembleDebug -PusePrebuiltNativeLibs
           build-root-directory: android
       - name: Run Gradle Assemble (Release)
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: assembleRelease
+          arguments: assembleRelease -PusePrebuiltNativeLibs
           build-root-directory: android
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci-cross-compile.yml
+++ b/.github/workflows/ci-cross-compile.yml
@@ -136,11 +136,12 @@ jobs:
         with:
           arguments: assembleDebug -PusePrebuiltNativeLibs
           build-root-directory: android
-      - name: Run Gradle Assemble (Release)
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: assembleRelease -PusePrebuiltNativeLibs
-          build-root-directory: android
+      # TODO(#632): Setup digital signing for Android release build
+      # - name: Run Gradle Assemble (Release)
+      #   uses: gradle/gradle-build-action@v2
+      #   with:
+      #     arguments: assembleRelease -PusePrebuiltNativeLibs
+      #     build-root-directory: android
       - uses: actions/upload-artifact@v3
         with:
           name: openblack-android-apk-${{github.sha}}

--- a/.github/workflows/ci-cross-compile.yml
+++ b/.github/workflows/ci-cross-compile.yml
@@ -83,3 +83,50 @@ jobs:
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}
       EMSDK: '/tmp/emsdk'
       ANDROID_NDK_HOME: '/usr/local/lib/android/sdk/ndk/23.2.8568313'
+
+  assemble-android-apk:
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # This is the matrix. They form permutations.
+        os: [ ubuntu-latest, windows-latest ]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install Linux dependencies
+        run: |
+          sudo apt update -y
+          sudo apt install -y libgl1-mesa-dev libglu1-mesa-dev
+        if: startsWith(matrix.os, 'ubuntu')
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - name: Run Gradle Configure CMake (Debug)
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: configureCMakeDebug
+          build-root-directory: android
+      - name: Run Gradle Configure CMake (Release)
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: configureCMakeRelWithDebInfo
+          build-root-directory: android
+      - name: Run Gradle Assemble (Debug)
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: assembleDebug
+          build-root-directory: android
+      - name: Run Gradle Assemble (Release)
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: assembleRelease
+          build-root-directory: android
+      - uses: actions/upload-artifact@v3
+        with:
+          name: openblack-android-apk-${{github.sha}}
+          path: android/app/build/outputs/apk
+          if-no-files-found: error

--- a/.github/workflows/ci-cross-compile.yml
+++ b/.github/workflows/ci-cross-compile.yml
@@ -108,12 +108,12 @@ jobs:
       - name: Run Gradle Configure CMake (Debug)
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: configureCMakeDebug
+          arguments: --configuration-cache configureCMakeDebug
           build-root-directory: android
       - name: Run Gradle Configure CMake (Release)
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: configureCMakeRelWithDebInfo
+          arguments: --configuration-cache configureCMakeRelWithDebInfo
           build-root-directory: android
       - name: Run Gradle Assemble (Debug)
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -182,3 +182,17 @@ jobs:
       - uses: reviewdog/action-suggester@v1
         with:
           tool_name: license_checker
+
+  gradle-lint:
+    name: gradle lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - uses: gradle/gradle-build-action@v2
+        with:
+          arguments: lint
+          build-root-directory: android

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -67,4 +67,5 @@ android {
 }
 
 dependencies {
+    implementation 'androidx.documentfile:documentfile:1.0.1'
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -9,20 +9,36 @@ android {
         applicationId "org.openblack.app"
         minSdk 21
         targetSdk 32
-        ndkVersion "23.1.7779620"
+        ndkVersion "23.2.8568313"
         versionCode 1
         versionName "0.1.0"
         archivesBaseName = "$applicationId-$versionName"
 
-        externalNativeBuild {
-            cmake {
-                cppFlags "-std=c++20"
-                targets "openblack_lib"
-                arguments '-DCMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake',
-                          '-DANDROID_NDK_HOME='+android.ndkDirectory,
-                          '-DVCPKG_TARGET_ANDROID=ON',
-                          '-DVCPKG_CHAINLOAD_TOOLCHAIN_FILE='+android.ndkDirectory+'/build/cmake/android.toolchain.cmake',
-                          '-DANDROID_PLATFORM=android-'+minSdk
+        // To use this configuration, pre-built native libraries must be placed into the respective directories:
+        // For debug build variant, place libraries in 'src/main/jniLibs/Debug' and call ./gradlew assembleDebug -PusePrebuiltNativeLibs
+        // For release build variant, place libraries in 'src/main/jniLibs/Release' and call ./gradlew assembleRelease -PusePrebuiltNativeLibs
+        // In android studio, add -PusePrebuiltNativeLibs to the "Command-line Options" in "Build, Execution, Deployment" / "Compiler".
+        if (project.hasProperty("usePrebuiltNativeLibs")) {
+            sourceSets {
+                debug {
+                    jniLibs.srcDirs = ['src/main/jniLibs/debug']
+                }
+                release {
+                    jniLibs.srcDirs = ['src/main/jniLibs/release']
+                }
+            }
+        }
+        else {
+            externalNativeBuild {
+                cmake {
+                    cppFlags "-std=c++20"
+                    targets "openblack_lib"
+                    arguments '-DCMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake',
+                              '-DANDROID_NDK_HOME='+android.ndkDirectory,
+                              '-DVCPKG_TARGET_ANDROID=ON',
+                              '-DVCPKG_CHAINLOAD_TOOLCHAIN_FILE='+android.ndkDirectory+'/build/cmake/android.toolchain.cmake',
+                              '-DANDROID_PLATFORM=android-'+minSdk
+                }
             }
         }
     }
@@ -37,10 +53,12 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    externalNativeBuild {
-        cmake {
-            path file('../../CMakeLists.txt')
-            version '3.18.1'
+    if (!project.hasProperty("usePrebuiltNativeLibs")) {
+        externalNativeBuild {
+            cmake {
+                path file('../../CMakeLists.txt')
+                version '3.18.1'
+            }
         }
     }
     buildFeatures {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.libsdl.app">
+    package="org.openblack.app">
 
     <!-- OpenGL ES 3.0 -->
     <uses-feature android:glEsVersion="0x00030000" android:required="true" />

--- a/android/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -84,7 +84,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
 
 
         int s2 = s_copy & ~InputDevice.SOURCE_ANY; // keep class bits
-        s2 &= ~(  InputDevice.SOURCE_CLASS_BUTTON 
+        s2 &= ~(  InputDevice.SOURCE_CLASS_BUTTON
                 | InputDevice.SOURCE_CLASS_JOYSTICK
                 | InputDevice.SOURCE_CLASS_POINTER
                 | InputDevice.SOURCE_CLASS_POSITION
@@ -878,6 +878,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     }
 
     // C functions we call
+    public static native String nativeGetVersion();
     public static native int nativeSetupJNI();
     public static native int nativeRunMain(String library, String function, Object arguments);
     public static native void nativeLowMemory();

--- a/android/app/src/main/java/org/openblack/app/FileSystemInterop.java
+++ b/android/app/src/main/java/org/openblack/app/FileSystemInterop.java
@@ -1,0 +1,70 @@
+package org.openblack.app;
+
+import android.content.Context;
+import android.net.Uri;
+import android.util.Log;
+
+import androidx.documentfile.provider.DocumentFile;
+
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+
+public class FileSystemInterop {
+
+    private static Uri getDirectoryFromPath(Context context, String storageUriString, String path) {
+        Uri uri = Uri.parse(storageUriString);
+        DocumentFile directory = DocumentFile.fromTreeUri(context, uri);
+        if (directory != null) {
+            for (String part : path.split("/")) {
+                // Ignore "." paths
+                if (part.equals(".")) continue;
+
+                directory = directory.findFile(part);
+                if (directory == null || !directory.exists()) {
+                    Log.e("FileReader", "Directory not found: " + part);
+                    return null;
+                }
+            }
+            return directory.getUri();
+        } else {
+            Log.e("FileReader", "Directory not found: " + storageUriString);
+        }
+        return null;
+    }
+
+    public static String[] listFilesFromPath(Context context, String storageUriString, String path) {
+        Uri uri = getDirectoryFromPath(context, storageUriString, path);
+        DocumentFile directory = DocumentFile.fromTreeUri(context, uri);
+        DocumentFile[] files = directory.listFiles();
+        String[] fileNames = new String[files.length];
+
+        for (int i = 0; i < files.length; i++) {
+            fileNames[i] = files[i].getName();
+        }
+
+        return fileNames;
+    }
+
+    public static byte[] readFileFromPath(Context context, String storageUriString, String path) {
+        Uri uri = getDirectoryFromPath(context, storageUriString, path);
+        if (uri != null) {
+            try {
+                InputStream inputStream = context.getContentResolver().openInputStream(uri);
+                if (inputStream != null) {
+                    byte[] bytes = new byte[inputStream.available()];
+                    inputStream.read(bytes);
+                    inputStream.close();
+                    return bytes;
+                } else {
+                    Log.e("FileReader", "Input stream is null");
+                }
+            } catch (Exception e) {
+                Log.e("FileReader", "Error reading file", e);
+            }
+        } else {
+            Log.e("FileReader", "File not found: " + storageUriString);
+        }
+        return new byte[0];
+    }
+}

--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -21,10 +21,11 @@
 
 #include "Common/stb_image_write.h"
 #include "Dynamics/LandBlockBulletMeshInterface.h"
-#include "FileSystem/Stream.h"
+#include "FileSystem/FileSystemInterface.h"
 #include "Graphics/FrameBuffer.h"
 #include "Graphics/Mesh.h"
 #include "Graphics/Texture2D.h"
+#include "Locator.h"
 
 using namespace openblack;
 using namespace openblack::graphics;
@@ -47,7 +48,12 @@ void LandIsland::LoadFromFile(const std::filesystem::path& path)
 
 	try
 	{
+#if __ANDROID__
+		//  Android has a complicated permissions API, must call java code to read contents.
+		lnd.Open(Locator::filesystem::value().ReadAll(path));
+#else
 		lnd.Open(path);
+#endif
 	}
 	catch (std::runtime_error& err)
 	{

--- a/src/3D/Sky.cpp
+++ b/src/3D/Sky.cpp
@@ -33,7 +33,13 @@ Sky::Sky()
 
 	// load in the mesh
 	_model = std::make_unique<L3DMesh>("Sky");
+#if __ANDROID__
+	//  Android has a complicated permissions API, must call java code to read contents.
+	_model->LoadFromBuffer(
+	    Locator::filesystem::value().ReadAll(fileSystem.GetPath<filesystem::Path::WeatherSystem>() / "sky.l3d"));
+#else
 	_model->LoadFromFile(fileSystem.GetPath<filesystem::Path::WeatherSystem>() / "sky.l3d");
+#endif
 
 	for (uint32_t idx = 0; const auto& alignment : k_Alignments)
 	{

--- a/src/FileSystem/AndroidFileSystem.cpp
+++ b/src/FileSystem/AndroidFileSystem.cpp
@@ -1,0 +1,122 @@
+/******************************************************************************
+ * Copyright (c) 2018-2023 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *******************************************************************************/
+
+#if __ANDROID__
+
+#include "AndroidFileSystem.h"
+
+#include <cctype>
+#include <cstddef>
+
+#include <SDL2/SDL.h>
+
+#include "MemoryStream.h"
+
+using namespace openblack::filesystem;
+
+AndroidFileSystem::AndroidFileSystem()
+    : _jniEnv(static_cast<JNIEnv*>(SDL_AndroidGetJNIEnv()))
+    , _jniActivity(static_cast<jobject>(SDL_AndroidGetActivity()))
+    , _jniInteropClass(_jniEnv->FindClass("org/openblack/app/FileSystemInterop"))
+{
+	// You need to create a global reference to use it outside the method where it was created
+	_jniInteropClass = _jniEnv->FindClass("org/openblack/app/FileSystemInterop");
+	_jniReadFileFromPathMid = _jniEnv->GetStaticMethodID(_jniInteropClass, "readFileFromPath",
+	                                                     "(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;)[B");
+	_jniListFilesFromPathMid =
+	    _jniEnv->GetStaticMethodID(_jniInteropClass, "listFilesFromPath",
+	                               "(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;)[Ljava/lang/String;");
+}
+
+AndroidFileSystem::~AndroidFileSystem()
+{
+	// Remember to clean up the global reference when you're done
+	_jniEnv->DeleteGlobalRef(_jniInteropClass);
+}
+
+std::filesystem::path AndroidFileSystem::FindPath(const std::filesystem::path& path) const
+{
+	if (path.empty())
+	{
+		throw std::invalid_argument("empty path");
+	}
+
+	return path;
+}
+
+std::unique_ptr<Stream> AndroidFileSystem::Open(const std::filesystem::path& path, Stream::Mode mode)
+{
+	jstring jpath = _jniEnv->NewStringUTF(path.c_str());
+	jstring jgamePath = _jniEnv->NewStringUTF(_gamePath.c_str());
+
+	// You need to create a global reference to use it outside the method where it was created
+	jbyteArray jbytes =
+	    (jbyteArray)_jniEnv->CallStaticObjectMethod(_jniInteropClass, _jniReadFileFromPathMid, _jniActivity, jgamePath, jpath);
+
+	jsize length = _jniEnv->GetArrayLength(jbytes);
+	jbyte* jbytesPtr = _jniEnv->GetByteArrayElements(jbytes, nullptr);
+
+	std::vector<uint8_t> bytes(jbytesPtr, jbytesPtr + length);
+
+	_jniEnv->ReleaseByteArrayElements(jbytes, jbytesPtr, 0);
+	return std::unique_ptr<Stream>(new MemoryStream(std::move(bytes)));
+}
+
+bool AndroidFileSystem::Exists(const std::filesystem::path& path) const
+{
+	try
+	{
+		[[maybe_unused]] auto realPath = FindPath(path);
+		return true;
+	}
+	catch (std::exception&)
+	{
+		return false;
+	}
+}
+
+std::vector<uint8_t> AndroidFileSystem::ReadAll(const std::filesystem::path& path)
+{
+	auto file = Open(path, Stream::Mode::Read);
+	std::size_t size = file->Size();
+
+	std::vector<uint8_t> data(size);
+	file->Read(data.data(), size);
+
+	return data;
+}
+
+void AndroidFileSystem::Iterate(const std::filesystem::path& path,
+                                const std::function<void(const std::filesystem::path&)>& function) const
+{
+	// Converting C++ string to Java string
+	jstring jgamePath = _jniEnv->NewStringUTF(_gamePath.c_str());
+	jstring jpath = _jniEnv->NewStringUTF(path.c_str());
+
+	// Calling Java method
+	jobjectArray jfilePaths = (jobjectArray)_jniEnv->CallStaticObjectMethod(_jniInteropClass, _jniListFilesFromPathMid,
+	                                                                        _jniActivity, jgamePath, jpath);
+
+	// Processing returned string array
+	int stringCount = _jniEnv->GetArrayLength(jfilePaths);
+
+	for (int i = 0; i < stringCount; i++)
+	{
+		jstring filePath = (jstring)(_jniEnv->GetObjectArrayElement(jfilePaths, i));
+		const char* rawString = _jniEnv->GetStringUTFChars(filePath, nullptr);
+
+		// Calling provided function
+		function(path / rawString);
+
+		// Don't forget to release the string
+		_jniEnv->ReleaseStringUTFChars(filePath, rawString);
+	}
+}
+
+#endif

--- a/src/FileSystem/AndroidFileSystem.h
+++ b/src/FileSystem/AndroidFileSystem.h
@@ -1,0 +1,52 @@
+/******************************************************************************
+ * Copyright (c) 2018-2023 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *******************************************************************************/
+
+#pragma once
+
+#if __ANDROID__
+
+#include <vector>
+
+#include <jni.h>
+
+#include "FileSystemInterface.h"
+
+namespace openblack::filesystem
+{
+
+class AndroidFileSystem: public FileSystemInterface
+{
+public:
+	AndroidFileSystem();
+	~AndroidFileSystem();
+
+	[[nodiscard]] std::filesystem::path FindPath(const std::filesystem::path& path) const override;
+	std::unique_ptr<Stream> Open(const std::filesystem::path& path, Stream::Mode mode) override;
+	bool Exists(const std::filesystem::path& path) const override;
+	void SetGamePath(const std::filesystem::path& path) override { _gamePath = path; }
+	[[nodiscard]] const std::filesystem::path& GetGamePath() const override { return _gamePath; }
+	void AddAdditionalPath(const std::filesystem::path& path) override { _additionalPaths.push_back(path); }
+	std::vector<uint8_t> ReadAll(const std::filesystem::path& path) override;
+	void Iterate(const std::filesystem::path& path,
+	             const std::function<void(const std::filesystem::path&)>& function) const override;
+
+private:
+	JNIEnv* _jniEnv;
+	jobject _jniActivity;
+	jclass _jniInteropClass;
+	jmethodID _jniReadFileFromPathMid;
+	jmethodID _jniListFilesFromPathMid;
+
+	std::filesystem::path _gamePath;
+	std::vector<std::filesystem::path> _additionalPaths;
+};
+
+} // namespace openblack::filesystem
+
+#endif

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -504,7 +504,12 @@ bool Game::Initialize()
 		    }
 	    });
 	pack::PackFile pack;
+#if __ANDROID__
+	//  Android has a complicated permissions API, must call java code to read contents.
+	pack.Open(fileSystem.ReadAll(fileSystem.GetPath<filesystem::Path::Data>(true) / "AllMeshes.g3d"));
+#else
 	pack.Open(fileSystem.GetPath<filesystem::Path::Data>(true) / "AllMeshes.g3d");
+#endif
 	const auto& meshes = pack.GetMeshes();
 	for (size_t i = 0; const auto& mesh : meshes)
 	{
@@ -520,7 +525,12 @@ bool Game::Initialize()
 	}
 
 	pack::PackFile animationPack;
+#if __ANDROID__
+	//  Android has a complicated permissions API, must call java code to read contents.
+	animationPack.Open(fileSystem.ReadAll(fileSystem.GetPath<filesystem::Path::Data>(true) / "AllAnims.anm"));
+#else
 	animationPack.Open(fileSystem.GetPath<filesystem::Path::Data>(true) / "AllAnims.anm");
+#endif
 	const auto& animations = animationPack.GetAnimations();
 	for (size_t i = 0; i < animations.size(); i++)
 	{
@@ -662,7 +672,12 @@ bool Game::Run()
 	if (fileSystem.Exists(challengePath))
 	{
 		_lhvm = std::make_unique<LHVM::LHVM>();
-		_lhvm->Open(fileSystem.GetGamePath() / challengePath);
+#if __ANDROID__
+		//  Android has a complicated permissions API, must call java code to read contents.
+		_lhvm->Open(fileSystem.ReadAll(fileSystem.FindPath(challengePath)));
+#else
+		_lhvm->Open(fileSystem.FindPath(challengePath));
+#endif
 	}
 	else
 	{

--- a/src/Locator.cpp
+++ b/src/Locator.cpp
@@ -20,23 +20,31 @@
 #include "ECS/Systems/Implementations/PathfindingSystem.h"
 #include "ECS/Systems/Implementations/RenderingSystem.h"
 #include "ECS/Systems/Implementations/TownSystem.h"
+#if __ANDROID__
+#include "FileSystem/AndroidFileSystem.h"
+#else
 #include "FileSystem/DefaultFileSystem.h"
+#endif
 #include "Resources/Resources.h"
 
+using namespace openblack::filesystem;
 using openblack::ecs::systems::CameraBookmarkSystem;
 using openblack::ecs::systems::DynamicsSystem;
 using openblack::ecs::systems::LivingActionSystem;
 using openblack::ecs::systems::PathfindingSystem;
 using openblack::ecs::systems::RenderingSystem;
 using openblack::ecs::systems::TownSystem;
-using openblack::filesystem::DefaultFileSystem;
 using openblack::resources::Resources;
 
 namespace openblack::ecs::systems
 {
 void InitializeGame()
 {
-	Locator::filesystem::emplace<DefaultFileSystem>();
+#if __ANDROID__
+	Locator::filesystem::emplace<filesystem::AndroidFileSystem>();
+#else
+	Locator::filesystem::emplace<filesystem::DefaultFileSystem>();
+#endif
 	Locator::terrainSystem::emplace<UnloadedIsland>();
 	Locator::resources::emplace<Resources>();
 	Locator::rng::emplace<RandomNumberManagerProduction>();

--- a/src/Parsers/InfoFile.cpp
+++ b/src/Parsers/InfoFile.cpp
@@ -26,7 +26,13 @@ bool InfoFile::LoadFromFile(const std::filesystem::path& path, InfoConstants& in
 	try
 	{
 		pack::PackFile pack;
+#if __ANDROID__
+		//  Android has a complicated permissions API, must call java code to read contents.
+		auto bytes = Locator::filesystem::value().ReadAll(Locator::filesystem::value().FindPath(path));
+		pack.Open(bytes);
+#else
 		pack.Open(Locator::filesystem::value().FindPath(path));
+#endif
 		data = pack.GetBlock("Info");
 		if (data.size() != sizeof(InfoConstants))
 		{

--- a/src/Resources/Loaders.cpp
+++ b/src/Resources/Loaders.cpp
@@ -40,10 +40,14 @@ L3DLoader::result_type L3DLoader::operator()(FromDiskTag, const std::filesystem:
 
 	if (pathExt == ".l3d")
 	{
+#if __ANDROID__
+		mesh->LoadFromBuffer(Locator::filesystem::value().ReadAll(path));
+#else
 		if (!mesh->LoadFromFile(path))
 		{
 			throw std::runtime_error("Unable to load mesh");
 		}
+#endif
 	}
 	else if (pathExt == ".zzz")
 	{
@@ -149,10 +153,14 @@ L3DAnimLoader::result_type L3DAnimLoader::operator()(FromBufferTag, const std::v
 L3DAnimLoader::result_type L3DAnimLoader::operator()(FromDiskTag, const std::filesystem::path& path) const
 {
 	auto animation = std::make_shared<L3DAnim>();
+#if __ANDROID__
+	animation->LoadFromBuffer(Locator::filesystem::value().ReadAll(path));
+#else
 	if (!animation->LoadFromFile(path))
 	{
 		throw std::runtime_error("Unable to load animation");
 	}
+#endif
 
 	return animation;
 }


### PR DESCRIPTION
Fixes and tests building the APK on windows.
Also fixes gradle lint and the apk name
Fixes android failing to find main function

You can now get the openblack apk from the workflow artifacts. E.g. https://github.com/openblack/openblack/suites/6326800004/artifacts/227483860

Implements #402

TODOs:
- [x] Merge #610 
- [x] Fix assemble not packaging .so files
- [x] Expand this to windows
- [x] With the new way we do vcpkg caching, a straight compile to apk might be good enough
- [x] `JNI DETECTED ERROR IN APPLICATION: JNI FindClass called with pending exception java.lang.NoSuchMethodError: no static or non-static method "Lorg/libsdl/app/SDLActivity;.nativeGetVersion()Ljava/lang/String;"`
- [x] Comment out the Release build and add issue to add digital signing for 0.1.0 milestone.
- [x] Reading files in Android is restricted through the java URI interface, need to add specific android (might have to be expanded to emscripten or iso mode) 
    - [x]  lhvm is not using Filesystem interface