### PR TITLE
CI: Restore annotations for CMake errors/warnings

### DIFF
--- a/.github/workflows/ci-cross-compile.yml
+++ b/.github/workflows/ci-cross-compile.yml
@@ -3,7 +3,6 @@ on:
   pull_request_target:
   push:
     tags:
-      - '*'
     branches:
       - 'master'
       - 'ci-tests/**'  # Branch namespace can be used to test changes to test before going to master
@@ -24,25 +23,7 @@ jobs:
         #     preset: ninja-multi-vcpkg
         #     triplet: x86-windows
 
-    env:
-      EMSDK: '/tmp/emsdk'
-      ANDROID_NDK_HOME: '/usr/local/lib/android/sdk/ndk/23.2.8568313'
-      # Indicates the location of the vcpkg as a Git submodule of the project repository.
-      VCPKG_ROOT: ${{ github.workspace }}/vcpkg
-      # Tells vcpkg where binary packages are stored.
-      VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg/bincache
-      # Let's use GitHub Action cache as storage for the vcpkg Binary Caching feature.
-      VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
-
     steps:
-      # Set env vars needed for vcpkg to leverage the GitHub Action cache as a storage
-      # for Binary Caching.
-      - uses: actions/github-script@v6
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
@@ -67,52 +48,46 @@ jobs:
           ./emsdk activate latest
         if: matrix.preset == 'emscripten-vcpkg'
 
-      - name: "Create directory '${{ env.VCPKG_DEFAULT_BINARY_CACHE }}'"
-        run: mkdir -p $VCPKG_DEFAULT_BINARY_CACHE
-        shell: bash
-
       # Setup the build machine with the most recent versions of CMake and Ninja. Both are cached if not already: on subsequent runs both will be quickly restored from GitHub cache service.
       - uses: lukka/get-cmake@latest
 
-      # Restore vcpkg from the GitHub Action cache service. Note that packages are restored by vcpkg's binary caching
-      # when it is being run afterwards by CMake.
-      - name: Restore vcpkg
-        uses: actions/cache@v3
+      - name: Restore artifacts, or setup vcpkg for building artifacts
+        uses: lukka/run-vcpkg@v10
+        id: runvcpkg
         with:
-          # The first path is the location of vcpkg: it contains the vcpkg executable and data files, as long as the
-          # built package archives (aka binary cache) which are located by VCPKG_DEFAULT_BINARY_CACHE env var.
-          # The other paths starting with '!' are exclusions: they contain termporary files generated during the build of the installed packages.
-          path: |
-            ${{ env.VCPKG_ROOT }}
-            !${{ env.VCPKG_ROOT }}/buildtrees
-            !${{ env.VCPKG_ROOT }}/packages
-            !${{ env.VCPKG_ROOT }}/downloads
-            !${{ env.VCPKG_ROOT }}/installed
-          # The key is composed in a way that it gets properly invalidated whenever a different version of vcpkg is being used.
-          key: |
-            ${{ hashFiles( '.git/modules/vcpkg/HEAD' )}}
+          vcpkgJsonGlob: 'vcpkg.json'
+          # Prevent all ubuntu-latest and windows-latest builds from having the same key
+          appendedCacheKey: ${{matrix.preset}}${{matrix.triplet}}
 
-      # On Windows runners, let's ensure to have the Developer Command Prompt environment setup correctly.
-      # As used here the Developer Command Prompt created is targeting x64 and using the default the Windows SDK.
-      - uses: ilammy/msvc-dev-cmd@v1
+      - name: Configure CMake+vcpkg.
+        uses: lukka/run-cmake@v10
+        with:
+          configurePreset: '${{ matrix.preset }}'
+          configurePresetCmdString: "[`--preset`, `$[env.CONFIGURE_PRESET_NAME]`, `-DOPENBLACK_WARNINGS_AS_ERRORS=ON`]"
 
