### PR TITLE
imgui: Update the draw implementation to use encoders

### DIFF
--- a/assets/shaders/imgui/fs_imgui_image.sc
+++ b/assets/shaders/imgui/fs_imgui_image.sc
@@ -2,7 +2,7 @@ $input v_texcoord0
 
 /*
  * Copyright 2014 Dario Manesku. All rights reserved.
- * License: https://github.com/bkaradzic/bgfx#license-bsd-2-clause
+ * License: https://github.com/bkaradzic/bgfx/blob/master/LICENSE
  */
 
 #include <bgfx_shader.sh>

--- a/assets/shaders/imgui/fs_ocornut_imgui.sc
+++ b/assets/shaders/imgui/fs_ocornut_imgui.sc
@@ -7,5 +7,5 @@ SAMPLER2D(s_tex, 0);
 void main()
 {
 	vec4 texel = texture2D(s_tex, v_texcoord0);
-	gl_FragColor = texel * v_color0; 
+	gl_FragColor = texel * v_color0;
 }

--- a/assets/shaders/imgui/varying.def.sc
+++ b/assets/shaders/imgui/varying.def.sc
@@ -2,7 +2,7 @@ vec4 v_color0    : COLOR0    = vec4(1.0, 0.0, 0.0, 1.0);
 vec3 v_normal    : NORMAL    = vec3(0.0, 0.0, 1.0);
 vec2 v_texcoord0 : TEXCOORD0 = vec2(0.0, 0.0);
 
-vec3 a_position  : POSITION;
+vec2 a_position  : POSITION;
 vec4 a_normal    : NORMAL;
 vec4 a_color0    : COLOR0;
 vec2 a_texcoord0 : TEXCOORD0;

--- a/assets/shaders/imgui/vs_imgui_image.sc
+++ b/assets/shaders/imgui/vs_imgui_image.sc
@@ -3,7 +3,7 @@ $output v_texcoord0
 
 /*
  * Copyright 2014 Dario Manesku. All rights reserved.
- * License: https://github.com/bkaradzic/bgfx#license-bsd-2-clause
+ * License: https://github.com/bkaradzic/bgfx/blob/master/LICENSE
  */
 
 #include <bgfx_shader.sh>

--- a/assets/shaders/imgui/vs_ocornut_imgui.sc
+++ b/assets/shaders/imgui/vs_ocornut_imgui.sc
@@ -5,8 +5,8 @@ $output v_color0, v_texcoord0
 
 void main()
 {
-	vec2 pos = 2.0*a_position.xy*u_viewTexel.xy;
-	gl_Position = vec4(pos.x - 1.0, 1.0 - pos.y, 0.0, 1.0);
+	vec4 pos = mul(u_viewProj, vec4(a_position.xy, 0.0, 1.0) );
+	gl_Position = vec4(pos.x, pos.y, 0.0, 1.0);
 	v_texcoord0 = a_texcoord0;
 	v_color0    = a_color0;
 }

--- a/src/Debug/Gui.cpp
+++ b/src/Debug/Gui.cpp
@@ -708,21 +708,14 @@ void Gui::NewFrameSdl2(SDL_Window* window)
 	{
 		int w;
 		int h;
-		int displayW;
-		int displayH;
 		SDL_GetWindowSize(window, &w, &h);
-		SDL_GL_GetDrawableSize(window, &displayW, &displayH);
 		io.DisplaySize = ImVec2(static_cast<float>(w), static_cast<float>(h));
-		if (w > 0 && h > 0)
-		{
-			io.DisplayFramebufferScale = ImVec2(static_cast<float>(displayW) / w, static_cast<float>(displayH) / h);
-		}
 	}
 	else
 	{
 		io.DisplaySize = ImVec2(1.0f, 1.0f);
-		io.DisplayFramebufferScale = ImVec2(1.0f, 1.0f);
 	}
+	io.DisplayFramebufferScale = ImVec2(1.0f, 1.0f);
 
 	// Setup time step (we don't use SDL_GetTicks() because it is using
 	// millisecond resolution)

--- a/src/Debug/Gui.h
+++ b/src/Debug/Gui.h
@@ -124,10 +124,6 @@ private:
 	ImGuiContext* _imgui;
 	ImVec2 _menuBarSize;
 	uint64_t _time {0};
-	bgfx::DynamicVertexBufferHandle _vertexBuffer;
-	bgfx::DynamicIndexBufferHandle _indexBuffer;
-	uint32_t _vertexCount;
-	uint32_t _indexCount;
 	bgfx::VertexLayout _layout;
 	bgfx::ProgramHandle _program;
 	bgfx::ProgramHandle _imageProgram;


### PR DESCRIPTION
This fixes imgui on metal on osx

Before:
<img width="1279" alt="Screen Shot 2022-08-27 at 9 14 25 AM" src="https://user-images.githubusercontent.com/1013356/187031930-3e303558-7734-4f37-ba23-d83c866fa101.png">

Encoders with scale 2:
<img width="1392" alt="Screen Shot 2022-08-27 at 9 15 30 AM" src="https://user-images.githubusercontent.com/1013356/187031940-869ef876-b16f-42a9-9f6e-2459e89b6ce6.png">

Encoders with scale 1:
<img width="1392" alt="Screen Shot 2022-08-27 at 9 16 53 AM" src="https://user-images.githubusercontent.com/1013356/187031969-0ed8c51b-0d5e-4986-8c29-4ee65121fb29.png">
