### PR TITLE
github: Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
New vcpkg tags come out about every month.
This configuration should have dependabot create a PR to update the vcpkg config monthly. Doing so will run our CI against vcpkg changes and hopefully catch out-of-date packages and vcpkg regressions early.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates