### PR TITLE
l3d: Extract footprint mesh and texture

### DIFF
--- a/assets/shaders/fs_footprint.sc
+++ b/assets/shaders/fs_footprint.sc
@@ -1,0 +1,10 @@
+$input v_texcoord0
+
+#include <bgfx_shader.sh>
+
+SAMPLER2D(s_footprint, 0);
+
+void main()
+{
+	gl_FragColor = texture2D(s_footprint, v_texcoord0.xy);
+}

--- a/assets/shaders/fs_terrain.sc
+++ b/assets/shaders/fs_terrain.sc
@@ -1,4 +1,4 @@
-$input v_texcoord0, v_weight, v_materialID0, v_materialID1, v_materialBlend, v_lightLevel, v_waterAlpha, v_distToCamera
+$input v_texcoord0, v_texcoord1, v_weight, v_materialID0, v_materialID1, v_materialBlend, v_lightLevel, v_waterAlpha, v_distToCamera
 
 #include <bgfx_shader.sh>
 
@@ -7,6 +7,7 @@ $input v_texcoord0, v_weight, v_materialID0, v_materialID1, v_materialBlend, v_l
 SAMPLER2DARRAY(s0_materials, 0);
 SAMPLER2D(s1_bump, 1);
 SAMPLER2D(s2_smallBump, 2);
+SAMPLER2D(s3_footprints, 3);
 
 uniform vec4 u_skyAndBump;
 
@@ -49,12 +50,14 @@ void main()
 		col = col * smallbump;
 	}
 
+	vec4 footprints = texture2D(s3_footprints, v_texcoord1.xy);
+	col.rgb = mix(col.rgb, footprints.rgb, footprints.a);
+
 	// apply light map
 	float skyBightness = skyType / 2.0f;
 	col = col * mix(0.25f, clamp(v_lightLevel * 2.0f, 0.5f, 1.0f), skyBightness);
 
 	gl_FragColor = vec4(col.rgb, v_waterAlpha);
-
 
 	//gl_FragColor.r = v_distToCamera / 200.0f;
 

--- a/assets/shaders/vs_footprint_instanced.sc
+++ b/assets/shaders/vs_footprint_instanced.sc
@@ -14,5 +14,4 @@ void main()
 	vec4 position = instMul(model, mul(u_model[0], vec4(a_position.x, 0.0f, a_position.y, 1.0f)));
 	v_texcoord0 = vec4(a_texcoord0, 0.0f, 0.0f);
 	gl_Position = mul(u_modelViewProj, position);
-
 }

--- a/assets/shaders/vs_footprint_instanced.sc
+++ b/assets/shaders/vs_footprint_instanced.sc
@@ -1,0 +1,18 @@
+$input a_position, a_texcoord0, i_data0, i_data1, i_data2, i_data3, i_data4
+$output v_texcoord0
+
+#include <bgfx_shader.sh>
+
+void main()
+{
+	mat4 model;
+	model[0] = i_data0;
+	model[1] = i_data1;
+	model[2] = i_data2;
+	model[3] = i_data3;
+
+	vec4 position = instMul(model, mul(u_model[0], vec4(a_position.x, 0.0f, a_position.y, 1.0f)));
+	v_texcoord0 = vec4(a_texcoord0, 0.0f, 0.0f);
+	gl_Position = mul(u_modelViewProj, position);
+
+}

--- a/assets/shaders/vs_footprint_instanced.sc
+++ b/assets/shaders/vs_footprint_instanced.sc
@@ -14,4 +14,5 @@ void main()
 	vec4 position = instMul(model, mul(u_model[0], vec4(a_position.x, 0.0f, a_position.y, 1.0f)));
 	v_texcoord0 = vec4(a_texcoord0, 0.0f, 0.0f);
 	gl_Position = mul(u_modelViewProj, position);
+	gl_Position.z = 0.0f;
 }

--- a/assets/shaders/vs_terrain.sc
+++ b/assets/shaders/vs_terrain.sc
@@ -1,5 +1,5 @@
 $input a_position, a_texcoord1, a_color1, a_color2, a_texcoord2, a_color0, a_color3
-$output v_texcoord0, v_weight, v_materialID0, v_materialID1, v_materialBlend, v_lightLevel, v_waterAlpha, v_distToCamera
+$output v_texcoord0, v_texcoord1, v_weight, v_materialID0, v_materialID1, v_materialBlend, v_lightLevel, v_waterAlpha, v_distToCamera
 
 #include <bgfx_shader.sh>
 