-      # Run CMake to generate Ninja project files, using the vcpkg's toolchain file to resolve and install
-      # the dependencies as specified in vcpkg.json. Note that the vcpkg's toolchain is specified
-      # in the CMakePresets.json file.
-      # This step also runs vcpkg with Binary Caching leveraging GitHub Action cache to
-      # store the built packages artifacts.
-      - name: Restore from cache the dependencies and generate project files
-        run: cmake --preset ${{ matrix.preset }} -DOPENBLACK_WARNINGS_AS_ERRORS=ON ${{ matrix.triplet && '-DVCPKG_TARGET_TRIPLET=' }}${{ matrix.triplet }}
+      - name: Run CMake+vcpkg to build (Debug).
+        uses: lukka/run-cmake@v10
+        with:
+          configurePreset: '${{ matrix.preset }}'
+          configurePresetCmdString: "[`--preset`, `$[env.CONFIGURE_PRESET_NAME]`, `-DOPENBLACK_WARNINGS_AS_ERRORS=ON`]"
+          buildPreset: '${{ matrix.preset }}-debug'
 
-
-      - name: Build (Debug configuration)
-        run: cmake --build --preset ${{ matrix.preset }}-debug
-
-      - name: Build (Release configuration)
-        run: cmake --build --preset ${{ matrix.preset }}-release
+      - name: Run CMake+vcpkg to build (Release).
+        uses: lukka/run-cmake@v10
+        with:
+          configurePreset: '${{ matrix.preset }}'
+          configurePresetCmdString: "[`--preset`, `$[env.CONFIGURE_PRESET_NAME]`, `-DOPENBLACK_WARNINGS_AS_ERRORS=ON`]"
+          buildPreset: '${{ matrix.preset }}-release'
 
       - uses: actions/upload-artifact@v3
         with:
           name: openblack-${{ matrix.triplet || matrix.preset }}-${{github.sha}}
           path: cmake-build-presets/${{ matrix.preset }}/bin
           if-no-files-found: error
+
+    env:
+      VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}
+      EMSDK: '/tmp/emsdk'
+      ANDROID_NDK_HOME: '/usr/local/lib/android/sdk/ndk/23.2.8568313'
+      CXX: ''
+      CC: ''

--- a/.github/workflows/ci-cross-compile.yml
+++ b/.github/workflows/ci-cross-compile.yml
@@ -60,20 +60,20 @@ jobs:
           appendedCacheKey: ${{matrix.preset}}${{matrix.triplet}}
 
       - name: Configure CMake+vcpkg.
-        uses: lukka/run-cmake@v10
+        uses: lukka/run-cmake@main
         with:
           configurePreset: '${{ matrix.preset }}'
           configurePresetCmdString: "[`--preset`, `$[env.CONFIGURE_PRESET_NAME]`, `-DOPENBLACK_WARNINGS_AS_ERRORS=ON`]"
 
       - name: Run CMake+vcpkg to build (Debug).
-        uses: lukka/run-cmake@v10
+        uses: lukka/run-cmake@main
         with:
           configurePreset: '${{ matrix.preset }}'
           configurePresetCmdString: "[`--preset`, `$[env.CONFIGURE_PRESET_NAME]`, `-DOPENBLACK_WARNINGS_AS_ERRORS=ON`]"
           buildPreset: '${{ matrix.preset }}-debug'
 
       - name: Run CMake+vcpkg to build (Release).
-        uses: lukka/run-cmake@v10
+        uses: lukka/run-cmake@main
         with:
           configurePreset: '${{ matrix.preset }}'
           configurePresetCmdString: "[`--preset`, `$[env.CONFIGURE_PRESET_NAME]`, `-DOPENBLACK_WARNINGS_AS_ERRORS=ON`]"
@@ -87,6 +87,7 @@ jobs:
 
     env:
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}
+      VCPKG_ROOT: ${{github.workspace}}/vcpkg
       EMSDK: '/tmp/emsdk'
       ANDROID_NDK_HOME: '/usr/local/lib/android/sdk/ndk/23.2.8568313'
       CXX: ''

