### PR TITLE
Action map for input

### DIFF
--- a/src/3D/Camera.cpp
+++ b/src/3D/Camera.cpp
@@ -11,6 +11,8 @@
 
 #include <optional>
 
+#include <SDL_events.h>
+#include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtx/euler_angles.hpp>
 #include <glm/gtx/intersect.hpp>
 #include <glm/gtx/norm.hpp>
@@ -419,11 +421,11 @@ void Camera::HandleMouseInput(const SDL_Event& e)
 			_rotation.x -= pitch;
 			_rotation.y -= yaw;
 
-			glm::mat4x4 rotationMatrixX(1.0f);
+			glm::mat4 rotationMatrixX(1.0f);
 			rotationMatrixX = glm::rotate(rotationMatrixX, yaw, glm::vec3(0.0f, 1.0f, 0.0f));
 			_position = (rotationMatrixX * glm::vec4(_position - handPos, 0.0f)) + glm::vec4(handPos, 0.0f);
 
-			glm::mat4x4 rotationMatrixY(1.0f);
+			glm::mat4 rotationMatrixY(1.0f);
 			rotationMatrixY = glm::rotate(rotationMatrixY, pitch, GetRight());
 			_position = (rotationMatrixY * glm::vec4(_position - handPos, 0.0f)) + glm::vec4(handPos, 0.0f);
 			_position.y = (_position.y < 15.0f) ? 15.0f : _position.y;
@@ -719,7 +721,7 @@ glm::mat4 ReflectionCamera::GetViewMatrix() const
 	glm::mat4 mView = mRotation * glm::translate(glm::mat4(1.0f), -_position);
 
 	// M''camera = Mreflection * Mcamera * Mflip
-	glm::mat4x4 reflectionMatrix;
+	glm::mat4 reflectionMatrix;
 	ReflectMatrix(reflectionMatrix, _reflectionPlane);
 
 	return mView * reflectionMatrix;
@@ -731,7 +733,7 @@ Mreflection = |  -2NxNy 1-2Ny2   -2NyNz  -2NyD |
               |  -2NxNz  -2NyNz 1-2Nz2   -2NzD |
               |    0       0       0       1   |
 */
-void ReflectionCamera::ReflectMatrix(glm::mat4x4& m, const glm::vec4& plane) const
+void ReflectionCamera::ReflectMatrix(glm::mat4& m, const glm::vec4& plane) const
 {
 	m[0][0] = (1.0f - 2.0f * plane[0] * plane[0]);
 	m[1][0] = (-2.0f * plane[0] * plane[1]);

--- a/src/3D/Camera.h
+++ b/src/3D/Camera.h
@@ -72,7 +72,6 @@ public:
 	void ProcessSDLEvent(const SDL_Event&);
 
 	void HandleActions();
-	void HandleMouseInput(const SDL_Event&);
 
 	[[nodiscard]] glm::mat4 GetRotationMatrix() const;
 

--- a/src/3D/Camera.h
+++ b/src/3D/Camera.h
@@ -72,7 +72,6 @@ public:
 	void ProcessSDLEvent(const SDL_Event&);
 
 	void HandleActions();
-	void HandleKeyboardInput(const SDL_Event&);
 	void HandleMouseInput(const SDL_Event&);
 
 	[[nodiscard]] glm::mat4 GetRotationMatrix() const;

--- a/src/3D/Camera.h
+++ b/src/3D/Camera.h
@@ -19,8 +19,6 @@
 
 #include "ECS/Components/Transform.h"
 
-union SDL_Event;
-
 namespace openblack
 {
 
@@ -69,7 +67,6 @@ public:
 	bool ProjectWorldToScreen(glm::vec3 worldPosition, glm::vec4 viewport, glm::vec3& outScreenPosition) const;
 
 	void Update(std::chrono::microseconds dt);
-	void ProcessSDLEvent(const SDL_Event&);
 
 	void HandleActions();
 

--- a/src/3D/Camera.h
+++ b/src/3D/Camera.h
@@ -71,6 +71,7 @@ public:
 	void Update(std::chrono::microseconds dt);
 	void ProcessSDLEvent(const SDL_Event&);
 
+	void HandleActions();
 	void HandleKeyboardInput(const SDL_Event&);
 	void HandleMouseInput(const SDL_Event&);
 

--- a/src/3D/Camera.h
+++ b/src/3D/Camera.h
@@ -13,9 +13,9 @@
 #include <memory>
 #include <optional>
 
-#include <SDL_events.h>
-#include <glm/glm.hpp>
-#include <glm/gtc/matrix_transform.hpp>
+#include <glm/mat4x4.hpp>
+#include <glm/vec2.hpp>
+#include <glm/vec3.hpp>
 
 #include "ECS/Components/Transform.h"
 
@@ -56,7 +56,7 @@ public:
 	void SetRotation(const glm::vec3& eulerRadians) { _rotation = eulerRadians; }
 
 	void SetProjectionMatrixPerspective(float xFov, float aspect, float nearClip, float farClip);
-	void SetProjectionMatrix(const glm::mat4x4& projection) { _projectionMatrix = projection; }
+	void SetProjectionMatrix(const glm::mat4& projection) { _projectionMatrix = projection; }
 
 	[[nodiscard]] glm::vec3 GetForward() const;
 	[[nodiscard]] glm::vec3 GetRight() const;
@@ -131,6 +131,6 @@ public:
 
 private:
 	glm::vec4 _reflectionPlane;
-	void ReflectMatrix(glm::mat4x4& m, const glm::vec4& plane) const;
+	void ReflectMatrix(glm::mat4& m, const glm::vec4& plane) const;
 };
 } // namespace openblack

--- a/src/Common/EventManager.h
+++ b/src/Common/EventManager.h
@@ -19,9 +19,6 @@
 
 namespace openblack
 {
-
-class EventManager;
-
 class EventManager
 {
 public:

--- a/src/Debug/Gui.cpp
+++ b/src/Debug/Gui.cpp
@@ -182,6 +182,11 @@ Gui::~Gui()
 	}
 }
 
