### PR TITLE
l3d: Fix flags of submesh

### DIFF
--- a/apps/l3dtool/l3dtool.cpp
+++ b/apps/l3dtool/l3dtool.cpp
@@ -229,7 +229,7 @@ int PrintMeshHeaders(openblack::l3d::L3DFile& l3d)
 		{
 			result += "hasBones";
 		}
-		result += "|LOD" + std::to_string(flags.lod);
+		result += "|lodMask=" + std::to_string(flags.lodMask);
 		result += "|status=" + std::to_string(flags.status);
 		if (flags.unknown1 != 0u)
 		{
@@ -643,7 +643,7 @@ int WriteFile(const Arguments::Write& args) noexcept
 		using L3DSubmeshHeader = openblack::l3d::L3DSubmeshHeader;
 		L3DSubmeshHeader submesh;
 		submesh.flags.hasBones = false;
-		submesh.flags.lod = 0;
+		submesh.flags.lodMask = 0;
 		submesh.flags.status = 0;
 		submesh.flags.unknown1 = 0b0101;
 		submesh.flags.isWindow = false;

--- a/components/l3d/include/L3DFile.h
+++ b/components/l3d/include/L3DFile.h
@@ -93,17 +93,17 @@ static_assert(sizeof(L3DHeader) == 19 * sizeof(uint32_t));
 
 struct L3DSubmeshHeader
 {
-	// TODO(bwrsandman): Move to l3d lib
 #pragma pack(push, 1)
 	struct alignas(4) Flags
 	{
 		uint32_t hasBones : 1;
-		uint32_t lod : 2;
-		uint32_t status : 6;
-		uint32_t unknown1 : 3; // always 0b0101
+		uint32_t unknown1 : 3;
+		uint32_t status : 6;   // Used for scafolds and tomb stones in grave yard
+		uint32_t unknown2 : 2; // always 0b10
 		uint32_t isWindow : 1;
 		uint32_t isPhysics : 1;
-		uint32_t unknown2 : 16; // always 0, probably padding on 32 bits
+		uint32_t unknown3 : 15;
+		uint32_t lodMask : 3;
 	};
 #pragma pack(pop)
 	static_assert(sizeof(Flags) == 4);

--- a/src/Debug/MeshViewer.cpp
+++ b/src/Debug/MeshViewer.cpp
@@ -132,8 +132,18 @@ void MeshViewer::Draw([[maybe_unused]] Game& game)
 	auto const& submesh = mesh->GetSubMeshes()[_selectedSubMesh];
 
 	auto flags = submesh->GetFlags();
-	ImGui::Text("SubMesh LOD=%u Status=%u%s%s%s", flags.lod, flags.status, flags.hasBones ? " [Bones]" : "",
-	            flags.isPhysics ? " [Physics]" : "", flags.isWindow ? " [Window]" : "");
+	std::array<char, 0x20> subMeshFlagStr;
+	uint32_t flagsRaw;
+	memcpy(&flagsRaw, &flags, sizeof(flagsRaw));
+	std::snprintf(subMeshFlagStr.data(), subMeshFlagStr.size(), "SubMesh flag=0x%X", flagsRaw);
+	if (ImGui::TreeNodeEx(subMeshFlagStr.data()))
+	{
+		ImGui::Text("%s%s%s\nLOD Mask=0%s%s%s\nStatus=%u\nunknown1=0x%x\nunknown2=0x%x\nunknown2=0x%x",
+		            flags.hasBones ? "[Bones] " : "", flags.isPhysics ? "[Physics] " : "", flags.isWindow ? "[Window] " : "",
+		            (flags.lodMask & 0b001) == 0 ? "" : "|1", (flags.lodMask & 0b010) == 0 ? "" : "|2",
+		            (flags.lodMask & 0b100) == 0 ? "" : "|4", flags.status, flags.unknown1, flags.unknown2, flags.unknown3);
+		ImGui::TreePop();
+	}
 
 	auto const& graphicsMesh = submesh->GetMesh();
 	ImGui::Text("Vertices %u, Indices %u", graphicsMesh.GetVertexBuffer().GetCount(), graphicsMesh.GetIndexBuffer().GetCount());

--- a/src/Debug/MeshViewer.cpp
+++ b/src/Debug/MeshViewer.cpp
@@ -243,6 +243,7 @@ void MeshViewer::Update([[maybe_unused]] Game& game, const Renderer& renderer)
 		desc.state = state;
 		desc.modelMatrices = &identity;
 		desc.matrixCount = 1;
+		desc.drawAll = true;
 		std::vector<glm::mat4> bones; // In this scope to prevent free before draw
 		if (mesh->IsBoned())
 		{

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -249,7 +249,7 @@ void Renderer::DrawSubMesh(const L3DMesh& mesh, const L3DSubMesh& subMesh, const
                            bool preserveState) const
 {
 	assert(&subMesh.GetMesh());
-	if (subMesh.IsPhysics())
+	if (!desc.drawAll && subMesh.IsPhysics())
 	{
 		return;
 	}
@@ -346,10 +346,7 @@ void Renderer::DrawMesh(const L3DMesh& mesh, const L3DMeshSubmitDesc& desc, uint
 	for (auto it = subMeshes.begin(); it != subMeshes.end(); ++it)
 	{
 		const L3DSubMesh& subMesh = **it;
-		if (!subMesh.IsPhysics())
-		{
-			DrawSubMesh(mesh, subMesh, desc, std::next(it) != subMeshes.end());
-		}
+		DrawSubMesh(mesh, subMesh, desc, std::next(it) != subMeshes.end());
 	}
 }
 

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -249,7 +249,8 @@ void Renderer::DrawSubMesh(const L3DMesh& mesh, const L3DSubMesh& subMesh, const
                            bool preserveState) const
 {
 	assert(&subMesh.GetMesh());
-	if (!desc.drawAll && subMesh.IsPhysics())
+	// We don't draw physics meshes, we haven't implemented statuses (building and graves) and modern GPUs can handle high lod
+	if (!desc.drawAll && (subMesh.IsPhysics() || subMesh.GetFlags().status != 0 || (subMesh.GetFlags().lodMask & 1) != 1))
 	{
 		return;
 	}

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -96,6 +96,7 @@ public:
 		uint32_t instanceCount;
 		bool isSky;
 		float skyType;
+		bool drawAll; ///< For use in the mesh viewer
 	};
 
 	Renderer() = delete;


### PR DESCRIPTION
The LOD field was wrong. Firstly, it is at the other end of the dword, second, it is a bitmask for lods 1, 2, 4.
The Status field was offset by one bit and it encodes information about how the object morphs
in the case of building and a graveyard being filled.
Disabled drawing objects that have a status because no status is implemented yet.
Also fixed the meshviewer not showing physics meshes.

TODO:
- [x] Select an LOD for the trees (just go with LOD 1). Closes  #185 

![image](https://user-images.githubusercontent.com/1013356/176938218-0d9ba4e4-a7f9-43a5-b66c-1006960c36f2.png)