--- a/.github/workflows/ci-cross-compile.yml
+++ b/.github/workflows/ci-cross-compile.yml
@@ -3,6 +3,7 @@ on:
   pull_request_target:
   push:
     tags:
+      - '*'
     branches:
       - 'master'
       - 'ci-tests/**'  # Branch namespace can be used to test changes to test before going to master
@@ -51,32 +52,29 @@ jobs:
       # Setup the build machine with the most recent versions of CMake and Ninja. Both are cached if not already: on subsequent runs both will be quickly restored from GitHub cache service.
       - uses: lukka/get-cmake@latest
 
-      - name: Restore artifacts, or setup vcpkg for building artifacts
-        uses: lukka/run-vcpkg@v10
-        id: runvcpkg
+      - name: Restore from cache and setup vcpkg executable and data files.
+        uses: lukka/run-vcpkg@v11
         with:
           vcpkgJsonGlob: 'vcpkg.json'
-          # Prevent all ubuntu-latest and windows-latest builds from having the same key
-          appendedCacheKey: ${{matrix.preset}}${{matrix.triplet}}
 
-      - name: Configure CMake+vcpkg.
+      - name: Run CMake+vcpkg to build packages.
+        uses: lukka/run-cmake@main
+        with:
+          configurePreset: 'ninja-multi-vcpkg'
+          configurePresetAdditionalArgs: "['-DOPENBLACK_WARNINGS_AS_ERRORS=ON']"
+
+      - name: Run CMake+Ninja to build the code (Debug).
         uses: lukka/run-cmake@main
         with:
           configurePreset: '${{ matrix.preset }}'
-          configurePresetCmdString: "[`--preset`, `$[env.CONFIGURE_PRESET_NAME]`, `-DOPENBLACK_WARNINGS_AS_ERRORS=ON`]"
-
-      - name: Run CMake+vcpkg to build (Debug).
-        uses: lukka/run-cmake@main
-        with:
-          configurePreset: '${{ matrix.preset }}'
-          configurePresetCmdString: "[`--preset`, `$[env.CONFIGURE_PRESET_NAME]`, `-DOPENBLACK_WARNINGS_AS_ERRORS=ON`]"
+          configurePresetAdditionalArgs: "['-DOPENBLACK_WARNINGS_AS_ERRORS=ON']"
           buildPreset: '${{ matrix.preset }}-debug'
 
-      - name: Run CMake+vcpkg to build (Release).
+      - name: Run CMake+vcpkg to build the code (Release).
         uses: lukka/run-cmake@main
         with:
           configurePreset: '${{ matrix.preset }}'
-          configurePresetCmdString: "[`--preset`, `$[env.CONFIGURE_PRESET_NAME]`, `-DOPENBLACK_WARNINGS_AS_ERRORS=ON`]"
+          configurePresetAdditionalArgs: "['-DOPENBLACK_WARNINGS_AS_ERRORS=ON']"
           buildPreset: '${{ matrix.preset }}-release'
 
       - uses: actions/upload-artifact@v3
@@ -90,5 +88,3 @@ jobs:
       VCPKG_ROOT: ${{github.workspace}}/vcpkg
       EMSDK: '/tmp/emsdk'
       ANDROID_NDK_HOME: '/usr/local/lib/android/sdk/ndk/23.2.8568313'
-      CXX: ''
-      CC: ''

--- a/.github/workflows/ci-vcpkg.yml
+++ b/.github/workflows/ci-vcpkg.yml
@@ -3,11 +3,9 @@ on:
   pull_request_target:
   push:
     tags:
-      - '*'
     branches:
       - 'master'
       - 'ci-tests/**'  # Branch namespace can be used to test changes to test before going to master
