### PR TITLE
Morph with Terrain

### DIFF
--- a/assets/shaders/vs_object.sc
+++ b/assets/shaders/vs_object.sc
@@ -1,24 +1,61 @@
+#ifdef USE_INSTANCING
+$input a_position, a_texcoord0, a_normal, a_indices, i_data0, i_data1, i_data2, i_data3, i_data4
+#else
 $input a_position, a_texcoord0, a_normal, a_indices
+#endif // USE_INSTANCING
 $output v_position, v_texcoord0, v_normal
 
 #if BGFX_SHADER_LANGUAGE_HLSL == 3
 #define BGFX_CONFIG_MAX_BONES 48
 #else
-#define BGFX_CONFIG_MAX_BONES 64
+#define BGFX_CONFIG_MAX_BONES 128
 #endif
 
 #include <bgfx_shader.sh>
 
+#ifdef USE_HEIGHT_MAP
+SAMPLER2D(s_heightmap, 1);
+uniform vec4 u_islandExtent;
+#endif // USE_HEIGHT_MAP
+
 void main()
 {
+	// Unpack
+#ifdef USE_HEIGHT_MAP
+	vec2 extentMin = u_islandExtent.xy;
+	vec2 extentMax = u_islandExtent.zw;
+#endif // USE_HEIGHT_MAP
 
 #if BGFX_SHADER_LANGUAGE_HLSL > 300 || BGFX_SHADER_LANGUAGE_PSSL || BGFX_SHADER_LANGUAGE_SPIRV || BGFX_SHADER_LANGUAGE_METAL
 	uint modelIndex = uint(max(0, asint(a_indices.x)));
 #else
 	uint modelIndex = uint(max(0, a_indices.x));
 #endif
+
 	v_position = mul(u_model[modelIndex], vec4(a_position.xyz, 1.0f));
-	v_texcoord0 = vec4(a_texcoord0, 0, 0);
+
+#ifdef USE_INSTANCING
+	mat4 model;
+	model[0] = i_data0;
+	model[1] = i_data1;
+	model[2] = i_data2;
+	model[3] = i_data3;
+
+	v_position = instMul(model, v_position);
+#endif // USE_INSTANCING
+
+#ifdef USE_HEIGHT_MAP
+#ifdef USE_INSTANCING
+	float original_height = i_data3.y;
+#else
+    float original_height = u_model[modelIndex][3].y;
+#endif // USE_INSTANCING
+	vec2 blockUv = (v_position.xz - extentMin) / (extentMax - extentMin);
+	float terrain_height = texture2DLod(s_heightmap, blockUv, 0.0f).r * 170.85f;
+	v_position.y += terrain_height - original_height;
+#endif // USE_HEIGHT_MAP
+
+	v_texcoord0 = vec4(a_texcoord0, 0.0f, 0.0f);
 	v_normal = a_normal;
 	gl_Position = mul(u_viewProj, v_position);
 }

--- a/assets/shaders/vs_object_hm_instanced.sc
+++ b/assets/shaders/vs_object_hm_instanced.sc
@@ -1,0 +1,2 @@
+#define USE_HEIGHT_MAP 1
+#include "vs_object_instanced.sc"

--- a/assets/shaders/vs_object_instanced.sc
+++ b/assets/shaders/vs_object_instanced.sc
@@ -1,32 +1,3 @@
-$input a_position, a_texcoord0, a_normal, a_indices, i_data0, i_data1, i_data2, i_data3, i_data4
-$output v_position, v_texcoord0, v_normal
+#define USE_INSTANCING 1
 
