### PR TITLE
Fix d3d11 release shutdown bug

### DIFF
--- a/src/ECS/Systems/Implementations/RenderingSystem.cpp
+++ b/src/ECS/Systems/Implementations/RenderingSystem.cpp
@@ -37,6 +37,7 @@ RenderContext::~RenderContext()
 	{
 		bgfx::destroy(instanceUniformBuffer);
 		bgfx::frame();
+		bgfx::frame();
 	}
 }
 

--- a/src/ECS/Systems/Implementations/RenderingSystem.cpp
+++ b/src/ECS/Systems/Implementations/RenderingSystem.cpp
@@ -27,6 +27,19 @@
 using namespace openblack::ecs::systems;
 using namespace openblack::ecs::components;
 
+RenderContext::RenderContext()
+    : instanceUniformBuffer(BGFX_INVALID_HANDLE)
+{
+}
+RenderContext::~RenderContext()
+{
+	if (bgfx::isValid(instanceUniformBuffer))
+	{
+		bgfx::destroy(instanceUniformBuffer);
+		bgfx::frame();
+	}
+}
+
 RenderingSystemInterface::~RenderingSystemInterface() = default;
 
 RenderingSystem::~RenderingSystem() = default;

--- a/src/ECS/Systems/RenderingSystemInterface.h
+++ b/src/ECS/Systems/RenderingSystemInterface.h
@@ -19,15 +19,8 @@ namespace openblack::ecs::systems
 {
 struct RenderContext
 {
-	RenderContext()
-	    : instanceUniformBuffer(BGFX_INVALID_HANDLE) {};
-	~RenderContext()
-	{
-		if (bgfx::isValid(instanceUniformBuffer))
-		{
-			bgfx::destroy(instanceUniformBuffer);
-		}
-	}
+	RenderContext();
+	~RenderContext();
 	std::unique_ptr<graphics::Mesh> boundingBox;
 	std::unique_ptr<graphics::Mesh> streams;
 	std::unique_ptr<graphics::Mesh> footpaths;

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -195,6 +195,7 @@ Renderer::~Renderer()
 	_plane.reset();
 	_shaderManager.reset();
 	_debugCross.reset();
+	bgfx::frame();
 	bgfx::shutdown();
 }
 


### PR DESCRIPTION
There is a bug in d3d11 when shutting down bgfx. A failure happens in the driver code and it happens only when `instanceUniformBuffer` is used.

This bug prevents #449 from completing as the game exits non-cleanly.
