### PR TITLE
Remove msvc-16 support

### DIFF
--- a/.github/workflows/ci-vcpkg.yml
+++ b/.github/workflows/ci-vcpkg.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         # This is the matrix. They form permutations.
-        os: [ubuntu-22.04, macos-latest, windows-latest, windows-2019]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
         cc: [""]
         cxx: [""]
         # These are additional individual jobs. There are no permutations of these.
@@ -160,7 +160,7 @@ jobs:
       fail-fast: false
       matrix:
         # This is the matrix. They form permutations.
-        os: [ ubuntu-22.04, macos-latest, windows-latest, windows-2019 ]
+        os: [ ubuntu-22.04, macos-latest, windows-latest ]
     steps:
       - name: Download compiled openblack and tools
         uses: actions/download-artifact@v3

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -75,13 +75,6 @@
       "inherits": "template-vcpkg"
     },
     {
-      "name": "msvc-16-vcpkg",
-      "displayName": "Visual Studio 2019 (vcpkg)",
-      "description": "Configure with vcpkg toolchain and generate Visual Studio 2019 project files for all configurations",
-      "generator": "Visual Studio 16 2019",
-      "inherits": "template-vcpkg"
-    },
-    {
       "name": "msvc-17-vcpkg",
       "displayName": "Visual Studio 2022 (vcpkg)",
       "description": "Configure with vcpkg toolchain and generate Visual Studio 2022 project files for all configurations",
@@ -166,20 +159,6 @@
       "configurePreset": "ninja-multi-vcpkg",
       "displayName": "Build ninja-multi-vcpkg-release",
       "description": "Build ninja-multi-vcpkg Release configuration",
-      "configuration": "Release"
-    },
-    {
-      "name": "msvc-16-vcpkg-debug",
-      "configurePreset": "msvc-16-vcpkg",
-      "displayName": "Build msvc-16-vcpkg-debug",
-      "description": "Build msvc-16-vcpkg Debug configuration",
-      "configuration": "Debug"
-    },
-    {
-      "name": "msvc-16-vcpkg-release",
-      "configurePreset": "msvc-16-vcpkg",
-      "displayName": "Build msvc-16-vcpkg-release",
-      "description": "Build msvc-16-vcpkg Release configuration",
       "configuration": "Release"
     },
     {

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ for you. To do so, you will be selecting the `"ninja-multi-vcpkg"   - Ninja Mult
      * Install [CMake version 3.20+](https://cmake.org/download/)
  * You can simply [open the `openblack` folder directly in Visual Studio Code and select a preset](https://devblogs.microsoft.com/cppblog/cmake-presets-integration-in-visual-studio-and-visual-studio-code/).
 
-### Visual Studio 2019 / 2022
+### Visual Studio 2022
 * Install [Visual Studio](https://visualstudio.microsoft.com/downloads/)
     * Select an appropriate MSVC C++ Component for your version
     * Select an appropriate Windows SDK Component for your version


### PR DESCRIPTION
Visual studio 2022 works very well and is stable in the test framework.
Remove support for Visual Studio 2019