-#if BGFX_SHADER_LANGUAGE_HLSL == 3
-#define BGFX_CONFIG_MAX_BONES 48
-#else
-#define BGFX_CONFIG_MAX_BONES 128
-#endif
-
-#include <bgfx_shader.sh>
-
-void main()
-{
-
-#if BGFX_SHADER_LANGUAGE_HLSL > 300 || BGFX_SHADER_LANGUAGE_PSSL || BGFX_SHADER_LANGUAGE_SPIRV || BGFX_SHADER_LANGUAGE_METAL
-	uint modelIndex = uint(max(0, asint(a_indices.x)));
-#else
-	uint modelIndex = uint(max(0, a_indices.x));
-#endif
-
-	mat4 model;
-	model[0] = i_data0;
-	model[1] = i_data1;
-	model[2] = i_data2;
-	model[3] = i_data3;
-
-	v_position = instMul(model, mul(u_model[modelIndex], vec4(a_position.xyz, 1.0f)));
-	v_texcoord0 = vec4(a_texcoord0, 0.0f, 0.0f);
-	v_normal = a_normal;
-	gl_Position = mul(u_viewProj, v_position);
-
-}
+#include "vs_object.sc"

--- a/src/3D/L3DMesh.cpp
+++ b/src/3D/L3DMesh.cpp
@@ -42,7 +42,8 @@ void L3DMesh::Load(const l3d::L3DFile& l3d)
 	{
 		_skins[skin.id] = std::make_unique<Texture2D>(_debugName.c_str());
 		_skins[skin.id]->Create(l3d::L3DTexture::k_Width, l3d::L3DTexture::k_Height, 1, Format::RGBA4, Wrapping::Repeat,
-		                        skin.texels.data(), static_cast<uint32_t>(skin.texels.size() * sizeof(skin.texels[0])));
+		                        Filter::Linear, skin.texels.data(),
+		                        static_cast<uint32_t>(skin.texels.size() * sizeof(skin.texels[0])));
 	}
 
 	if (HasDoorPosition() && !l3d.GetExtraPoints().empty())
@@ -68,7 +69,7 @@ void L3DMesh::Load(const l3d::L3DFile& l3d)
 			auto texture = std::make_unique<Texture2D>("footprints/texture/" + _debugName + "/" + std::to_string(i));
 			++i;
 			texture->Create(static_cast<uint16_t>(footprint.header.width), static_cast<uint16_t>(footprint.header.height), 1,
-			                graphics::Format::RGBA4, Wrapping::ClampEdge, entry.pixels.data(),
+			                graphics::Format::RGBA4, Wrapping::ClampEdge, Filter::Linear, entry.pixels.data(),
 			                static_cast<uint32_t>(entry.pixels.size() * sizeof(entry.pixels[0])));
 
 			const bgfx::Memory* verticesMem =

--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -108,19 +108,19 @@ void LandIsland::LoadFromFile(const std::filesystem::path& path)
 	}
 	_materialArray = std::make_unique<Texture2D>("LandIslandMaterialArray");
 	_materialArray->Create(lnd::LNDMaterial::k_Width, lnd::LNDMaterial::k_Height, materialCount, Format::RGB5A1,
-	                       Wrapping::ClampEdge, rgba5TextureData.data(),
+	                       Wrapping::ClampEdge, Filter::Linear, rgba5TextureData.data(),
 	                       static_cast<uint32_t>(rgba5TextureData.size() * sizeof(rgba5TextureData[0])));
 
 	// read noise map into Texture2D
 	_noiseMap = lnd.GetExtra().noise.texels;
 	_textureNoiseMap = std::make_unique<Texture2D>("LandIslandNoiseMap");
 	_textureNoiseMap->Create(lnd::LNDBumpMap::k_Width, lnd::LNDBumpMap::k_Height, 1, Format::R8, Wrapping::ClampEdge,
-	                         _noiseMap.data(), static_cast<uint32_t>(_noiseMap.size() * sizeof(_noiseMap[0])));
+	                         Filter::Linear, _noiseMap.data(), static_cast<uint32_t>(_noiseMap.size() * sizeof(_noiseMap[0])));
 
 	// read bump map into Texture2D
 	_textureBumpMap = std::make_unique<Texture2D>("LandIslandBumpMap");
 	_textureBumpMap->Create(lnd::LNDBumpMap::k_Width, lnd::LNDBumpMap::k_Height, 1, Format::R8, Wrapping::Repeat,
-	                        lnd.GetExtra().bump.texels.data(),
+	                        Filter::Linear, lnd.GetExtra().bump.texels.data(),
 	                        static_cast<uint32_t>(sizeof(lnd.GetExtra().bump.texels[0]) * lnd.GetExtra().bump.texels.size()));
 
 	// build the meshes (we could move this elsewhere)