@@ -9,11 +9,23 @@ $output v_texcoord0, v_weight, v_materialID0, v_materialID1, v_materialBlend, v_
 #   define materialIdFix(x) (ivec3(x))
 #endif
 
-uniform vec4 u_blockPosition;
+uniform vec4 u_blockPositionAndSize;
+uniform vec4 u_islandExtent;
 
 void main()
 {
-	v_texcoord0 = vec4(a_position.z / 160.0f, a_position.x / 160.0f, 0.0f, 0.0f);
+	// Unpack
+	vec2 blockPosition = u_blockPositionAndSize.xy;
+	vec2 blockSize = u_blockPositionAndSize.zw;
+	vec2 extentMin = u_islandExtent.xy;
+	vec2 extentMax = u_islandExtent.zw;
+
+	v_texcoord0 = vec4(a_position.zx / blockSize.yx, 0.0f, 0.0f);
+	vec2 blockStartUv = (blockPosition + a_position.xz - extentMin) / (extentMax - extentMin);
+	#if !BGFX_SHADER_LANGUAGE_GLSL
+		blockStartUv.y = 1.0f - blockStartUv.y;
+	#endif
+	v_texcoord1 = vec4(blockStartUv, 0.0f, 0.0f);
 	v_weight = a_texcoord1;
 	v_materialID0 = materialIdFix(a_color1);
 	v_materialID1 = materialIdFix(a_color2);
@@ -21,7 +33,7 @@ void main()
 	v_lightLevel = a_color0.x;
 	v_waterAlpha = a_color3;
 
-	vec3 transformedPosition = vec3(a_position.x + u_blockPosition.x, a_position.y, a_position.z + u_blockPosition.y);
+	vec3 transformedPosition = vec3(a_position.x + blockPosition.x, a_position.y, a_position.z + blockPosition.y);
 
 	vec4 cs_position = mul(u_view, vec4(transformedPosition, 1.0f));
 	v_distToCamera = cs_position.z;

--- a/components/l3d/include/L3DFile.h
+++ b/components/l3d/include/L3DFile.h
@@ -11,6 +11,7 @@
 
 #include <array>
 #include <filesystem>
+#include <optional>
 #include <span>
 #include <string>
 #include <vector>
@@ -20,6 +21,7 @@ namespace openblack::l3d
 
 enum class L3DMeshFlags : uint32_t
 {
+	None,
 	Unknown1 = 1U << 0U,                  // 0x1      (31)
 	Unknown2 = 1U << 1U,                  // 0x2      (30)
 	Unknown3 = 1U << 2U,                  // 0x4      (29)
@@ -144,6 +146,48 @@ struct L3DBone
 };
 static_assert(sizeof(L3DBone) == 3 * sizeof(uint32_t) + 9 * sizeof(float) + sizeof(L3DPoint));
 
+struct L3DFootprintTriangle
+{
+	std::array<L3DPoint2D, 3> world;
+	std::array<L3DPoint2D, 3> texture;
+};
+
+struct L3DFootprintHeader
+{
+	uint32_t count;
+	uint32_t offset;
+	uint32_t size;
+	uint32_t width;
+	uint32_t height;
+	uint32_t unknown;
+};
+
+struct L3DFootprintEntry
+{
+	uint32_t unknown1;
+	uint32_t unknown2;
+	uint32_t triangleCount;
+	std::vector<L3DFootprintTriangle> triangles;
+	std::vector<uint16_t> pixels; //< ARGB
+	uint32_t unknown3;
+	uint32_t unknown4;
+	uint32_t unknown5;
+};
+
+struct L3DFootprintFooter
+{
+	uint32_t unknown1;
+	float unknown2;
+	uint32_t unknown3;
+};
+
+struct L3DFootprint
+{
+	L3DFootprintHeader header;
+	std::vector<L3DFootprintEntry> entries;
+	L3DFootprintFooter footer;
+};
+
 struct L3DMaterial
 {
 	enum class Type : uint32_t
@@ -252,7 +296,7 @@ protected:
 	std::vector<std::span<uint16_t>> _indexSpans;
 	std::vector<std::span<L3DVertexGroup>> _vertexGroupSpans;
 	std::vector<std::span<L3DBone>> _boneSpans;
-	std::vector<uint8_t> _footprintData;
+	std::optional<L3DFootprint> _footprint;
 	std::vector<uint8_t> _uv2Data;
 	std::string _nameData;
 
@@ -289,9 +333,9 @@ public:
 	[[nodiscard]] const std::vector<L3DVertexGroup>& GetLookUpTableData() const { return _vertexGroups; }
 	[[nodiscard]] const std::vector<L3DBlend>& GetBlends() const { return _blends; }
 	[[nodiscard]] const std::vector<L3DBone>& GetBones() const { return _bones; }
-	[[nodiscard]] const std::vector<uint8_t>& GetFootprintData() const { return _footprintData; }
+	[[nodiscard]] const std::optional<L3DFootprint>& GetFootprint() const { return _footprint; }
 	[[nodiscard]] const std::vector<uint8_t>& GetUv2Data() const { return _uv2Data; }
-	void SetFootprintData(std::vector<uint8_t>& footprintData) { _footprintData = footprintData; }
+	void SetFootprint(const L3DFootprint& footprint) { _footprint = footprint; }
 	void SetUv2Data(std::vector<uint8_t>& uv2Data) { _uv2Data = uv2Data; }
 	void SetNameData(std::string& nameData) { _nameData = nameData; }
 	[[nodiscard]] const std::string& GetNameData() const { return _nameData; }

--- a/src/3D/L3DMesh.h
+++ b/src/3D/L3DMesh.h
@@ -77,6 +77,11 @@ inline l3d::L3DMeshFlags operator&(l3d::L3DMeshFlags a, l3d::L3DMeshFlags b)
 class L3DMesh
 {
 public:
+	struct Footprint
+	{
+		std::unique_ptr<graphics::Texture2D> texture;
+		std::unique_ptr<graphics::Mesh> mesh;
+	};
 	explicit L3DMesh(std::string debugName = "");
 	virtual ~L3DMesh();
 
@@ -87,6 +92,7 @@ public:
 	[[nodiscard]] uint8_t GetNumSubMeshes() const { return static_cast<uint8_t>(_subMeshes.size()); }
 	[[nodiscard]] const std::vector<std::unique_ptr<L3DSubMesh>>& GetSubMeshes() const { return _subMeshes; }
 	[[nodiscard]] const std::unordered_map<SkinId, std::unique_ptr<graphics::Texture2D>>& GetSkins() const { return _skins; }
+	[[nodiscard]] const std::vector<Footprint>& GetFootprints() const { return _footprints; }
 	[[nodiscard]] const std::vector<uint32_t>& GetBoneParents() const { return _bonesParents; }
 	[[nodiscard]] const std::vector<glm::mat4>& GetBoneMatrices() const { return _bonesDefaultMatrices; }
 	[[nodiscard]] const std::optional<glm::vec3>& GetDoorPos() const { return _doorPos; }
@@ -101,6 +107,7 @@ private:
 	std::string _debugName;
 
 	std::unordered_map<SkinId, std::unique_ptr<graphics::Texture2D>> _skins;
+	std::vector<Footprint> _footprints; ///< If ContainsLandscapeFeature() is true
 	std::vector<std::unique_ptr<L3DSubMesh>> _subMeshes;
 	std::vector<uint32_t> _bonesParents;
 	std::vector<glm::mat4> _bonesDefaultMatrices;
@@ -121,9 +128,10 @@ public:
 	[[nodiscard]] uint32_t GetFlags() const { return static_cast<uint32_t>(_flags); }
 
 	[[nodiscard]] bool IsBoned() const { return static_cast<bool>(_flags & l3d::L3DMeshFlags::HasBones); }
+	[[nodiscard]] bool HasDoorPosition() const { return static_cast<bool>(_flags & l3d::L3DMeshFlags::HasDoorPosition); }
 	[[nodiscard]] bool IsPacked() const { return static_cast<bool>(_flags & l3d::L3DMeshFlags::Packed); }
 	[[nodiscard]] bool IsNoDraw() const { return static_cast<bool>(_flags & l3d::L3DMeshFlags::NoDraw); }
-	[[nodiscard]] bool IsContainsLandscapeFeature() const
+	[[nodiscard]] bool ContainsLandscapeFeature() const
 	{
 		return static_cast<bool>(_flags & l3d::L3DMeshFlags::ContainsLandscapeFeature);
 	}

--- a/src/3D/LandBlock.cpp
+++ b/src/3D/LandBlock.cpp
@@ -200,8 +200,8 @@ glm::ivec2 LandBlock::GetBlockPosition() const
 	return {_block ? _block->blockX : -1, _block ? _block->blockZ : -1};
 }
 
-glm::vec4 LandBlock::GetMapPosition() const
+glm::vec2 LandBlock::GetMapPosition() const
 {
 	assert(_block);
-	return {_block->mapX, _block->mapZ, 0, 0};
+	return {_block->mapX, _block->mapZ};
 }

--- a/src/3D/LandBlock.cpp
+++ b/src/3D/LandBlock.cpp
@@ -11,11 +11,8 @@
 
 #include <cassert>
 
-#include <utility>
-
 #include <BulletDynamics/Dynamics/btRigidBody.h>
 #include <LNDFile.h>
-#include <glm/gtc/type_ptr.hpp>
 
 #include "Dynamics/LandBlockBulletMeshInterface.h"
 #include "Graphics/VertexBuffer.h"
@@ -189,29 +186,6 @@ const bgfx::Memory* LandBlock::BuildVertexList(LandIsland& island)
 	}
 
 	return verticesMem;
-}
-
-void LandBlock::Draw(graphics::RenderPass viewId, const ShaderProgram& program, bool cullBack) const
-{
-	glm::vec4 mapPosition = glm::vec4(_block->mapX, _block->mapZ, 0, 0);
-	program.SetUniformValue("u_blockPosition", &mapPosition);
-
-	constexpr auto defaultState = BGFX_STATE_WRITE_MASK | BGFX_STATE_DEPTH_TEST_LESS | BGFX_STATE_BLEND_ALPHA | BGFX_STATE_MSAA;
-
-	Mesh::DrawDesc desc = {
-	    /*viewId =*/viewId,
-	    /*program =*/program,
-	    /*count =*/_mesh->GetVertexBuffer().GetCount(),
-	    /*offset =*/0,
-	    /*instanceBuffer =*/nullptr,
-	    /*instanceStart =*/0,
-	    /*instanceCount =*/1,
-	    /*state =*/defaultState | (cullBack ? BGFX_STATE_CULL_CCW : BGFX_STATE_CULL_CW),
-	    /*rgba =*/0,
-	    /*skip =*/Mesh::SkipState::SkipNone,
-	    /*preserveState =*/false,
-	};
-	_mesh->Draw(desc);
 }
 
 const lnd::LNDCell* LandBlock::GetCells() const