-
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -30,25 +28,8 @@ jobs:
           - os: ubuntu-20.04
             cc: clang
             cxx: clang++
-    env:
-      CC: ${{ matrix.cc }}
-      CXX: ${{ matrix.cxx }}
-      # Indicates the location of the vcpkg as a Git submodule of the project repository.
-      VCPKG_ROOT: ${{ github.workspace }}/vcpkg
-      # Tells vcpkg where binary packages are stored.
-      VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg/bincache
-      # Let's use GitHub Action cache as storage for the vcpkg Binary Caching feature.
-      VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
 
     steps:
-      # Set env vars needed for vcpkg to leverage the GitHub Action cache as a storage
-      # for Binary Caching.
-      - uses: actions/github-script@v6
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
@@ -70,54 +51,48 @@ jobs:
           brew install pkg-config
         if: startsWith(matrix.os, 'macos')
 
-      - name: "Create directory '${{ env.VCPKG_DEFAULT_BINARY_CACHE }}'"
-        run: mkdir -p $VCPKG_DEFAULT_BINARY_CACHE
-        shell: bash
-
       # Setup the build machine with the most recent versions of CMake and Ninja. Both are cached if not already: on subsequent runs both will be quickly restored from GitHub cache service.
       - uses: lukka/get-cmake@latest
 
-      # Restore vcpkg from the GitHub Action cache service. Note that packages are restored by vcpkg's binary caching
-      # when it is being run afterwards by CMake.
-      - name: Restore vcpkg
-        uses: actions/cache@v3
+      - name: Restore artifacts, or setup vcpkg for building artifacts
+        uses: lukka/run-vcpkg@v10
+        id: runvcpkg
         with:
-          # The first path is the location of vcpkg: it contains the vcpkg executable and data files, as long as the
-          # built package archives (aka binary cache) which are located by VCPKG_DEFAULT_BINARY_CACHE env var.
-          # The other paths starting with '!' are exclusions: they contain termporary files generated during the build of the installed packages.
-          path: |
-            ${{ env.VCPKG_ROOT }}
-            !${{ env.VCPKG_ROOT }}/buildtrees
-            !${{ env.VCPKG_ROOT }}/packages
-            !${{ env.VCPKG_ROOT }}/downloads
-            !${{ env.VCPKG_ROOT }}/installed
-          # The key is composed in a way that it gets properly invalidated whenever a different version of vcpkg is being used.
-          key: |
-            ${{ hashFiles( '.git/modules/vcpkg/HEAD' )}}
+          vcpkgJsonGlob: 'vcpkg.json'
+          # Prevent ubuntu-latest and ubuntu-latest (clang) from having the same key
+          appendedCacheKey: ${{matrix.cc}}
+            # doNotCache: true
 
-      # On Windows runners, let's ensure to have the Developer Command Prompt environment setup correctly.
-      # As used here the Developer Command Prompt created is targeting x64 and using the default the Windows SDK.
-      - uses: ilammy/msvc-dev-cmd@v1
+      - name: Configure CMake+vcpkg+Ninja to generate.
+        uses: lukka/run-cmake@v10
+        with:
+          configurePreset: 'ninja-multi-vcpkg'
+          configurePresetCmdString: "[`--preset`, `$[env.CONFIGURE_PRESET_NAME]`, `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`, `-DOPENBLACK_WARNINGS_AS_ERRORS=ON`]"
+        env:
+          CC: ${{matrix.cc}}
+          CXX: ${{matrix.cxx}}
 
