### PR TITLE
Update ClangFormat.cmake

### DIFF
--- a/CMakeModules/ClangFormat.cmake
+++ b/CMakeModules/ClangFormat.cmake
@@ -4,7 +4,7 @@
 # against all the src files. This should be used before making a pull request.
 # =======================================================================
 
-set(CLANG_FORMAT_POSTFIX "-12")
+set(CLANG_FORMAT_POSTFIX "-15")
 find_program(
   CLANG_FORMAT
   NAMES clang-format${CLANG_FORMAT_POSTFIX} clang-format


### PR DESCRIPTION
Just an update to the downloaded clang executable, since [3edb6cf](https://github.com/yuzu-emu/ext-windows-bin/commit/3edb6cfb82c89059b023dbe6e7e228cbc284f196) removed the one used by openblack.