### PR TITLE
Revert "ci: Disable emscripten cross compile test"

### DIFF
--- a/.github/workflows/ci-cross-compile.yml
+++ b/.github/workflows/ci-cross-compile.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         # This is the matrix. They form permutations.
         os: [ubuntu-latest]
-        preset: [android-armeabi-v7a-vcpkg, android-arm64-v8a-vcpkg, android-x86-vcpkg, android-x86_64-vcpkg]
+        preset: [android-armeabi-v7a-vcpkg, android-arm64-v8a-vcpkg, android-x86-vcpkg, android-x86_64-vcpkg, emscripten-vcpkg]
         triplet: [""]
         # TODO(#519) x86 disabled due to failing to find stdlib headers on workflows
         # include:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vcpkg"]
 	path = vcpkg
-	url = https://github.com/Microsoft/vcpkg.git
+	url = https://github.com/bwrsandman/vcpkg.git

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -28,7 +28,13 @@
         {
             "name": "bgfx",
             "default-features": false,
-            "features": [ "multithreaded" ]
+            "platform": "emscripten"
+        },
+        {
+            "name": "bgfx",
+            "default-features": false,
+            "features": [ "multithreaded" ],
+            "platform": "!emscripten"
         },
         "bullet3",
         "minizip",


### PR DESCRIPTION
This reverts commit 66355c2b6d63523259745d7224830a0c07f1f2e3.

- [ ] Fails to build bgfx (https://github.com/microsoft/vcpkg/pull/32058)