+bool Gui::StealsFocus() const
+{
+	return _stealsFocus;
+}
+
 bool Gui::ProcessEvents(const SDL_Event& event)
 {
 	ImGui::SetCurrentContext(_imgui);
@@ -194,23 +199,27 @@ bool Gui::ProcessEvents(const SDL_Event& event)
 	ImGui_ImplSDL2_ProcessEvent(&event);
 
 	ImGuiIO& io = ImGui::GetIO();
+	_stealsFocus = io.WantCaptureMouse;
 	switch (event.type)
 	{
 	case SDL_QUIT:
-		return false;
+		_stealsFocus = false;
+		break;
 	case SDL_TEXTINPUT:
-		return io.WantTextInput;
+		_stealsFocus = io.WantTextInput;
+		break;
 	case SDL_KEYDOWN:
 	case SDL_KEYUP:
-		return io.WantCaptureKeyboard;
+		_stealsFocus = io.WantCaptureKeyboard;
+		break;
 	case SDL_WINDOWEVENT:
 		if (event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED)
 		{
-			return false;
+			_stealsFocus = false;
 		}
 		break;
 	}
-	return io.WantCaptureMouse;
+	return _stealsFocus;
 }
 
 bool Gui::CreateFontsTextureBgfx()

--- a/src/Debug/Gui.h
+++ b/src/Debug/Gui.h
@@ -91,6 +91,7 @@ public:
 
 	virtual ~Gui();
 
+	[[nodiscard]] bool StealsFocus() const;
 	bool ProcessEvents(const SDL_Event& event);
 	bool Loop(Game& game, const Renderer& renderer);
 	void Draw();
@@ -123,5 +124,6 @@ private:
 	const bgfx::ViewId _viewId;
 	std::vector<std::unique_ptr<Window>> _debugWindows;
 	std::string _screenshotFilename = "screenshot.png";
+	bool _stealsFocus = false;
 };
 } // namespace openblack::debug::gui

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -355,6 +355,7 @@ bool Game::Update()
 		{
 			_eventManager->Create<SDL_Event>(e);
 		}
+		_camera->HandleActions();
 	}
 
 	if (!this->_config.running)

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -346,7 +346,10 @@ bool Game::Update()
 	// Input events
 	{
 		auto sdlInput = _profiler->BeginScoped(Profiler::Stage::SdlInput);
-		Locator::gameActionSystem::value().Frame();
+		if (!this->_gui->StealsFocus())
+		{
+			Locator::gameActionSystem::value().Frame();
+		}
 		SDL_Event e;
 		while (SDL_PollEvent(&e) != 0)
 		{

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -131,7 +131,6 @@ Game::Game(Arguments&& args)
 		// If gui captures this input, do not propagate
 		if (!this->_gui->ProcessEvents(event))
 		{
-			this->_camera->ProcessSDLEvent(event);
 			this->_config.running = this->ProcessEvents(event);
 			Locator::gameActionSystem::value().ProcessEvent(event);
 		}

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -47,6 +47,7 @@
 #include "FileSystem/FileSystemInterface.h"
 #include "Graphics/FrameBuffer.h"
 #include "Graphics/Texture2D.h"
+#include "Input/GameActionMapInterface.h"
 #include "LHScriptX/Script.h"
 #include "Locator.h"
 #include "PackFile.h"
@@ -132,6 +133,7 @@ Game::Game(Arguments&& args)
 		{
 			this->_camera->ProcessSDLEvent(event);
 			this->_config.running = this->ProcessEvents(event);
+			Locator::gameActionSystem::value().ProcessEvent(event);
 		}
 	}));
 }
@@ -168,6 +170,7 @@ Game::~Game()
 	Locator::pathfindingSystem::reset();
 	Locator::terrainSystem::reset();
 	Locator::filesystem::reset();
+	Locator::gameActionSystem::reset();
 
 	_water.reset();
 	_sky.reset();