--- a/src/3D/LandBlock.h
+++ b/src/3D/LandBlock.h
@@ -62,7 +62,7 @@ public:
 	[[nodiscard]] const graphics::Mesh& GetMesh() const { return *_mesh; }
 	[[nodiscard]] const lnd::LNDCell* GetCells() const;
 	[[nodiscard]] glm::ivec2 GetBlockPosition() const;
-	[[nodiscard]] glm::vec4 GetMapPosition() const;
+	[[nodiscard]] glm::vec2 GetMapPosition() const;
 	[[nodiscard]] std::unique_ptr<btRigidBody>& GetRigidBody() { return _rigidBody; };
 
 private:

--- a/src/3D/LandBlock.h
+++ b/src/3D/LandBlock.h
@@ -57,7 +57,6 @@ class LandBlock
 {
 public:
 	LandBlock() = default;
-	void Draw(graphics::RenderPass viewId, const graphics::ShaderProgram& program, bool cullBack) const;
 	void BuildMesh(LandIsland& island);
 
 	[[nodiscard]] const graphics::Mesh& GetMesh() const { return *_mesh; }

--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -63,36 +63,34 @@ void LandIsland::LoadFromFile(const std::filesystem::path& path)
 	uint32_t minZ = std::numeric_limits<uint32_t>::max();
 	uint32_t maxX = 0;
 	uint32_t maxZ = 0;
-	glm::vec2 mapMin(0.0f, 0.0f);
-	glm::vec2 mapMax(0.0f, 0.0f);
 	for (auto& b : _landBlocks)
 	{
 		if (minX > b._block->blockX)
 		{
 			minX = b._block->blockX;
-			mapMin.x = b.GetMapPosition().x;
+			_extentMin.x = b.GetMapPosition().x;
 		}
 		if (maxX < b._block->blockX)
 		{
 			maxX = b._block->blockX;
-			mapMax.x = b.GetMapPosition().x;
+			_extentMax.x = b.GetMapPosition().x;
 		}
 		if (minZ > b._block->blockZ)
 		{
 			minZ = b._block->blockZ;
-			mapMin.y = b.GetMapPosition().y;
+			_extentMin.y = b.GetMapPosition().y;
 		}
 		if (maxZ < b._block->blockZ)
 		{
 			maxZ = b._block->blockZ;
-			mapMax.y = b.GetMapPosition().y;
+			_extentMax.y = b.GetMapPosition().y;
 		}
 	}
 	const auto res =
 	    glm::u16vec2(maxX - minX, maxZ - minZ) * glm::u16vec2(lnd::LNDMaterial::k_Width, lnd::LNDMaterial::k_Height);
 	_footprintFrameBuffer = std::make_unique<FrameBuffer>("Footprints", res.x, res.y, graphics::Format::RGBA8);
 
-	_proj = glm::ortho(mapMin.x, mapMax.x, mapMin.y, mapMax.y, -400.0f, 400.0f);
+	_proj = glm::ortho(_extentMin.x, _extentMax.x, _extentMin.y, _extentMax.y);
 	_view = glm::rotate(glm::radians(-90.0f), glm::vec3(1.0f, 0.0f, 0.0f));
 
 	SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "[LandIsland] loading {} countries", lnd.GetCountries().size());

