### PR TITLE
object: don't asint in metal

### DIFF
--- a/assets/shaders/vs_object.sc
+++ b/assets/shaders/vs_object.sc
@@ -26,7 +26,7 @@ void main()
 	vec2 extentMax = u_islandExtent.zw;
 #endif // USE_HEIGHT_MAP
 
-#if BGFX_SHADER_LANGUAGE_HLSL > 300 || BGFX_SHADER_LANGUAGE_PSSL || BGFX_SHADER_LANGUAGE_SPIRV || BGFX_SHADER_LANGUAGE_METAL
+#if BGFX_SHADER_LANGUAGE_HLSL > 300 || BGFX_SHADER_LANGUAGE_PSSL || BGFX_SHADER_LANGUAGE_SPIRV
 	uint modelIndex = uint(max(0, asint(a_indices.x)));
 #else
 	uint modelIndex = uint(max(0, a_indices.x));


### PR DESCRIPTION
Fixes animated meshes in osx
Closes #541

Before:
<img width="1392" alt="Screen Shot 2022-08-27 at 9 38 19 AM" src="https://user-images.githubusercontent.com/1013356/187032687-ac3dd320-a7cc-42dd-8e9f-19c18c061f87.png">


After:
<img width="1392" alt="Screen Shot 2022-08-27 at 9 37 12 AM" src="https://user-images.githubusercontent.com/1013356/187032647-56f769c5-bd31-4282-81e4-fff06a5834b3.png">
