### PR TITLE
linux: Disable d3d from the BGFX_EMBEDDED_SHADER macro.

### DIFF
--- a/src/Debug/Gui.cpp
+++ b/src/Debug/Gui.cpp
@@ -13,6 +13,13 @@
 #include <cmath>
 
 #include <bgfx/embedded_shader.h>
+// BGFX has support for WSL to use windows d3d. We disable it here from the BGFX_EMBEDDED_SHADER macro.
+#if BX_PLATFORM_LINUX
+#undef BGFX_EMBEDDED_SHADER_DXBC
+#define BGFX_EMBEDDED_SHADER_DXBC(...)
+#undef BGFX_EMBEDDED_SHADER_DX9BC
+#define BGFX_EMBEDDED_SHADER_DX9BC(...)
+#endif
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"

--- a/src/Graphics/ShaderManager.cpp
+++ b/src/Graphics/ShaderManager.cpp
@@ -33,6 +33,13 @@
 #include <cstdint> // Shaders below need uint8_t
 
 #include <bgfx/embedded_shader.h>
+// BGFX has support for WSL to use windows d3d. We disable it here from the BGFX_EMBEDDED_SHADER macro.
+#if BX_PLATFORM_LINUX
+#undef BGFX_EMBEDDED_SHADER_DXBC
+#define BGFX_EMBEDDED_SHADER_DXBC(...)
+#undef BGFX_EMBEDDED_SHADER_DX9BC
+#define BGFX_EMBEDDED_SHADER_DX9BC(...)
+#endif
 
 #include "3D/Camera.h"
 


### PR DESCRIPTION
BGFX has support for WSL to use windows d3d. This whitelists d3d macros for BGFX_EMBEDDED_SHADER.