@@ -343,6 +346,7 @@ bool Game::Update()
 	// Input events
 	{
 		auto sdlInput = _profiler->BeginScoped(Profiler::Stage::SdlInput);
+		Locator::gameActionSystem::value().Frame();
 		SDL_Event e;
 		while (SDL_PollEvent(&e) != 0)
 		{

--- a/src/Game.h
+++ b/src/Game.h
@@ -67,6 +67,7 @@ class Script;
 enum class LoggingSubsystem : uint8_t
 {
 	game,
+	input,
 	graphics,
 	scripting,
 	audio,
@@ -78,6 +79,7 @@ enum class LoggingSubsystem : uint8_t
 
 constexpr static std::array<std::string_view, static_cast<size_t>(LoggingSubsystem::_count)> k_LoggingSubsystemStrs {
     "game",        //
+    "input",       //
     "graphics",    //
     "scripting",   //
     "audio",       //

--- a/src/Input/GameActionMap.cpp
+++ b/src/Input/GameActionMap.cpp
@@ -33,7 +33,6 @@ GameActionMap::GameActionMap()
 	_mouseWheelBinding[0] = BindableActionMap::ZOOM_IN;
 	_mouseWheelBinding[1] = BindableActionMap::ZOOM_OUT;
 	_keyboardBindings.emplace(SDL_SCANCODE_T, BindableActionMap::TALK);
-	_mouseBindings.emplace(SDL_BUTTON_LMASK | SDL_BUTTON_RMASK, BindableActionMap::ZOOM_ON);
 	_keyboardBindings.emplace(SDL_SCANCODE_LCTRL, BindableActionMap::ZOOM_ON);
 	_keyboardBindings.emplace(SDL_SCANCODE_RCTRL, BindableActionMap::ZOOM_ON);
 	_keyboardBindings.emplace(SDL_SCANCODE_LEFT, BindableActionMap::MOVE_LEFT);
@@ -111,6 +110,23 @@ glm::ivec2 GameActionMap::GetMouseDelta() const
 
 void GameActionMap::Frame()
 {
+	if ((SDL_GetMouseState(nullptr, nullptr) & (SDL_BUTTON_LMASK | SDL_BUTTON_RMASK)) == (SDL_BUTTON_LMASK | SDL_BUTTON_RMASK))
+	{
+		_unbindableMap = static_cast<UnbindableActionMap>(static_cast<uint8_t>(_unbindableMap) |
+		                                                  static_cast<uint8_t>(UnbindableActionMap::TWO_BUTTON_CLICK));
+		_bindableMap = static_cast<BindableActionMap>(static_cast<uint64_t>(_bindableMap) &
+		                                              ~(static_cast<uint64_t>(_mouseModBindings[SDL_BUTTON_LMASK].second) |
+		                                                static_cast<uint64_t>(_mouseModBindings[SDL_BUTTON_RMASK].second)));
+		_bindableMap = static_cast<BindableActionMap>(static_cast<uint64_t>(_bindableMap) &
+		                                              ~(static_cast<uint64_t>(_mouseBindings[SDL_BUTTON_LMASK]) |
+		                                                static_cast<uint64_t>(_mouseBindings[SDL_BUTTON_LMASK])));
+	}
+	else
+	{
+		_unbindableMap = static_cast<UnbindableActionMap>(static_cast<uint8_t>(_unbindableMap) &
+		                                                  ~static_cast<uint8_t>(UnbindableActionMap::TWO_BUTTON_CLICK));
+	}
+
 	if (_bindableMap != BindableActionMap::NONE || _unbindableMap != UnbindableActionMap::NONE)
 	{
 		SPDLOG_LOGGER_DEBUG(spdlog::get("input"), "GameActionMap:");
@@ -170,6 +186,7 @@ void GameActionMap::Frame()
 	} while (0)
 
 	get_print(DOUBLE_CLICK);
+	get_print(TWO_BUTTON_CLICK);
 
 #undef get_print
 

--- a/src/Input/GameActionMap.cpp
+++ b/src/Input/GameActionMap.cpp
@@ -77,6 +77,30 @@ bool GameActionMap::GetUnbindable(UnbindableActionMap action) const
 	return (static_cast<uint8_t>(_unbindableMap) & static_cast<uint8_t>(action)) != 0;
 }
 
+bool GameActionMap::GetBindableChanged(BindableActionMap action) const
+{
+	return ((static_cast<uint64_t>(_bindableMap) ^ static_cast<uint64_t>(_bindableMapPrevious)) &
+	        static_cast<uint64_t>(action)) != 0;
+}
+
+bool GameActionMap::GetUnbindableChanged(UnbindableActionMap action) const
+{
+	return ((static_cast<uint8_t>(_unbindableMap) ^ static_cast<uint8_t>(_unbindableMapPrevious)) &
+	        static_cast<uint8_t>(action)) != 0;
+}
+
+bool GameActionMap::GetBindableRepeat(BindableActionMap action) const
+{
+	return ((static_cast<uint64_t>(_bindableMap) & static_cast<uint64_t>(_bindableMapPrevious)) &
+	        static_cast<uint64_t>(action)) != 0;
+}
+
+bool GameActionMap::GetUnbindableRepeat(UnbindableActionMap action) const
+{
+	return ((static_cast<uint8_t>(_unbindableMap) & static_cast<uint8_t>(_unbindableMapPrevious)) &
+	        static_cast<uint8_t>(action)) != 0;
+}
+
 void GameActionMap::Frame()
 {
 	if (_bindableMap != BindableActionMap::NONE || _unbindableMap != UnbindableActionMap::NONE)
@@ -141,6 +165,7 @@ void GameActionMap::Frame()
 
 #undef get_print
 
+	_bindableMapPrevious = _bindableMap;
 	_bindableMap =
 	    static_cast<BindableActionMap>(static_cast<uint64_t>(_bindableMap) &
 	                                   ~(static_cast<uint64_t>(_mouseWheelBinding[0].value_or(BindableActionMap::NONE)) |

--- a/src/Input/GameActionMap.cpp
+++ b/src/Input/GameActionMap.cpp
@@ -12,11 +12,12 @@
 #include "GameActionMap.h"
 
 #include <SDL_events.h>
+#include <glm/common.hpp>
 #include <glm/gtc/constants.hpp>
 #include <spdlog/spdlog.h>
 
-#include "Game.h"
-#include "GameWindow.h"
+#include "Locator.h"
+#include "Windowing/WindowingInterface.h"
 
 using namespace openblack::input;
 
@@ -181,9 +182,9 @@ void GameActionMap::Frame()
 
 	{
 		glm::ivec2 absoluteMousePosition;
-		glm::ivec2 screenSize;
 		SDL_GetMouseState(&absoluteMousePosition.x, &absoluteMousePosition.y);
-		Game::Instance()->GetWindow()->GetSize(screenSize.x, screenSize.y);
+		const auto screenSize =
+		    Locator::windowing::has_value() ? Locator::windowing::value().GetSize() : glm::ivec2(1.0f, 1.0f);
 		_mousePosition = glm::clamp(absoluteMousePosition, glm::zero<decltype(screenSize)>(), screenSize);
 	}
 	_mouseDelta = glm::ivec2(0, 0);

--- a/src/Input/GameActionMap.cpp
+++ b/src/Input/GameActionMap.cpp
@@ -1,0 +1,235 @@
+/******************************************************************************
+ * Copyright (c) 2018-2024 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *******************************************************************************/
+
+#define LOCATOR_IMPLEMENTATIONS
+
+#include "GameActionMap.h"
+
+#include <SDL_events.h>
+#include <spdlog/spdlog.h>
+
+using namespace openblack::input;
+
+GameActionMap::GameActionMap()
+{
+	// TODO(#604): Support remapping
+	_keyboardBindings.emplace(SDL_SCANCODE_F1, BindableActionMap::HELP);
+	_mouseBindings.emplace(SDL_BUTTON_LEFT, BindableActionMap::MOVE);
+	_mouseBindings.emplace(SDL_BUTTON_RIGHT, BindableActionMap::ACTION);
+	_mouseWheelBinding[0] = BindableActionMap::ZOOM_IN;
+	_mouseWheelBinding[1] = BindableActionMap::ZOOM_OUT;
+	_mouseBindings.emplace(SDL_BUTTON_RIGHT, BindableActionMap::ACTION);
+	_keyboardBindings.emplace(SDL_SCANCODE_T, BindableActionMap::TALK);
+	_mouseModBindings.emplace(SDL_BUTTON_LEFT, std::make_pair(KMOD_LCTRL, BindableActionMap::ZOOM_ON));
+	_mouseModBindings.emplace(SDL_BUTTON_LEFT, std::make_pair(KMOD_RCTRL, BindableActionMap::ZOOM_ON));
+	_mouseModBindings.emplace(SDL_BUTTON_RIGHT, std::make_pair(KMOD_LCTRL, BindableActionMap::ZOOM_ON));
+	_mouseModBindings.emplace(SDL_BUTTON_RIGHT, std::make_pair(KMOD_RCTRL, BindableActionMap::ZOOM_ON));
+	_keyboardModBindings.emplace(SDL_SCANCODE_LEFT, std::make_pair(KMOD_LCTRL, BindableActionMap::ZOOM_ON));
+	_keyboardModBindings.emplace(SDL_SCANCODE_LEFT, std::make_pair(KMOD_RCTRL, BindableActionMap::ZOOM_ON));
+	_keyboardModBindings.emplace(SDL_SCANCODE_RIGHT, std::make_pair(KMOD_LCTRL, BindableActionMap::ZOOM_ON));
+	_keyboardModBindings.emplace(SDL_SCANCODE_RIGHT, std::make_pair(KMOD_RCTRL, BindableActionMap::ZOOM_ON));
+	_keyboardModBindings.emplace(SDL_SCANCODE_UP, std::make_pair(KMOD_LCTRL, BindableActionMap::ZOOM_ON));
+	_keyboardModBindings.emplace(SDL_SCANCODE_UP, std::make_pair(KMOD_RCTRL, BindableActionMap::ZOOM_ON));
+	_keyboardModBindings.emplace(SDL_SCANCODE_DOWN, std::make_pair(KMOD_LCTRL, BindableActionMap::ZOOM_ON));
+	_keyboardModBindings.emplace(SDL_SCANCODE_DOWN, std::make_pair(KMOD_RCTRL, BindableActionMap::ZOOM_ON));
+	_keyboardBindings.emplace(SDL_SCANCODE_LEFT, BindableActionMap::MOVE_LEFT);
+	_keyboardBindings.emplace(SDL_SCANCODE_RIGHT, BindableActionMap::MOVE_RIGHT);
+	_keyboardBindings.emplace(SDL_SCANCODE_UP, BindableActionMap::MOVE_FORWARDS);
+	_keyboardBindings.emplace(SDL_SCANCODE_DOWN, BindableActionMap::MOVE_BACKWARDS);
+	_keyboardBindings.emplace(SDL_SCANCODE_A, BindableActionMap::TILT_UP);
+	_keyboardBindings.emplace(SDL_SCANCODE_Q, BindableActionMap::TILT_DOWN);
+	_keyboardBindings.emplace(SDL_SCANCODE_Z, BindableActionMap::ROTATE_LEFT);
+	_keyboardBindings.emplace(SDL_SCANCODE_U, BindableActionMap::ROTATE_RIGHT);
+	_keyboardBindings.emplace(SDL_SCANCODE_LSHIFT, BindableActionMap::ROTATE_ON);
+	_keyboardBindings.emplace(SDL_SCANCODE_RSHIFT, BindableActionMap::ROTATE_ON);
+	_mouseBindings.emplace(SDL_BUTTON_MIDDLE, BindableActionMap::ROTATE_AROUND_MOUSE_ON);
+	_keyboardBindings.emplace(SDL_SCANCODE_SPACE, BindableActionMap::ZOOM_TO_TEMPLE);
+	_keyboardBindings.emplace(SDL_SCANCODE_C, BindableActionMap::ZOOM_TO_CREATURE);
+	_keyboardBindings.emplace(SDL_SCANCODE_F3, BindableActionMap::ZOOM_TO_REALM);
+	_keyboardBindings.emplace(SDL_SCANCODE_F4, BindableActionMap::ZOOM_TO_INSIDE_TEMPLE);
+	_keyboardBindings.emplace(SDL_SCANCODE_F5, BindableActionMap::ZOOM_TO_CREATURE_ROOM);
+	_keyboardBindings.emplace(SDL_SCANCODE_F6, BindableActionMap::ZOOM_TO_CHALLENGE_ROOM);
+	_keyboardBindings.emplace(SDL_SCANCODE_F7, BindableActionMap::ZOOM_TO_SAVE_GAME_ROOM);
+	_keyboardBindings.emplace(SDL_SCANCODE_F8, BindableActionMap::ZOOM_TO_OPTIONS_ROOM);
+	_keyboardBindings.emplace(SDL_SCANCODE_F9, BindableActionMap::ZOOM_TO_LIBRARY);
+	_keyboardBindings.emplace(SDL_SCANCODE_L, BindableActionMap::LEASH_UNLEASH_CREATURE);
+	_keyboardBindings.emplace(SDL_SCANCODE_N, BindableActionMap::SHOW_VILLAGER_NAMES);
+	_keyboardBindings.emplace(SDL_SCANCODE_S, BindableActionMap::SHOW_VILLAGER_DETAILS);
+	_keyboardModBindings.emplace(SDL_SCANCODE_S, std::make_pair(KMOD_CTRL, BindableActionMap::QUICK_SAVE));
+	_keyboardModBindings.emplace(SDL_SCANCODE_L, std::make_pair(KMOD_CTRL, BindableActionMap::QUICK_LOAD));
+	_keyboardBindings.emplace(SDL_SCANCODE_V, BindableActionMap::PREVIOUS_LEASH);
+	_keyboardBindings.emplace(SDL_SCANCODE_B, BindableActionMap::NEXT_LEASH);
+}
+
+bool GameActionMap::GetBindable(BindableActionMap action) const
+{
+	return (static_cast<uint64_t>(_bindableMap) & static_cast<uint64_t>(action)) != 0;
+}
+
+bool GameActionMap::GetUnbindable(UnbindableActionMap action) const
+{
+	return (static_cast<uint8_t>(_unbindableMap) & static_cast<uint8_t>(action)) != 0;
+}
+
+void GameActionMap::Frame()
+{
+	if (_bindableMap != BindableActionMap::NONE || _unbindableMap != UnbindableActionMap::NONE)
+	{
+		SPDLOG_LOGGER_DEBUG(spdlog::get("input"), "GameActionMap:");
+	}
+#define get_print(x)                                               \
+	do                                                             \
+	{                                                              \
+		if (Get(BindableActionMap::x))                             \
+		{                                                          \
+			SPDLOG_LOGGER_DEBUG(spdlog::get("input"), "\t{}", #x); \
+		}                                                          \
+	} while (0)
+
+	get_print(HELP);
+	get_print(MOVE);
+	get_print(ACTION);
+	get_print(ZOOM_OUT);
+	get_print(ZOOM_IN);
+	get_print(TALK);
+	get_print(ZOOM_ON);
+	get_print(MOVE_LEFT);
+	get_print(MOVE_RIGHT);
+	get_print(MOVE_FORWARDS);
+	get_print(MOVE_BACKWARDS);
+	get_print(TILT_UP);
+	get_print(TILT_DOWN);
+	get_print(ROTATE_LEFT);
+	get_print(ROTATE_RIGHT);
+	get_print(ROTATE_ON);
+	get_print(ROTATE_AROUND_MOUSE_ON);
+	get_print(ZOOM_TO_TEMPLE);
+	get_print(ZOOM_TO_CREATURE);
+	get_print(ZOOM_TO_REALM);
+	get_print(ZOOM_TO_INSIDE_TEMPLE);
+	get_print(ZOOM_TO_CREATURE_ROOM);
+	get_print(ZOOM_TO_CHALLENGE_ROOM);
+	get_print(ZOOM_TO_SAVE_GAME_ROOM);
+	get_print(ZOOM_TO_OPTIONS_ROOM);
+	get_print(ZOOM_TO_LIBRARY);
+	get_print(LEASH_UNLEASH_CREATURE);
+	get_print(SHOW_VILLAGER_NAMES);
+	get_print(SHOW_VILLAGER_DETAILS);
+	get_print(QUICK_SAVE);
+	get_print(QUICK_LOAD);
+	get_print(PREVIOUS_LEASH);
+	get_print(NEXT_LEASH);
+
+#undef get_print
+
+#define get_print(x)                                               \
+	do                                                             \
+	{                                                              \
+		if (Get(UnbindableActionMap::x))                           \
+		{                                                          \
+			SPDLOG_LOGGER_DEBUG(spdlog::get("input"), "\t{}", #x); \
+		}                                                          \
+	} while (0)
+
+	get_print(DOUBLE_CLICK);
+
+#undef get_print
+
+	_bindableMap =
+	    static_cast<BindableActionMap>(static_cast<uint64_t>(_bindableMap) &
+	                                   ~(static_cast<uint64_t>(_mouseWheelBinding[0].value_or(BindableActionMap::NONE)) |
+	                                     static_cast<uint64_t>(_mouseWheelBinding[1].value_or(BindableActionMap::NONE))));
+}
+
+void GameActionMap::ProcessEvent(const SDL_Event& event)
+{
+	if (event.type == SDL_KEYDOWN)
+	{
+		if (_keyboardModBindings.contains(event.key.keysym.scancode) &&
+		    (_keyboardModBindings[event.key.keysym.scancode].first & event.key.keysym.mod) != 0)
+		{
+			_bindableMap = static_cast<BindableActionMap>(
+			    // Remove non-modded action
+			    (static_cast<uint64_t>(_bindableMap) & ~static_cast<uint64_t>(_keyboardBindings[event.key.keysym.scancode])) |
+			    // Add modded action
+			    static_cast<uint64_t>(_keyboardModBindings[event.key.keysym.scancode].second));
+		}
+		else if (_keyboardBindings.contains(event.key.keysym.scancode))
+		{
+			_bindableMap = static_cast<BindableActionMap>(static_cast<uint64_t>(_bindableMap) |
+			                                              static_cast<uint64_t>(_keyboardBindings[event.key.keysym.scancode]));
+		}
+	}
+	// Double click will not count as a single click
+	else if (event.type == SDL_MOUSEBUTTONDOWN && (event.button.button & SDL_BUTTON(SDL_BUTTON_LEFT)) != 0 &&
+	         event.button.clicks == 2)
+	{
+		_unbindableMap = static_cast<UnbindableActionMap>(static_cast<uint8_t>(_unbindableMap) |
+		                                                  static_cast<uint8_t>(UnbindableActionMap::DOUBLE_CLICK));
+	}
+	else if (event.type == SDL_MOUSEBUTTONDOWN)
+	{
+		auto mod = SDL_GetModState();
+		if (_mouseModBindings.contains(event.button.button) && (_mouseModBindings[event.button.button].first & mod) != 0)
+		{
+			_bindableMap = static_cast<BindableActionMap>(
+			    // Remove non-modded action
+			    (static_cast<uint64_t>(_bindableMap) & ~static_cast<uint64_t>(_mouseBindings[event.button.button])) |
+			    // Add modded action
+			    static_cast<uint64_t>(_mouseModBindings[event.button.button].second));
+		}
+		else if (_mouseBindings.contains(event.button.button))
+		{
+			_bindableMap = static_cast<BindableActionMap>(static_cast<uint64_t>(_bindableMap) |
+			                                              static_cast<uint64_t>(_mouseBindings[event.button.button]));
+		}
+	}
+	else if (event.type == SDL_MOUSEWHEEL)
+	{
+		if (event.wheel.y > 0)
+		{
+			_bindableMap =
+			    static_cast<BindableActionMap>(static_cast<uint64_t>(_bindableMap) |
+			                                   static_cast<uint64_t>(_mouseWheelBinding[0].value_or(BindableActionMap::NONE)));
+		}
+		else if (event.wheel.y < 0)
+		{
+			_bindableMap =
+			    static_cast<BindableActionMap>(static_cast<uint64_t>(_bindableMap) |
+			                                   static_cast<uint64_t>(_mouseWheelBinding[1].value_or(BindableActionMap::NONE)));
+		}
+	}
+	else if (event.type == SDL_KEYUP)
+	{
+		if (_keyboardBindings.contains(event.key.keysym.scancode))
+		{
+			_bindableMap =
+			    static_cast<BindableActionMap>(static_cast<uint64_t>(_bindableMap) &
+			                                   ~static_cast<uint64_t>(_keyboardModBindings[event.key.keysym.scancode].second));
+			_bindableMap = static_cast<BindableActionMap>(static_cast<uint64_t>(_bindableMap) &
+			                                              ~static_cast<uint64_t>(_keyboardBindings[event.key.keysym.scancode]));
+		}
+	}
+	else if (event.type == SDL_MOUSEBUTTONUP && (event.button.button & SDL_BUTTON(SDL_BUTTON_LEFT)) != 0 &&
+	         event.button.clicks == 2)
+	{
+		_unbindableMap = static_cast<UnbindableActionMap>(static_cast<uint8_t>(_unbindableMap) &
+		                                                  ~static_cast<uint8_t>(UnbindableActionMap::DOUBLE_CLICK));
+	}
+	else if (event.type == SDL_MOUSEBUTTONUP)
+	{
+		if (_mouseBindings.contains(event.button.button))
+		{
+			_bindableMap = static_cast<BindableActionMap>(
+			    static_cast<uint64_t>(_bindableMap) & ~static_cast<uint64_t>(_mouseModBindings[event.button.button].second));
+			_bindableMap = static_cast<BindableActionMap>(static_cast<uint64_t>(_bindableMap) &
+			                                              ~static_cast<uint64_t>(_mouseBindings[event.button.button]));
+		}
+	}
+}

--- a/src/Input/GameActionMap.h
+++ b/src/Input/GameActionMap.h
@@ -15,6 +15,7 @@
 
 #include <SDL_keyboard.h>
 #include <SDL_mouse.h>
+#include <glm/vec3.hpp>
 
 #include "GameActionMapInterface.h"
 
@@ -40,6 +41,7 @@ public:
 	bool GetUnbindableRepeat(UnbindableActionMap action) const final;
 	glm::uvec2 GetMousePosition() const final;
 	glm::ivec2 GetMouseDelta() const final;
+	std::array<std::optional<glm::vec3>, 2> GetHandPositions() const final;
 
 	void Frame() final;
 	void ProcessEvent(const SDL_Event& event) final;

--- a/src/Input/GameActionMap.h
+++ b/src/Input/GameActionMap.h
@@ -1,0 +1,49 @@
+/******************************************************************************
+ * Copyright (c) 2018-2024 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *******************************************************************************/
+
+#pragma once
+
+#include <array>
+#include <optional>
+#include <unordered_map>
+
+#include <SDL_keyboard.h>
+#include <SDL_mouse.h>
+
+#include "GameActionMapInterface.h"
+
+#if !defined(LOCATOR_IMPLEMENTATIONS)
+#warning "Locator interface implementations should only be included in Locator.cpp"
+#endif
+
+namespace openblack::input
+{
+class GameActionMap final: public GameActionInterface
+{
+
+public:
+	GameActionMap();
+	GameActionMap(const GameActionMap&) = delete;
+	GameActionMap& operator=(const GameActionMap&) = delete;
+
+	bool GetBindable(BindableActionMap action) const final;
+	bool GetUnbindable(UnbindableActionMap action) const final;
+	void Frame() final;
+	void ProcessEvent(const SDL_Event& event) final;
+
+private:
+	BindableActionMap _bindableMap = BindableActionMap::NONE;
+	UnbindableActionMap _unbindableMap = UnbindableActionMap::NONE;
+	std::unordered_map<SDL_Keycode, std::pair<SDL_Keymod, BindableActionMap>> _keyboardModBindings;
+	std::unordered_map<SDL_Keycode, BindableActionMap> _keyboardBindings;
+	std::unordered_map<uint8_t /*mousebutton*/, BindableActionMap> _mouseBindings;
+	std::unordered_map<uint8_t /*mousebutton*/, std::pair<SDL_Keymod, BindableActionMap>> _mouseModBindings;
+	std::array<std::optional<BindableActionMap>, 2> _mouseWheelBinding; // up, down
+};
+} // namespace openblack::input

--- a/src/Input/GameActionMap.h
+++ b/src/Input/GameActionMap.h
@@ -34,12 +34,19 @@ public:
 
 	bool GetBindable(BindableActionMap action) const final;
 	bool GetUnbindable(UnbindableActionMap action) const final;
+	bool GetBindableChanged(BindableActionMap action) const final;
+	bool GetUnbindableChanged(UnbindableActionMap action) const final;
+	bool GetBindableRepeat(BindableActionMap action) const final;
+	bool GetUnbindableRepeat(UnbindableActionMap action) const final;
+
 	void Frame() final;
 	void ProcessEvent(const SDL_Event& event) final;
 
 private:
 	BindableActionMap _bindableMap = BindableActionMap::NONE;
 	UnbindableActionMap _unbindableMap = UnbindableActionMap::NONE;
+	BindableActionMap _bindableMapPrevious = BindableActionMap::NONE;
+	UnbindableActionMap _unbindableMapPrevious = UnbindableActionMap::NONE;
 	std::unordered_map<SDL_Keycode, std::pair<SDL_Keymod, BindableActionMap>> _keyboardModBindings;
 	std::unordered_map<SDL_Keycode, BindableActionMap> _keyboardBindings;
 	std::unordered_map<uint8_t /*mousebutton*/, BindableActionMap> _mouseBindings;

--- a/src/Input/GameActionMap.h
+++ b/src/Input/GameActionMap.h
@@ -38,6 +38,8 @@ public:
 	bool GetUnbindableChanged(UnbindableActionMap action) const final;
 	bool GetBindableRepeat(BindableActionMap action) const final;
 	bool GetUnbindableRepeat(UnbindableActionMap action) const final;
+	glm::uvec2 GetMousePosition() const final;
+	glm::ivec2 GetMouseDelta() const final;
 
 	void Frame() final;
 	void ProcessEvent(const SDL_Event& event) final;
@@ -52,5 +54,7 @@ private:
 	std::unordered_map<uint8_t /*mousebutton*/, BindableActionMap> _mouseBindings;
 	std::unordered_map<uint8_t /*mousebutton*/, std::pair<SDL_Keymod, BindableActionMap>> _mouseModBindings;
 	std::array<std::optional<BindableActionMap>, 2> _mouseWheelBinding; // up, down
+	glm::uvec2 _mousePosition;
+	glm::ivec2 _mouseDelta;
 };
 } // namespace openblack::input

--- a/src/Input/GameActionMap.h
+++ b/src/Input/GameActionMap.h
@@ -51,8 +51,9 @@ private:
 	UnbindableActionMap _unbindableMapPrevious = UnbindableActionMap::NONE;
 	std::unordered_map<SDL_Keycode, std::pair<SDL_Keymod, BindableActionMap>> _keyboardModBindings;
 	std::unordered_map<SDL_Keycode, BindableActionMap> _keyboardBindings;
-	std::unordered_map<uint8_t /*mousebutton*/, BindableActionMap> _mouseBindings;
-	std::unordered_map<uint8_t /*mousebutton*/, std::pair<SDL_Keymod, BindableActionMap>> _mouseModBindings;
+	std::unordered_map<int /*mousebutton*/, BindableActionMap> _mouseBindings;
+	std::unordered_map<int /*mousebutton*/, std::pair<SDL_Keymod, BindableActionMap>> _mouseModBindings;
+	uint8_t _currentMouseButtons = 0;
 	std::array<std::optional<BindableActionMap>, 2> _mouseWheelBinding; // up, down
 	glm::uvec2 _mousePosition;
 	glm::ivec2 _mouseDelta;

--- a/src/Input/GameActionMapInterface.h
+++ b/src/Input/GameActionMapInterface.h
@@ -13,6 +13,8 @@
 
 #include <variant>
 
+#include <glm/vec2.hpp>
+
 union SDL_Event;
 
 namespace openblack::input
@@ -182,6 +184,8 @@ public:
 	[[nodiscard]] virtual bool GetUnbindableChanged(UnbindableActionMap action) const = 0;
 	[[nodiscard]] virtual bool GetBindableRepeat(BindableActionMap action) const = 0;
 	[[nodiscard]] virtual bool GetUnbindableRepeat(UnbindableActionMap action) const = 0;
+	[[nodiscard]] virtual glm::uvec2 GetMousePosition() const = 0;
+	[[nodiscard]] virtual glm::ivec2 GetMouseDelta() const = 0;
 
 	virtual void Frame() = 0;
 	virtual void ProcessEvent(const SDL_Event& event) = 0;

--- a/src/Input/GameActionMapInterface.h
+++ b/src/Input/GameActionMapInterface.h
@@ -65,6 +65,7 @@ enum class UnbindableActionMap : uint8_t
 {
 	NONE                   = 0b00000000,
 	DOUBLE_CLICK           = 0b00000001,
+	TWO_BUTTON_CLICK       = 0b00000010, // Is in the bindable menu in vanilla but in practice it is not.
 };
 using ActionMap = std::variant<BindableActionMap, UnbindableActionMap>;
 // clang-format on

--- a/src/Input/GameActionMapInterface.h
+++ b/src/Input/GameActionMapInterface.h
@@ -11,9 +11,12 @@
 
 #include <cstdint>
 
+#include <array>
+#include <optional>
 #include <variant>
 
 #include <glm/vec2.hpp>
+#include <glm/vec3.hpp>
 
 union SDL_Event;
 
@@ -189,6 +192,7 @@ public:
 	[[nodiscard]] virtual bool GetUnbindableRepeat(UnbindableActionMap action) const = 0;
 	[[nodiscard]] virtual glm::uvec2 GetMousePosition() const = 0;
 	[[nodiscard]] virtual glm::ivec2 GetMouseDelta() const = 0;
+	[[nodiscard]] virtual std::array<std::optional<glm::vec3>, 2> GetHandPositions() const = 0;
 
 	virtual void Frame() = 0;
 	virtual void ProcessEvent(const SDL_Event& event) = 0;

--- a/src/Input/GameActionMapInterface.h
+++ b/src/Input/GameActionMapInterface.h
@@ -1,0 +1,126 @@
+/******************************************************************************
+ * Copyright (c) 2018-2024 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *******************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+#include <variant>
+
+union SDL_Event;
+
+namespace openblack::input
+{
+// clang-format off
+enum class BindableActionMap : uint64_t
+{
+	NONE                   = 0b000000000000000000000000000000000,
+	ALL                    = 0b111111111111111111111111111111111,
+	HELP                   = 0b000000000000000000000000000000001, // F1
+	MOVE                   = 0b000000000000000000000000000000010, // LMB
+	ACTION                 = 0b000000000000000000000000000000100, // RMB
+	ZOOM_OUT               = 0b000000000000000000000000000001000, // wheel down
+	ZOOM_IN                = 0b000000000000000000000000000010000, // wheel up
+	TALK                   = 0b000000000000000000000000000100000, // T
+	ZOOM_ON                = 0b000000000000000000000000001000000, // ctrl + arrows / lmb + rmb + mouse_motion
+	MOVE_LEFT              = 0b000000000000000000000000010000000, // left
+	MOVE_RIGHT             = 0b000000000000000000000000100000000, // right
+	MOVE_FORWARDS          = 0b000000000000000000000001000000000, // up
+	MOVE_BACKWARDS         = 0b000000000000000000000010000000000, // down
+	TILT_UP                = 0b000000000000000000000100000000000, // a
+	TILT_DOWN              = 0b000000000000000000001000000000000, // q
+	ROTATE_LEFT            = 0b000000000000000000010000000000000, // z
+	ROTATE_RIGHT           = 0b000000000000000000100000000000000, // u
+	ROTATE_ON              = 0b000000000000000001000000000000000, // shift
+	ROTATE_AROUND_MOUSE_ON = 0b000000000000000010000000000000000, // mmb
+	ZOOM_TO_TEMPLE         = 0b000000000000000100000000000000000, // space
+	ZOOM_TO_CREATURE       = 0b000000000000001000000000000000000, // c
+	ZOOM_TO_REALM          = 0b000000000000010000000000000000000, // f_3
+	ZOOM_TO_INSIDE_TEMPLE  = 0b000000000000100000000000000000000, // f_4
+	ZOOM_TO_CREATURE_ROOM  = 0b000000000001000000000000000000000, // f_5
+	ZOOM_TO_CHALLENGE_ROOM = 0b000000000010000000000000000000000, // f_6
+	ZOOM_TO_SAVE_GAME_ROOM = 0b000000000100000000000000000000000, // f_7
+	ZOOM_TO_OPTIONS_ROOM   = 0b000000001000000000000000000000000, // f_8
+	ZOOM_TO_LIBRARY        = 0b000000010000000000000000000000000, // f_9
+	LEASH_UNLEASH_CREATURE = 0b000000100000000000000000000000000, // l
+	SHOW_VILLAGER_NAMES    = 0b000001000000000000000000000000000, // n
+	SHOW_VILLAGER_DETAILS  = 0b000010000000000000000000000000000, // s
+	QUICK_SAVE             = 0b000100000000000000000000000000000, // ctrl + s
+	QUICK_LOAD             = 0b001000000000000000000000000000000, // ctrl + l
+	PREVIOUS_LEASH         = 0b010000000000000000000000000000000, // v
+	NEXT_LEASH             = 0b100000000000000000000000000000000, // B
+};
+enum class UnbindableActionMap : uint8_t
+{
+	NONE                   = 0b00000000,
+	DOUBLE_CLICK           = 0b00000001,
+};
+using ActionMap = std::variant<BindableActionMap, UnbindableActionMap>;
+// clang-format on
+
+class GameActionInterface
+{
+public:
+	template <typename... Args>
+	    requires(... && (std::is_same_v<Args, BindableActionMap> || std::is_same_v<Args, UnbindableActionMap>))
+	[[nodiscard]] bool GetAny(Args... actions) const
+	{
+		BindableActionMap bindableAccumulator = BindableActionMap::NONE;
+		UnbindableActionMap unbindableAccumulator = UnbindableActionMap::NONE;
+
+		auto processArg = [&](auto&& arg) {
+			using T = std::decay_t<decltype(arg)>;
+			if constexpr (std::is_same_v<T, BindableActionMap>)
+			{
+				bindableAccumulator =
+				    static_cast<BindableActionMap>(static_cast<uint64_t>(bindableAccumulator) | static_cast<uint64_t>(arg));
+			}
+			else if constexpr (std::is_same_v<T, UnbindableActionMap>)
+			{
+				unbindableAccumulator =
+				    static_cast<UnbindableActionMap>(static_cast<uint8_t>(unbindableAccumulator) | static_cast<uint8_t>(arg));
+			}
+		};
+
+		(processArg(actions), ...);
+
+		return GetBindable(bindableAccumulator) || GetUnbindable(unbindableAccumulator);
+	}
+
+	template <typename... Args>
+	    requires(... && (std::is_same_v<Args, BindableActionMap> || std::is_same_v<Args, UnbindableActionMap>))
+	[[nodiscard]] bool GetAll(Args... actions) const
+	{
+		return (Get(actions) && ...);
+	}
+
+	[[nodiscard]] bool Get(ActionMap action) const
+	{
+		return std::visit(
+		    [&](auto&& arg) {
+			    using T = std::decay_t<decltype(arg)>;
+			    if constexpr (std::is_same_v<T, BindableActionMap>)
+			    {
+				    return GetBindable(arg);
+			    }
+			    else if constexpr (std::is_same_v<T, UnbindableActionMap>)
+			    {
+				    return GetUnbindable(arg);
+			    }
+		    },
+		    action);
+	}
+
+	[[nodiscard]] virtual bool GetBindable(BindableActionMap action) const = 0;
+	[[nodiscard]] virtual bool GetUnbindable(UnbindableActionMap action) const = 0;
+
+	virtual void Frame() = 0;
+	virtual void ProcessEvent(const SDL_Event& event) = 0;
+};
+} // namespace openblack::input

--- a/src/Input/GameActionMapInterface.h
+++ b/src/Input/GameActionMapInterface.h
@@ -79,6 +79,8 @@ class GameActionInterface
 	}
 
 public:
+	// clang-format is having trouble with requires
+	// clang-format off
 	template <typename... Args>
 	    requires(... && (std::is_same_v<Args, BindableActionMap> || std::is_same_v<Args, UnbindableActionMap>))
 	[[nodiscard]] bool GetAny(Args... actions) const
@@ -126,6 +128,7 @@ public:
 	{
 		return (GetRepeat(actions) && ...);
 	}
+	// clang-format on
 
 	[[nodiscard]] bool Get(ActionMap action) const
 	{

--- a/src/Locator.cpp
+++ b/src/Locator.cpp
@@ -29,6 +29,7 @@
 #include "ECS/Systems/Implementations/PlayerSystem.h"
 #include "ECS/Systems/Implementations/RenderingSystem.h"
 #include "ECS/Systems/Implementations/TownSystem.h"
+#include "Input/GameActionMap.h"
 #include "Resources/Resources.h"
 #include "Windowing/Sdl2WindowingSystem.h"
 #if __ANDROID__
@@ -52,6 +53,7 @@ using openblack::ecs::systems::PathfindingSystem;
 using openblack::ecs::systems::PlayerSystem;
 using openblack::ecs::systems::RenderingSystem;
 using openblack::ecs::systems::TownSystem;
+using openblack::input::GameActionMap;
 using openblack::resources::Resources;
 using openblack::windowing::DisplayMode;
 using openblack::windowing::Sdl2WindowingSystem;
@@ -81,6 +83,7 @@ void openblack::InitializeGame()
 		Locator::audio::emplace<AudioManagerNoOp>();
 	}
 	Locator::playerSystem::emplace<PlayerSystem>();
+	Locator::gameActionSystem::emplace<GameActionMap>();
 	Locator::rendereringSystem::emplace<RenderingSystem>();
 	Locator::entitiesRegistry::emplace<Registry>();
 	Locator::temple::emplace<TempleInterior>();

--- a/src/Locator.h
+++ b/src/Locator.h
@@ -32,6 +32,11 @@ namespace filesystem
 class FileSystemInterface;
 }
 
+namespace input
+{
+class GameActionInterface;
+}
+
 namespace resources
 {
 class ResourcesInterface;
@@ -72,6 +77,7 @@ struct Locator
 	using rng = entt::locator<RandomNumberManagerInterface>;
 	using terrainSystem = entt::locator<LandIslandInterface>;
 	using audio = entt::locator<audio::AudioManagerInterface>;
+	using gameActionSystem = entt::locator<input::GameActionInterface>;
 	using rendereringSystem = entt::locator<ecs::systems::RenderingSystemInterface>;
 	using dynamicsSystem = entt::locator<ecs::systems::DynamicsSystemInterface>;
 	using cameraBookmarkSystem = entt::locator<ecs::systems::CameraBookmarkSystemInterface>;


### PR DESCRIPTION
This PR is the first in two or more parts for re-doing the camera controller model.

This bit brings the vanilla input mapping as a service.
The part for rebinding keys is not yet done. This would require a menu, defined Key names and icons and the ability to save and fetch them from the system like vanilla (#293 is close but is using a totally new input mapping strategy).

Vanilla has a total of 64 inputs that can be bound but it also has inputs that can't be rebound such as double clicking. There is also mouse position and delta.

As a proof of concept, I re-worked the current camera to use the input map and no longer use SDL2. The result works as before but the code is far from elegant since it was written with the event callbacks in mind. Since moving the camera up and down and using the ctrl key is not in the original keymapping, I re-assigned moving up and down to `SPACE` and `SHIFT + SPACE`

The Camera model will be completely re-written in a future PR.

I'm using contracts from C++20 and variants from C++17.