--- a/src/3D/LandIsland.h
+++ b/src/3D/LandIsland.h
@@ -76,6 +76,11 @@ public:
 		view = _view;
 		proj = _proj;
 	}
+	void GetExtent(glm::vec2& extentMin, glm::vec2& extentMax) const
+	{
+		extentMin = _extentMin;
+		extentMax = _extentMax;
+	}
 
 	uint8_t GetNoise(int x, int y);
 
@@ -89,6 +94,8 @@ private:
 	std::unique_ptr<graphics::FrameBuffer> _footprintFrameBuffer;
 	glm::mat4 _proj;
 	glm::mat4 _view;
+	glm::vec2 _extentMin;
+	glm::vec2 _extentMax;
 
 	std::array<uint8_t, 256 * 256> _noiseMap;
 };

--- a/src/3D/LandIsland.h
+++ b/src/3D/LandIsland.h
@@ -16,9 +16,8 @@
 #include <vector>
 
 #include <entt/core/hashed_string.hpp>
+#include <glm/mat4x4.hpp>
 
-#include "Graphics/Mesh.h"
-#include "Graphics/Texture2D.h"
 #include "LandBlock.h"
 
 namespace openblack
@@ -27,6 +26,11 @@ namespace openblack
 namespace ecs::systems
 {
 class DynamicsSystem;
+}
+
+namespace graphics
+{
+class FrameBuffer;
 }
 
 namespace lnd
