### PR TITLE
Add missing iostream includes

### DIFF
--- a/apps/anmtool/anmtool.cpp
+++ b/apps/anmtool/anmtool.cpp
@@ -9,6 +9,7 @@
 
 #include <cstdlib>
 
+#include <iostream>
 #include <string>
 
 #include <ANMFile.h>

--- a/apps/l3dtool/l3dtool.cpp
+++ b/apps/l3dtool/l3dtool.cpp
@@ -11,6 +11,7 @@
 #include <cstring>
 
 #include <filesystem>
+#include <iostream>
 #include <stack>
 #include <string>
 

--- a/apps/lndtool/lndtool.cpp
+++ b/apps/lndtool/lndtool.cpp
@@ -10,6 +10,7 @@
 #include <cstdlib>
 
 #include <fstream>
+#include <iostream>
 #include <string>
 
 #include <LNDFile.h>

--- a/apps/morphtool/morphtool.cpp
+++ b/apps/morphtool/morphtool.cpp
@@ -10,6 +10,7 @@
 #include <cstdlib>
 
 #include <fstream>
+#include <iostream>
 #include <string>
 
 #include <MorphFile.h>

--- a/apps/packtool/packtool.cpp
+++ b/apps/packtool/packtool.cpp
@@ -11,6 +11,7 @@
 #include <cstdlib>
 
 #include <fstream>
+#include <iostream>
 #include <limits>
 #include <string>
 

--- a/test/mock/gen_info.cpp
+++ b/test/mock/gen_info.cpp
@@ -11,6 +11,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 
 #include <InfoConstants.h>
 #include <cxxopts.hpp>


### PR DESCRIPTION
gcc 12.2.1 complains about missing iostream includes. This is probably due to fstream no longer leaking iostream includes. This could also be due to the new modules feature of c++.