-      # Run CMake to generate Ninja project files, using the vcpkg's toolchain file to resolve and install
-      # the dependencies as specified in vcpkg.json. Note that the vcpkg's toolchain is specified
-      # in the CMakePresets.json file.
-      # This step also runs vcpkg with Binary Caching leveraging GitHub Action cache to
-      # store the built packages artifacts.
-      - name: Restore from cache the dependencies and generate project files
-        run: cmake --preset ninja-multi-vcpkg -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DOPENBLACK_WARNINGS_AS_ERRORS=ON
+      - name: Run CMake+vcpkg+Ninja+CTest to build/test (Debug).
+        uses: lukka/run-cmake@v10
+        with:
+          configurePreset: 'ninja-multi-vcpkg'
+          configurePresetCmdString: "[`--preset`, `$[env.CONFIGURE_PRESET_NAME]`, `-DOPENBLACK_WARNINGS_AS_ERRORS=ON`]"
+          buildPreset: 'ninja-multi-vcpkg-debug'
+          testPreset: 'ninja-multi-vcpkg-debug'
+        env:
+          CC: ${{matrix.cc}}
+          CXX: ${{matrix.cxx}}
 
-      - name: Build (Debug configuration)
-        run: cmake --build --preset ninja-multi-vcpkg-debug
-
-      - name: Build (Release configuration)
-        run: cmake --build --preset ninja-multi-vcpkg-release
-
-      - name: Test (Debug configuration)
-        run: ctest --preset ninja-multi-vcpkg-debug
-
-      - name: Test (Release configuration)
-        run: ctest --preset ninja-multi-vcpkg-release
+      - name: Run CMake+vcpkg+Ninja+CTest to build/test (Release).
+        uses: lukka/run-cmake@v10
+        with:
+          configurePreset: 'ninja-multi-vcpkg'
+          configurePresetCmdString: "[`--preset`, `$[env.CONFIGURE_PRESET_NAME]`, `-DOPENBLACK_WARNINGS_AS_ERRORS=ON`]"
+          buildPreset: 'ninja-multi-vcpkg-release'
+          testPreset: 'ninja-multi-vcpkg-release'
+        env:
+          CC: ${{matrix.cc}}
+          CXX: ${{matrix.cxx}}
 
       - name: Upload compile database and system includes
         uses: actions/upload-artifact@v3
@@ -148,6 +123,10 @@ jobs:
             cmake-build-presets/ninja-multi-vcpkg/test/mock/Scripts
             cmake-build-presets/ninja-multi-vcpkg/test/mock/Data
           if-no-files-found: error
+
+    env:
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
 
   clang-tidy:
     needs: build

--- a/.github/workflows/ci-vcpkg.yml
+++ b/.github/workflows/ci-vcpkg.yml
@@ -3,6 +3,7 @@ on:
   pull_request_target:
   push:
     tags:
+      - '*'
     branches:
       - 'master'
       - 'ci-tests/**'  # Branch namespace can be used to test changes to test before going to master
@@ -54,45 +55,32 @@ jobs:
       # Setup the build machine with the most recent versions of CMake and Ninja. Both are cached if not already: on subsequent runs both will be quickly restored from GitHub cache service.
       - uses: lukka/get-cmake@latest
 
-      - name: Restore artifacts, or setup vcpkg for building artifacts
-        uses: lukka/run-vcpkg@v10
-        id: runvcpkg
+      - name: Restore from cache and setup vcpkg executable and data files.
+        uses: lukka/run-vcpkg@v11
         with:
           vcpkgJsonGlob: 'vcpkg.json'
-          # Prevent ubuntu-latest and ubuntu-latest (clang) from having the same key
-          appendedCacheKey: ${{matrix.cc}}
-            # doNotCache: true
 
-      - name: Configure CMake+vcpkg+Ninja to generate.
+      - name: Run CMake+vcpkg to build packages.
         uses: lukka/run-cmake@main
         with:
           configurePreset: 'ninja-multi-vcpkg'
-          configurePresetCmdString: "[`--preset`, `$[env.CONFIGURE_PRESET_NAME]`, `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`, `-DOPENBLACK_WARNINGS_AS_ERRORS=ON`]"
-        env:
-          CC: ${{matrix.cc}}
-          CXX: ${{matrix.cxx}}
+          configurePresetAdditionalArgs: "['-DCMAKE_EXPORT_COMPILE_COMMANDS=ON', '-DOPENBLACK_WARNINGS_AS_ERRORS=ON']"
 