@@ -66,6 +70,12 @@ public:
 	[[nodiscard]] const std::vector<lnd::LNDCountry>& GetCountries() const { return _countries; }
 	[[nodiscard]] const graphics::Texture2D& GetAlbedoArray() const { return *_materialArray; }
 	[[nodiscard]] const graphics::Texture2D& GetBump() const { return *_textureBumpMap; }
+	[[nodiscard]] const graphics::FrameBuffer& GetFootprintFramebuffer() const { return *_footprintFrameBuffer; }
+	void GetOrthoViewProj(glm::mat4& view, glm::mat4& proj) const
+	{
+		view = _view;
+		proj = _proj;
+	}
 
 	uint8_t GetNoise(int x, int y);
 
@@ -75,6 +85,10 @@ private:
 
 	std::unique_ptr<graphics::Texture2D> _textureNoiseMap;
 	std::unique_ptr<graphics::Texture2D> _textureBumpMap;
+
+	std::unique_ptr<graphics::FrameBuffer> _footprintFrameBuffer;
+	glm::mat4 _proj;
+	glm::mat4 _view;
 
 	std::array<uint8_t, 256 * 256> _noiseMap;
 };

--- a/src/Debug/Gui.cpp
+++ b/src/Debug/Gui.cpp
@@ -75,9 +75,6 @@
 using namespace openblack;
 using namespace openblack::debug::gui;
 