--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -88,6 +88,12 @@ void LandIsland::LoadFromFile(const std::filesystem::path& path)
 			_extentMax.y = b.GetMapPosition().y;
 		}
 	}
+
+	_heightMap = std::make_unique<Texture2D>("Height Map");
+	auto heightMapData = CreateHeightMap();
+	_heightMap->Create(k_GridCount * k_CellCount, k_GridCount * k_CellCount, 1, graphics::Format::R8, Wrapping::ClampEdge,
+	                   Filter::Linear, heightMapData.data(), static_cast<uint32_t>(heightMapData.size()));
+
 	const auto res =
 	    glm::u16vec2(maxX - minX, maxZ - minZ) * glm::u16vec2(lnd::LNDMaterial::k_Width, lnd::LNDMaterial::k_Height);
 	_footprintFrameBuffer = std::make_unique<FrameBuffer>("Footprints", res.x, res.y, graphics::Format::RGBA8);

--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -138,9 +138,9 @@ float LandIsland::GetHeightAt(glm::vec2 vec) const
 	return GetCell(vec * 0.1f).altitude * LandIsland::k_HeightUnit;
 }
 
-uint8_t LandIsland::GetNoise(int x, int y)
+uint8_t LandIsland::GetNoise(glm::u8vec2 pos)
 {
-	return _noiseMap.at((y & 0xFF) + 256 * (x & 0xFF));
+	return _noiseMap.at(pos.x * 256 + pos.y);
 }
 
 const LandBlock* LandIsland::GetBlock(const glm::u8vec2& coordinates) const

--- a/src/3D/LandIsland.h
+++ b/src/3D/LandIsland.h
@@ -41,7 +41,6 @@ struct LNDCountry;
 class LandIsland
 {
 public:
-	static const uint8_t k_GridCount;
 	static const uint8_t k_CellCount;
 	static const float k_HeightUnit;
 	static const float k_CellSize;
@@ -81,6 +80,11 @@ public:
 		view = _view;
 		proj = _proj;
 	}