-      - name: Run CMake+vcpkg+Ninja+CTest to build/test (Debug).
+      - name: Run CMake+Ninja+CTest to build/test the code (Debug).
         uses: lukka/run-cmake@main
         with:
           configurePreset: 'ninja-multi-vcpkg'
-          configurePresetCmdString: "[`--preset`, `$[env.CONFIGURE_PRESET_NAME]`, `-DOPENBLACK_WARNINGS_AS_ERRORS=ON`]"
+          configurePresetAdditionalArgs: "['-DOPENBLACK_WARNINGS_AS_ERRORS=ON']"
           buildPreset: 'ninja-multi-vcpkg-debug'
           testPreset: 'ninja-multi-vcpkg-debug'
-        env:
-          CC: ${{matrix.cc}}
-          CXX: ${{matrix.cxx}}
 
-      - name: Run CMake+vcpkg+Ninja+CTest to build/test (Release).
+      - name: Run CMake+Ninja+CTest to build packages and build/test the code (Release).
         uses: lukka/run-cmake@main
         with:
+          configurePresetAdditionalArgs: "['-DOPENBLACK_WARNINGS_AS_ERRORS=ON']"
           configurePreset: 'ninja-multi-vcpkg'
-          configurePresetCmdString: "[`--preset`, `$[env.CONFIGURE_PRESET_NAME]`, `-DOPENBLACK_WARNINGS_AS_ERRORS=ON`]"
           buildPreset: 'ninja-multi-vcpkg-release'
           testPreset: 'ninja-multi-vcpkg-release'
-        env:
-          CC: ${{matrix.cc}}
-          CXX: ${{matrix.cxx}}
 
       - name: Upload compile database and system includes
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci-vcpkg.yml
+++ b/.github/workflows/ci-vcpkg.yml
@@ -64,7 +64,7 @@ jobs:
             # doNotCache: true
 
       - name: Configure CMake+vcpkg+Ninja to generate.
-        uses: lukka/run-cmake@v10
+        uses: lukka/run-cmake@main
         with:
           configurePreset: 'ninja-multi-vcpkg'
           configurePresetCmdString: "[`--preset`, `$[env.CONFIGURE_PRESET_NAME]`, `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`, `-DOPENBLACK_WARNINGS_AS_ERRORS=ON`]"
@@ -73,7 +73,7 @@ jobs:
           CXX: ${{matrix.cxx}}
 
       - name: Run CMake+vcpkg+Ninja+CTest to build/test (Debug).
-        uses: lukka/run-cmake@v10
+        uses: lukka/run-cmake@main
         with:
           configurePreset: 'ninja-multi-vcpkg'
           configurePresetCmdString: "[`--preset`, `$[env.CONFIGURE_PRESET_NAME]`, `-DOPENBLACK_WARNINGS_AS_ERRORS=ON`]"
@@ -84,7 +84,7 @@ jobs:
           CXX: ${{matrix.cxx}}
 
       - name: Run CMake+vcpkg+Ninja+CTest to build/test (Release).
-        uses: lukka/run-cmake@v10
+        uses: lukka/run-cmake@main
         with:
           configurePreset: 'ninja-multi-vcpkg'
           configurePresetCmdString: "[`--preset`, `$[env.CONFIGURE_PRESET_NAME]`, `-DOPENBLACK_WARNINGS_AS_ERRORS=ON`]"
@@ -127,6 +127,7 @@ jobs:
     env:
       CC: ${{ matrix.cc }}
       CXX: ${{ matrix.cxx }}
+      VCPKG_ROOT: ${{github.workspace}}/vcpkg
 
   clang-tidy:
     needs: build


### PR DESCRIPTION
Use `run-vcpkg@v11` for better caching and `run-cmake@main` for fixes to multi step build.