-#define IMGUI_FLAGS_NONE UINT8_C(0x00)
-#define IMGUI_FLAGS_ALPHA_BLEND UINT8_C(0x01)
-
 namespace
 {
 const std::array<bgfx::EmbeddedShader, 5> k_EmbeddedShaders = {{

--- a/src/Debug/LandIsland.cpp
+++ b/src/Debug/LandIsland.cpp
@@ -13,11 +13,13 @@
 
 #include "3D/LandIsland.h"
 #include "Game.h"
+#include "Graphics/FrameBuffer.h"
+#include "Gui.h"
 
 using namespace openblack::debug::gui;
 
 LandIsland::LandIsland()
-    : Window("Land Island", ImVec2(250.0f, 165.0f))
+    : Window("Land Island", ImVec2(600.0f, 600.0f))
 {
 }
 
@@ -34,6 +36,20 @@ void LandIsland::Draw(openblack::Game& game)
 
 	ImGui::Text("Block Count: %zu", landIsland.GetBlocks().size());
 	ImGui::Text("Country Count: %zu", landIsland.GetCountries().size());
+
+	ImGui::Separator();
+
+	if (ImGui::TreeNodeEx("Footprints", ImGuiTreeNodeFlags_DefaultOpen))
+	{
+		const auto& frameBuffer = landIsland.GetFootprintFramebuffer();
+		uint16_t width;
+		uint16_t height;
+		frameBuffer.GetSize(width, height);
+		ImGui::Text("Resolution: %ux%u", width, height);
+		float scaling = 512.0f / static_cast<float>(width);
+		ImGui::Image(frameBuffer.GetColorAttachment().GetNativeHandle(), ImVec2(width * scaling, height * scaling));
+		ImGui::TreePop();
+	}
 
 	ImGui::Separator();
 

--- a/src/Debug/MeshViewer.cpp
+++ b/src/Debug/MeshViewer.cpp
@@ -123,6 +123,7 @@ void MeshViewer::Draw([[maybe_unused]] Game& game)
 	ImGui::SliderInt("submesh", &_selectedSubMesh, 0, static_cast<int>(mesh->GetSubMeshes().size()) - 1);
 	ImGui::DragFloat3("position", &_cameraPosition[0], 0.5f);
 	ImGui::Checkbox("View bounding box", &_viewBoundingBox);
+	ImGui::Checkbox("Show matching armature", &_matchBones);
 
 	if (_selectedSubMesh >= mesh->GetNumSubMeshes())
 	{
@@ -150,7 +151,18 @@ void MeshViewer::Draw([[maybe_unused]] Game& game)
 
 	ImGui::NextColumn();
 
-	ImGui::Checkbox("Show matching armature", &_matchBones);
+	if (mesh->ContainsLandscapeFeature() && ImGui::TreeNodeEx("Footprint", ImGuiTreeNodeFlags_DefaultOpen))
+	{
+		ImGui::SliderInt("index", &_selectedFootprint, 0, static_cast<int>(mesh->GetFootprints().size() - 1));
+		if (_selectedFootprint > static_cast<int>(mesh->GetFootprints().size()))
+		{
+			_selectedFootprint = static_cast<int>(mesh->GetFootprints().size()) - 1;
+		}
+		const auto& footprint = mesh->GetFootprints().at(_selectedFootprint);
+		ImGui::Image(footprint.texture->GetNativeHandle(), ImVec2(128, 128));
+		ImGui::TreePop();
+	}
+
 	if (_selectedAnimation)
 	{
 		auto const& animation = animations.Handle(*_selectedAnimation);

--- a/src/Debug/MeshViewer.h
+++ b/src/Debug/MeshViewer.h
@@ -47,6 +47,7 @@ private:
 	entt::id_type _selectedMesh;
 	int _selectedSubMesh {0};
 	std::optional<entt::id_type> _selectedAnimation;
+	int _selectedFootprint {0};
 	int _selectedFrame {0};
 	ImGuiTextFilter _filter;
 	uint32_t _meshFlagFilter {0xFFFFFFFF};

--- a/src/ECS/Systems/RenderingSystemInterface.h
+++ b/src/ECS/Systems/RenderingSystemInterface.h
@@ -31,6 +31,7 @@ struct RenderContext
 	std::unique_ptr<graphics::Mesh> boundingBox;
 	std::unique_ptr<graphics::Mesh> streams;
 	std::unique_ptr<graphics::Mesh> footpaths;
+	std::unique_ptr<graphics::Mesh> footprints;
 
 	struct InstancedDrawDesc
 	{

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -612,10 +612,18 @@ bool Game::Run()
 	}
 
 	{
-		uint16_t waterWidth;
-		uint16_t waterHeight;
-		_water->GetFrameBuffer().GetSize(waterWidth, waterHeight);
-		_renderer->ConfigureView(graphics::RenderPass::Reflection, waterWidth, waterHeight);
+		uint16_t width;
+		uint16_t height;
+		_water->GetFrameBuffer().GetSize(width, height);
+		_renderer->ConfigureView(graphics::RenderPass::Reflection, width, height);
+	}
+
+	if (_config.drawIsland)
+	{
+		uint16_t width;
+		uint16_t height;
+		_landIsland->GetFootprintFramebuffer().GetSize(width, height);
+		_renderer->ConfigureView(graphics::RenderPass::Footprint, width, height, 0x00000000);
 	}
 
 	Game::SetTime(_config.timeOfDay);

--- a/src/Graphics/FrameBuffer.h
+++ b/src/Graphics/FrameBuffer.h
@@ -30,7 +30,7 @@ public:
 
 	void Bind(RenderPass viewId) const;
 
-	Texture2D& GetColorAttachment() { return _colorAttachment; }
+	[[nodiscard]] const Texture2D& GetColorAttachment() const { return _colorAttachment; }
 	void GetSize(uint16_t& width, uint16_t& height) const { width = _width, height = _height; }
 
 private:

--- a/src/Graphics/RenderPass.h
+++ b/src/Graphics/RenderPass.h
@@ -19,6 +19,7 @@ namespace openblack::graphics
 
 enum class RenderPass : uint8_t
 {
+	Footprint,
 	Reflection,
 	Main,
 	ImGui,
@@ -28,10 +29,11 @@ enum class RenderPass : uint8_t
 };
 
 static constexpr std::array<std::string_view, static_cast<uint8_t>(RenderPass::_count)> k_RenderPassNames {
-    "Reflection Pass",
-    "Main Pass",
-    "ImGui Pass",
-    "Mesh Viewer Pass",
+    "Footprint Pass",   //
+    "Reflection Pass",  //
+    "Main Pass",        //
+    "ImGui Pass",       //
+    "Mesh Viewer Pass", //
 };
 
 } // namespace openblack::graphics

--- a/src/Graphics/ShaderManager.cpp
+++ b/src/Graphics/ShaderManager.cpp
@@ -67,6 +67,11 @@
 #include "ShaderIncluder.h"
 #define SHADER_NAME fs_sprite
 #include "ShaderIncluder.h"
+
+#define SHADER_NAME vs_footprint_instanced
+#include "ShaderIncluder.h"
+#define SHADER_NAME fs_footprint
+#include "ShaderIncluder.h"
 // clang-format on
 
 namespace openblack::graphics
@@ -79,15 +84,16 @@ struct ShaderDefinition
 	const std::string_view fragmentShaderName;
 };
 
-const std::array<bgfx::EmbeddedShader, 14> k_EmbeddedShaders = {{
-    BGFX_EMBEDDED_SHADER(vs_line), BGFX_EMBEDDED_SHADER(vs_line_instanced),     //
-    BGFX_EMBEDDED_SHADER(fs_line),                                              //
-    BGFX_EMBEDDED_SHADER(vs_object), BGFX_EMBEDDED_SHADER(vs_object_instanced), //
-    BGFX_EMBEDDED_SHADER(fs_object), BGFX_EMBEDDED_SHADER(fs_sky),              //
-    BGFX_EMBEDDED_SHADER(vs_terrain), BGFX_EMBEDDED_SHADER(fs_terrain),         //
-    BGFX_EMBEDDED_SHADER(vs_water), BGFX_EMBEDDED_SHADER(fs_water),             //
-    BGFX_EMBEDDED_SHADER(vs_sprite), BGFX_EMBEDDED_SHADER(fs_sprite),           //
-    BGFX_EMBEDDED_SHADER_END()                                                  //
+const std::array<bgfx::EmbeddedShader, 16> k_EmbeddedShaders = {{
+    BGFX_EMBEDDED_SHADER(vs_line), BGFX_EMBEDDED_SHADER(vs_line_instanced),           //
+    BGFX_EMBEDDED_SHADER(fs_line),                                                    //
+    BGFX_EMBEDDED_SHADER(vs_object), BGFX_EMBEDDED_SHADER(vs_object_instanced),       //
+    BGFX_EMBEDDED_SHADER(fs_object), BGFX_EMBEDDED_SHADER(fs_sky),                    //
+    BGFX_EMBEDDED_SHADER(vs_terrain), BGFX_EMBEDDED_SHADER(fs_terrain),               //
+    BGFX_EMBEDDED_SHADER(vs_water), BGFX_EMBEDDED_SHADER(fs_water),                   //
+    BGFX_EMBEDDED_SHADER(vs_sprite), BGFX_EMBEDDED_SHADER(fs_sprite),                 //
+    BGFX_EMBEDDED_SHADER(vs_footprint_instanced), BGFX_EMBEDDED_SHADER(fs_footprint), //
+    BGFX_EMBEDDED_SHADER_END()                                                        //
 }};
 
 constexpr std::array k_Shaders {
@@ -99,6 +105,7 @@ constexpr std::array k_Shaders {
     ShaderDefinition {"Sky", "vs_object", "fs_sky"},
     ShaderDefinition {"Water", "vs_water", "fs_water"},
     ShaderDefinition {"Sprite", "vs_sprite", "fs_sprite"},
+    ShaderDefinition {"FootprintInstanced", "vs_footprint_instanced", "fs_footprint"},
 };
 
 ShaderManager::~ShaderManager()

--- a/src/Profiler.h
+++ b/src/Profiler.h
@@ -33,6 +33,7 @@ public:
 		GuiLoop,
 		GameLogic,
 		SceneDraw,
+		FootprintPass,
 		ReflectionPass,
 		ReflectionDrawSky,
 		ReflectionDrawWater,
@@ -63,6 +64,7 @@ public:
 	    "GUI Loop",             //
 	    "Game Logic",           //
 	    "Encode Draw Scene",    //
+	    "Footprint Pass",       //
 	    "Reflection Pass",      //
 	    "Draw Sky",             //
 	    "Draw Water",           //

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -117,6 +117,7 @@ public:
 	void Reset(uint16_t width, uint16_t height) const;
 
 private:
+	void DrawFootprintPass(const DrawSceneDesc& drawDesc) const;
 	void DrawSubMesh(const L3DMesh& mesh, const L3DSubMesh& subMesh, const L3DMeshSubmitDesc& desc, bool preserveState) const;
 	void DrawPass(const DrawSceneDesc& desc) const;
 

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -108,7 +108,7 @@ public:
 
 	void UpdateDebugCrossUniforms(const glm::mat4& pose);
 
-	void ConfigureView(graphics::RenderPass viewId, uint16_t width, uint16_t height) const;
+	void ConfigureView(graphics::RenderPass viewId, uint16_t width, uint16_t height, uint32_t clearColor = 0x274659ff) const;
 
 	void DrawScene(const DrawSceneDesc& drawDesc) const;
 	void DrawMesh(const L3DMesh& mesh, const L3DMeshSubmitDesc& desc, uint8_t subMeshIndex) const;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1013356/179329530-6418472c-370b-4e70-ba93-1a75fb03a3f6.png)
![image](https://user-images.githubusercontent.com/1013356/179329451-435f49f9-cd66-4e40-9ac7-ff06cef7cb47.png)
![image](https://user-images.githubusercontent.com/1013356/179329423-faae0e86-3500-42a2-9591-84ca8e13c873.png)

TODO: 
- [x] Sometimes there's more than one footprint. There are two meshes that have 4 in the mesh pack.
- [x] Vanilla draws footprints onto a framebuffer that the landscape samples from instead of the texture array. We might be able to get away with something more like a decal. There is z-fighting and drawing the footprint shouldn't write to depth.
- [x] Some footprints might not be shadows but lights in some cases
- [x] Switching lands breaks the rendering
- [x] Works in OpenGL but not Vulkan (Failed depth test?)
- [x] Move Pass code out of DrawScene
- [x] SegFault on exit in Vulkan
- [x] Add a TODO saying that the footprint framebuffer doesn't need to be updated each frame
- [x] The shadowy part of the village centre is not the same in vanilla