+	void GetIndexExtent(glm::u16vec2& extentMin, glm::u16vec2& extentMax) const
+	{
+		extentMin = _extentIndexMin;
+		extentMax = _extentIndexMax;
+	}
 	void GetExtent(glm::vec2& extentMin, glm::vec2& extentMax) const
 	{
 		extentMin = _extentMin;
@@ -100,6 +104,8 @@ private:
 	std::unique_ptr<graphics::FrameBuffer> _footprintFrameBuffer;
 	glm::mat4 _proj;
 	glm::mat4 _view;
+	glm::u16vec2 _extentIndexMin;
+	glm::u16vec2 _extentIndexMax;
 	glm::vec2 _extentMin;
 	glm::vec2 _extentMax;
 

--- a/src/3D/LandIsland.h
+++ b/src/3D/LandIsland.h
@@ -74,6 +74,7 @@ public:
 	[[nodiscard]] const std::vector<lnd::LNDCountry>& GetCountries() const { return _countries; }
 	[[nodiscard]] const graphics::Texture2D& GetAlbedoArray() const { return *_materialArray; }
 	[[nodiscard]] const graphics::Texture2D& GetBump() const { return *_textureBumpMap; }
+	[[nodiscard]] const graphics::Texture2D& GetHeightMap() const { return *_heightMap; }
 	[[nodiscard]] const graphics::FrameBuffer& GetFootprintFramebuffer() const { return *_footprintFrameBuffer; }
 	void GetOrthoViewProj(glm::mat4& view, glm::mat4& proj) const
 	{
@@ -92,6 +93,7 @@ private:
 	std::unique_ptr<graphics::Texture2D> _materialArray;
 	std::unique_ptr<graphics::Texture2D> _countryLookup;
 
+	std::unique_ptr<graphics::Texture2D> _heightMap;
 	std::unique_ptr<graphics::Texture2D> _textureNoiseMap;
 	std::unique_ptr<graphics::Texture2D> _textureBumpMap;
 

--- a/src/3D/LandIsland.h
+++ b/src/3D/LandIsland.h
@@ -41,6 +41,8 @@ struct LNDCountry;
 class LandIsland
 {
 public:
+	static const uint8_t k_GridCount;
+	static const uint8_t k_CellCount;
 	static const float k_HeightUnit;
 	static const float k_CellSize;
 	static constexpr entt::hashed_string k_SmallBumpTextureId = entt::hashed_string("raw/smallbumpa");
@@ -59,6 +61,8 @@ public:
 	void DumpMaps() const;
 
 private:
+	[[nodiscard]] std::vector<uint8_t> CreateHeightMap() const;
+
 	std::array<uint8_t, 1024> _blockIndexLookup {0};
 	std::vector<LandBlock> _landBlocks;
 	std::vector<lnd::LNDCountry> _countries;

--- a/src/3D/LandIsland.h
+++ b/src/3D/LandIsland.h
@@ -86,7 +86,7 @@ public:
 		extentMax = _extentMax;
 	}
 
-	uint8_t GetNoise(int x, int y);
+	uint8_t GetNoise(glm::u8vec2 pos);
 
 private:
 	std::unique_ptr<graphics::Texture2D> _materialArray;

--- a/src/3D/Sky.cpp
+++ b/src/3D/Sky.cpp
@@ -57,7 +57,8 @@ Sky::Sky()
 	_timeOfDay = 1.0f;
 
 	_texture->Create(k_TextureResolution[0], k_TextureResolution[1], k_TextureResolution[2], Format::RGB5A1,
-	                 Wrapping::ClampEdge, _bitmaps.data(), static_cast<uint32_t>(_bitmaps.size() * sizeof(_bitmaps[0])));
+	                 Wrapping::ClampEdge, Filter::Linear, _bitmaps.data(),
+	                 static_cast<uint32_t>(_bitmaps.size() * sizeof(_bitmaps[0])));
 }
 
 void Sky::SetDayNightTimes(float nightFull, float duskStart, float duskEnd, float dayFull)

--- a/src/Debug/LandIsland.cpp
+++ b/src/Debug/LandIsland.cpp
@@ -39,6 +39,15 @@ void LandIsland::Draw(openblack::Game& game)
 
 	ImGui::Separator();
 
+	if (ImGui::TreeNodeEx("Height Map", ImGuiTreeNodeFlags_DefaultOpen))
+	{
+		auto dim = openblack::LandIsland::k_CellCount * openblack::LandIsland::k_GridCount;
+		const auto& texture = landIsland.GetHeightMap();
+		ImGui::Text("Resolution: %ux%u", dim, dim);
+		ImGui::Image(texture.GetNativeHandle(), ImVec2(512.0f, 512.0f));
+		ImGui::TreePop();
+	}
+
 	if (ImGui::TreeNodeEx("Footprints", ImGuiTreeNodeFlags_DefaultOpen))
 	{
 		const auto& frameBuffer = landIsland.GetFootprintFramebuffer();

--- a/src/Debug/LandIsland.cpp
+++ b/src/Debug/LandIsland.cpp
@@ -41,10 +41,15 @@ void LandIsland::Draw(openblack::Game& game)
 
 	if (ImGui::TreeNodeEx("Height Map", ImGuiTreeNodeFlags_DefaultOpen))
 	{
-		auto dim = openblack::LandIsland::k_CellCount * openblack::LandIsland::k_GridCount;
+		glm::u16vec2 extentMin;
+		glm::u16vec2 extentMax;
+		landIsland.GetIndexExtent(extentMin, extentMax);
+		const auto extentSize = extentMax - extentMin;
+		const auto dim = static_cast<uint16_t>(openblack::LandIsland::k_CellCount) * extentSize;
 		const auto& texture = landIsland.GetHeightMap();
-		ImGui::Text("Resolution: %ux%u", dim, dim);
-		ImGui::Image(texture.GetNativeHandle(), ImVec2(512.0f, 512.0f));
+		ImGui::Text("Resolution: %ux%u", dim.x, dim.y);
+		float scaling = 512.0f / static_cast<float>(dim.x);
+		ImGui::Image(texture.GetNativeHandle(), ImVec2(dim.x * scaling, dim.y * scaling));
 		ImGui::TreePop();
 	}
 

--- a/src/ECS/Archetypes/AbodeArchetype.cpp
+++ b/src/ECS/Archetypes/AbodeArchetype.cpp
@@ -16,6 +16,7 @@
 #include "ECS/Components/Abode.h"
 #include "ECS/Components/Fixed.h"
 #include "ECS/Components/Mesh.h"
+#include "ECS/Components/MorphWithTerrain.h"
 #include "ECS/Components/StoragePit.h"
 #include "ECS/Components/Transform.h"
 #include "ECS/Registry.h"
@@ -84,12 +85,33 @@ entt::entity AbodeArchetype::Create(uint32_t townId, const glm::vec3& position, 
 	const auto entity = registry.Create();
 
 	const auto& info = game->GetInfoConstants().abode.at(static_cast<size_t>(type));
+	bool morphsWithTerrain = false;
+	morphsWithTerrain |= info.abodeType == AbodeType::Graveyard;
+	morphsWithTerrain |= info.abodeType == AbodeType::StoragePit;
+	if (info.abodeType == AbodeType::Wonder)
+	{
+		morphsWithTerrain |= info.tribeType == Tribe::CELTIC;
+		morphsWithTerrain |= info.tribeType == Tribe::JAPANESE;
+		morphsWithTerrain |= info.tribeType == Tribe::INDIAN;
+		morphsWithTerrain |= info.tribeType == Tribe::NORSE;
+		morphsWithTerrain |= info.tribeType == Tribe::TIBETAN;
+	}
+	morphsWithTerrain |= info.abodeType == AbodeType::Workshop;
+	morphsWithTerrain |= info.abodeType == AbodeType::Citadel;
+	morphsWithTerrain |= info.abodeType == AbodeType::Creche;
+	morphsWithTerrain |= info.abodeType == AbodeType::FootballPitch;
+	morphsWithTerrain |= info.abodeType == AbodeType::TownCentre;
+	morphsWithTerrain |= info.abodeType == AbodeType::Field;
 
 	const auto& transform =
 	    registry.Assign<Transform>(entity, position, glm::mat3(glm::eulerAngleY(-yAngleRadians)), glm::vec3(scale));
 	registry.Assign<Abode>(entity, info.abodeNumber, townId, foodAmount, woodAmount);
 	auto resourceId = resources::MeshIdToResourceId(info.meshId);
 	const auto& mesh = registry.Assign<Mesh>(entity, resourceId, static_cast<int8_t>(0), static_cast<int8_t>(0));
+	if (morphsWithTerrain)
+	{
+		registry.Assign<MorphWithTerrain>(entity);
+	}
 
 	// Create Fixed component with a 2d bounding circle
 	const auto [point, radius] = GetFixedObstacleBoundingCircle(info.meshId, transform);

--- a/src/ECS/Archetypes/BigForestArchetype.cpp
+++ b/src/ECS/Archetypes/BigForestArchetype.cpp
@@ -14,6 +14,7 @@
 #include "ECS/Components/Fixed.h"
 #include "ECS/Components/Forest.h"
 #include "ECS/Components/Mesh.h"
+#include "ECS/Components/MorphWithTerrain.h"
 #include "ECS/Components/Transform.h"
 #include "ECS/Registry.h"
 #include "Game.h"
@@ -37,6 +38,7 @@ entt::entity BigForestArchetype::Create(const glm::vec3& position, BigForestInfo
 	registry.Assign<Fixed>(entity, point, radius);
 	registry.Assign<Forest>(entity);
 	registry.Assign<BigForest>(entity);
+	registry.Assign<MorphWithTerrain>(entity);
 	const auto resourceId = resources::MeshIdToResourceId(info.meshId);
 	registry.Assign<Mesh>(entity, resourceId, static_cast<int8_t>(0), static_cast<int8_t>(1));
 

--- a/src/ECS/Archetypes/PotArchetype.cpp
+++ b/src/ECS/Archetypes/PotArchetype.cpp
@@ -12,6 +12,7 @@
 #include <glm/gtx/euler_angles.hpp>
 
 #include "ECS/Components/Mesh.h"
+#include "ECS/Components/MorphWithTerrain.h"
 #include "ECS/Components/Pot.h"
 #include "ECS/Components/Transform.h"
 #include "ECS/Registry.h"
@@ -42,6 +43,10 @@ entt::entity PotArchetype::Create(const glm::vec3& position, float yAngleRadians
 	registry.Assign<Pot>(entity, static_cast<uint16_t>(amount), static_cast<uint16_t>(info.maxAmountInPot));
 	const auto resourceId = resources::MeshIdToResourceId(info.meshId);
 	registry.Assign<Mesh>(entity, resourceId, static_cast<int8_t>(0), static_cast<int8_t>(1));
+	if (info.potType == PotType::PileFood)
+	{
+		registry.Assign<MorphWithTerrain>(entity);
+	}
 
 	return entity;
 }

--- a/src/ECS/Components/MorphWithTerrain.h
+++ b/src/ECS/Components/MorphWithTerrain.h
@@ -1,0 +1,37 @@
+/*****************************************************************************
+ * Copyright (c) 2018-2022 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+namespace openblack::ecs::components
+{
+
+/// Meshes with this component will have their vertices match terrain height maps
+///
+/// They correspond with vanilla Get3DType of MORPHABLE or CITADEL
+/// The following Objects should be created with this component:
+/// * BigForest
+/// * Graveyard
+/// * PileFood (not wood)
+/// * StoragePit x2 meshes
+/// * Wonder (Depends on tribe type but defaults to morphable)
+/// * Workshop
+/// * CitadelHeart
+/// * CitadelPart
+/// * Creche
+/// * Football
+/// * TODO: PhysicalShield (not magic)
+/// * TownCentre
+/// * Field
+struct MorphWithTerrain
+{
+	int dummy;
+};
+
+} // namespace openblack::ecs::components

--- a/src/ECS/Systems/RenderingSystemInterface.h
+++ b/src/ECS/Systems/RenderingSystemInterface.h
@@ -28,13 +28,15 @@ struct RenderContext
 
 	struct InstancedDrawDesc
 	{
-		InstancedDrawDesc(uint32_t offset, uint32_t count)
+		InstancedDrawDesc(uint32_t offset, uint32_t count, bool morphWithTerrain)
 		    : offset(offset)
 		    , count(count)
+		    , morphWithTerrain(morphWithTerrain)
 		{
 		}
 		uint32_t offset;
 		uint32_t count;
+		bool morphWithTerrain;
 	};
 
 	/// A list of cpu-side uniforms which is refilled at every \ref PrepareDraw.

--- a/src/Enums.h
+++ b/src/Enums.h
@@ -127,7 +127,7 @@ enum class AbodeType : uint32_t
 	Creche = 1 << 6 | Civic,
 	Workshop = 1 << 7 | Civic,
 	Wonder = 1 << 8,
-	Graveyard = 1 << 9,
+	Graveyard = 1 << 9 | Civic,
 	TownCentre = 1 << 10 | Civic,
 	Citadel = 1 << 11 | Civic,
 	FootballPitch = 1 << 12 | Civic,

--- a/src/Graphics/ShaderManager.cpp
+++ b/src/Graphics/ShaderManager.cpp
@@ -48,6 +48,8 @@
 #include "ShaderIncluder.h"
 #define SHADER_NAME vs_object_instanced
 #include "ShaderIncluder.h"
+#define SHADER_NAME vs_object_hm_instanced
+#include "ShaderIncluder.h"
 #define SHADER_NAME fs_object
 #include "ShaderIncluder.h"
 #define SHADER_NAME fs_sky
@@ -84,16 +86,16 @@ struct ShaderDefinition
 	const std::string_view fragmentShaderName;
 };
 
-const std::array<bgfx::EmbeddedShader, 16> k_EmbeddedShaders = {{
-    BGFX_EMBEDDED_SHADER(vs_line), BGFX_EMBEDDED_SHADER(vs_line_instanced),           //
-    BGFX_EMBEDDED_SHADER(fs_line),                                                    //
-    BGFX_EMBEDDED_SHADER(vs_object), BGFX_EMBEDDED_SHADER(vs_object_instanced),       //
-    BGFX_EMBEDDED_SHADER(fs_object), BGFX_EMBEDDED_SHADER(fs_sky),                    //
-    BGFX_EMBEDDED_SHADER(vs_terrain), BGFX_EMBEDDED_SHADER(fs_terrain),               //
-    BGFX_EMBEDDED_SHADER(vs_water), BGFX_EMBEDDED_SHADER(fs_water),                   //
-    BGFX_EMBEDDED_SHADER(vs_sprite), BGFX_EMBEDDED_SHADER(fs_sprite),                 //
-    BGFX_EMBEDDED_SHADER(vs_footprint_instanced), BGFX_EMBEDDED_SHADER(fs_footprint), //
-    BGFX_EMBEDDED_SHADER_END()                                                        //
+const std::array<bgfx::EmbeddedShader, 17> k_EmbeddedShaders = {{
+    BGFX_EMBEDDED_SHADER(vs_line), BGFX_EMBEDDED_SHADER(vs_line_instanced),                                                   //
+    BGFX_EMBEDDED_SHADER(fs_line),                                                                                            //
+    BGFX_EMBEDDED_SHADER(vs_object), BGFX_EMBEDDED_SHADER(vs_object_instanced), BGFX_EMBEDDED_SHADER(vs_object_hm_instanced), //
+    BGFX_EMBEDDED_SHADER(fs_object), BGFX_EMBEDDED_SHADER(fs_sky),                                                            //
+    BGFX_EMBEDDED_SHADER(vs_terrain), BGFX_EMBEDDED_SHADER(fs_terrain),                                                       //
+    BGFX_EMBEDDED_SHADER(vs_water), BGFX_EMBEDDED_SHADER(fs_water),                                                           //
+    BGFX_EMBEDDED_SHADER(vs_sprite), BGFX_EMBEDDED_SHADER(fs_sprite),                                                         //
+    BGFX_EMBEDDED_SHADER(vs_footprint_instanced), BGFX_EMBEDDED_SHADER(fs_footprint),                                         //
+    BGFX_EMBEDDED_SHADER_END()                                                                                                //
 }};
 
 constexpr std::array k_Shaders {
@@ -102,6 +104,7 @@ constexpr std::array k_Shaders {
     ShaderDefinition {"Terrain", "vs_terrain", "fs_terrain"},
     ShaderDefinition {"Object", "vs_object", "fs_object"},
     ShaderDefinition {"ObjectInstanced", "vs_object_instanced", "fs_object"},
+    ShaderDefinition {"ObjectHeightMapInstanced", "vs_object_hm_instanced", "fs_object"},
     ShaderDefinition {"Sky", "vs_object", "fs_sky"},
     ShaderDefinition {"Water", "vs_water", "fs_water"},
     ShaderDefinition {"Sprite", "vs_sprite", "fs_sprite"},

--- a/src/Graphics/Texture2D.cpp
+++ b/src/Graphics/Texture2D.cpp
@@ -92,8 +92,8 @@ Texture2D::~Texture2D()
 	}
 }
 
-void Texture2D::Create(uint16_t width, uint16_t height, uint16_t layers, Format format, Wrapping wrapping, const void* data,
-                       uint32_t size)
+void Texture2D::Create(uint16_t width, uint16_t height, uint16_t layers, Format format, Wrapping wrapping, Filter filter,
+                       const void* data, uint32_t size)
 {
 	uint64_t flags = BGFX_TEXTURE_NONE;
 	switch (wrapping)
@@ -109,6 +109,16 @@ void Texture2D::Create(uint16_t width, uint16_t height, uint16_t layers, Format 
 	case Wrapping::MirroredRepeat:
 		flags |= BGFX_SAMPLER_U_MIRROR | BGFX_SAMPLER_V_MIRROR;
 		break;
+	}
+	switch (filter)
+	{
+	case Filter::Nearest:
+		flags |= BGFX_SAMPLER_POINT;
+		break;
+	case Filter::Linear:
+		break;
+	default:
+		assert(false);
 	}
 	const auto* memory = bgfx::makeRef(data, size);
 	_handle = bgfx::createTexture2D(width, height, false, layers, getBgfxTextureFormat(format), flags, memory);

--- a/src/Graphics/Texture2D.h
+++ b/src/Graphics/Texture2D.h
@@ -104,7 +104,8 @@ public:
 	Texture2D& operator=(const Texture2D&) = delete;
 
 	void Create(uint16_t width, uint16_t height, uint16_t layers, Format format = Format::RGBA8,
-	            Wrapping wrapping = Wrapping::ClampEdge, const void* data = nullptr, uint32_t size = 0);
+	            Wrapping wrapping = Wrapping::ClampEdge, Filter filter = Filter::Linear, const void* data = nullptr,
+	            uint32_t size = 0);
 
 	[[nodiscard]] const std::string& GetName() const { return _name; }
 	[[nodiscard]] const bgfx::TextureHandle& GetNativeHandle() const { return _handle; }

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -98,6 +98,7 @@ public:
 		bool isSky;
 		float skyType;
 		bool drawAll; ///< For use in the mesh viewer
+		bool morphWithTerrain;
 	};
 
 	Renderer() = delete;

--- a/src/Resources/Loaders.cpp
+++ b/src/Resources/Loaders.cpp
@@ -86,7 +86,7 @@ Texture2DLoader::result_type Texture2DLoader::operator()(FromPackTag, const std:
 	}
 
 	texture2D->Create(static_cast<uint16_t>(g3dTexture.ddsHeader.width), static_cast<uint16_t>(g3dTexture.ddsHeader.height), 1,
-	                  internalFormat, graphics::Wrapping::Repeat, g3dTexture.ddsData.data(),
+	                  internalFormat, graphics::Wrapping::Repeat, graphics::Filter::Linear, g3dTexture.ddsData.data(),
 	                  static_cast<uint32_t>(g3dTexture.ddsData.size()));
 	return texture2D;
 }
@@ -129,7 +129,8 @@ Texture2DLoader::result_type Texture2DLoader::operator()(FromDiskTag, const std:
 	}
 
 	auto texture = std::make_shared<graphics::Texture2D>(("raw" / rawTexturePath.stem()).string());
-	texture->Create(width, height, 1, format, graphics::Wrapping::Repeat, data.data(), static_cast<uint32_t>(data.size()));
+	texture->Create(width, height, 1, format, graphics::Wrapping::Repeat, graphics::Filter::Linear, data.data(),
+	                static_cast<uint32_t>(data.size()));
 
 	return texture;
 }


### PR DESCRIPTION
This PR adds the functionality to morph objects with the terrain height map.
The objects that do this are documented in https://github.com/openblack/openblack/wiki/3D-Object-Types

![image](https://user-images.githubusercontent.com/1013356/180900953-c67c5cfc-879d-45b0-bbc0-fbe3a3fb431d.png)
![image](https://user-images.githubusercontent.com/1013356/180901009-33e5b922-2fc7-4f0f-bf47-777a402af99c.png)


Code clean-up and refactor:
* Fixed the Graveyard info.dat enum value
* Added filter type for texture2d in case is it better to point sample height map
* Cleaned-up terrain block mesh generation to be more readable and to expand upon if we decide to merge the meshes into one large one
* The instancing code in Rendering System now uses an unordered map for faster look-ups

I chose not to sample the height map in a shader as this would be a waste of cycles since the height map is static.
Objects are sampled each frame because the meshes are shared and instance drawn.

The attribute for morphing with terrain was added to the instancing code in RenderingSystem because there is no ordering.
I'm not 100% happy with this and would have preferred to have the instances sorted and storing the range of morphable objects.

TODO:
- [x] Depends on #517 and needs to add `MorphWithTerrain` to Food type Pots
- [x] Look-up which tribes morph their wonders
- [x] Add `MorphWithTerrain` component in `MobileStaticArchetype::Create(..., MobileStaticInfo::PhysicalShield, ...)`