### PR TITLE
CI: Update the license checker

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -149,5 +149,35 @@ jobs:
       - name: Add base repo to git config
         run: git remote add upstream ${{ github.event.pull_request.base.repo.html_url }}
         if: startsWith(github.event_name, 'pull_request')
+      - uses: denoland/setup-deno@main
+        with:
+          deno-version: v1.x
       - name: Check License Lines
-        uses: kt3k/license_checker@v1.0.6
+        run: deno run --allow-read https://deno.land/x/license_checker@v3.2.2/main.ts --quiet
+  
+  copyright-check-action-suggester:
+    name: license_checker fix suggester
+    runs-on: ubuntu-latest
+    needs: cmake-format-check
+    if: always() && startsWith(github.event_name, 'pull_request') && needs.copyright-check.result == 'failure'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: Add base repo to git config
+        run: git remote add upstream ${{ github.event.pull_request.base.repo.html_url }}
+        if: startsWith(github.event_name, 'pull_request')
+      - uses: denoland/setup-deno@main
+        with:
+          deno-version: v1.x
+      - name: Check License Lines
+        run: deno run --allow-read --allow-write https://deno.land/x/license_checker@v3.2.2/main.ts --quiet --inject
+      - run: git diff > license-check.patch
+      - uses: actions/upload-artifact@v2
+        with:
+          name: formatting-fix-${{github.sha}}
+          path: license-check.patch.patch
+      - uses: reviewdog/action-suggester@v1
+        with:
+          tool_name: license_checker

--- a/.licenserc.json
+++ b/.licenserc.json
@@ -1,16 +1,21 @@
 {
     "**/*.{h,cpp}": [
-        "/*****************************************************************************",
+        "/******************************************************************************",
         " * Copyright (c) 2018-2023 openblack developers",
         " *",
         " * For a complete list of all authors, please refer to contributors.md",
         " * Interested in contributing? Visit https://github.com/openblack/openblack",
         " *",
         " * openblack is licensed under the GNU General Public License version 3.",
-        " *****************************************************************************"
+        " *******************************************************************************/"
     ],
     "ignore": [
+        "android/",
+        "bw/",
         "externals/",
+        "vcpkg/",
+        "cmake-build-presets/",
+        "CMakeFiles/",
         "stb_image_write.h",
         "tiny_gltf.h"
     ]

--- a/apps/anmtool/anmtool.cpp
+++ b/apps/anmtool/anmtool.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include <cstdlib>
 

--- a/apps/l3dtool/l3dtool.cpp
+++ b/apps/l3dtool/l3dtool.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include <cstdlib>
 #include <cstring>

--- a/apps/lndtool/lndtool.cpp
+++ b/apps/lndtool/lndtool.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include <cstdlib>
 

--- a/apps/morphtool/morphtool.cpp
+++ b/apps/morphtool/morphtool.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include <cstdlib>
 

--- a/apps/packtool/packtool.cpp
+++ b/apps/packtool/packtool.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include <cassert>
 #include <cstdlib>

--- a/components/ScriptLibrary/include/LHVM/LHVM.h
+++ b/components/ScriptLibrary/include/LHVM/LHVM.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/components/ScriptLibrary/include/LHVM/OpcodeNames.h
+++ b/components/ScriptLibrary/include/LHVM/OpcodeNames.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/components/ScriptLibrary/include/LHVM/VMInstruction.h
+++ b/components/ScriptLibrary/include/LHVM/VMInstruction.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/components/ScriptLibrary/include/LHVM/VMScript.h
+++ b/components/ScriptLibrary/include/LHVM/VMScript.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/components/ScriptLibrary/include/LHVM/VMTask.h
+++ b/components/ScriptLibrary/include/LHVM/VMTask.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/components/ScriptLibrary/src/LHVM.cpp
+++ b/components/ScriptLibrary/src/LHVM.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "LHVM/LHVM.h"
 

--- a/components/anm/include/ANMFile.h
+++ b/components/anm/include/ANMFile.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/components/anm/src/ANMFile.cpp
+++ b/components/anm/src/ANMFile.cpp
@@ -1,12 +1,13 @@
-/*******************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *******************************************************************************
- *
+ *******************************************************************************/
+
+/*
  * The layout of a ANM File is as follows:
  *
  * - 84 byte header

--- a/components/l3d/include/L3DFile.h
+++ b/components/l3d/include/L3DFile.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/components/l3d/src/L3DFile.cpp
+++ b/components/l3d/src/L3DFile.cpp
@@ -5,8 +5,9 @@
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *******************************************************************************
- *
+ *******************************************************************************/
+
+/*
  * The layout of a L3D File is as follows:
  *
  * - 76 byte header, containing 19 ints

--- a/components/lnd/include/LNDFile.h
+++ b/components/lnd/include/LNDFile.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/components/lnd/src/LNDFile.cpp
+++ b/components/lnd/src/LNDFile.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 /*
  *

--- a/components/morph/include/MorphFile.h
+++ b/components/morph/include/MorphFile.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/components/morph/src/MorphFile.cpp
+++ b/components/morph/src/MorphFile.cpp
@@ -5,8 +5,9 @@
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *******************************************************************************
- *
+ *******************************************************************************/
+
+/*
  * The layout of a Morph Spec Text File is as follows:
  *
  * - 1 line with an int representing the spec version

--- a/components/pack/include/PackFile.h
+++ b/components/pack/include/PackFile.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/components/pack/src/PackFile.cpp
+++ b/components/pack/src/PackFile.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 /*
  *

--- a/src/3D/AllMeshes.cpp
+++ b/src/3D/AllMeshes.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "AllMeshes.h"
 

--- a/src/3D/AllMeshes.h
+++ b/src/3D/AllMeshes.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/3D/AxisAlignedBoundingBox.h
+++ b/src/3D/AxisAlignedBoundingBox.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/3D/Camera.cpp
+++ b/src/3D/Camera.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "Camera.h"
 

--- a/src/3D/Camera.h
+++ b/src/3D/Camera.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/3D/CreatureBody.cpp
+++ b/src/3D/CreatureBody.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "CreatureBody.h"
 

--- a/src/3D/CreatureBody.h
+++ b/src/3D/CreatureBody.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/3D/L3DAnim.cpp
+++ b/src/3D/L3DAnim.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "L3DAnim.h"
 

--- a/src/3D/L3DAnim.h
+++ b/src/3D/L3DAnim.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/3D/L3DMesh.cpp
+++ b/src/3D/L3DMesh.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "L3DMesh.h"
 

--- a/src/3D/L3DMesh.h
+++ b/src/3D/L3DMesh.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/3D/L3DSubMesh.cpp
+++ b/src/3D/L3DSubMesh.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "L3DSubMesh.h"
 

--- a/src/3D/L3DSubMesh.h
+++ b/src/3D/L3DSubMesh.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/3D/LandBlock.cpp
+++ b/src/3D/LandBlock.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "LandBlock.h"
 

--- a/src/3D/LandBlock.h
+++ b/src/3D/LandBlock.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "LandIsland.h"
 

--- a/src/3D/LandIsland.h
+++ b/src/3D/LandIsland.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/3D/Sky.cpp
+++ b/src/3D/Sky.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "Sky.h"
 

--- a/src/3D/Sky.h
+++ b/src/3D/Sky.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/3D/Water.cpp
+++ b/src/3D/Water.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "Water.h"
 

--- a/src/3D/Water.h
+++ b/src/3D/Water.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Common/Bitmap16B.cpp
+++ b/src/Common/Bitmap16B.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "Bitmap16B.h"
 

--- a/src/Common/Bitmap16B.h
+++ b/src/Common/Bitmap16B.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Common/EventManager.h
+++ b/src/Common/EventManager.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include <functional>
 #include <stdexcept>

--- a/src/Common/FileStream.cpp
+++ b/src/Common/FileStream.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "FileStream.h"
 

--- a/src/Common/FileStream.h
+++ b/src/Common/FileStream.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Common/FileSystem.cpp
+++ b/src/Common/FileSystem.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "FileSystem.h"
 

--- a/src/Common/FileSystem.h
+++ b/src/Common/FileSystem.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Common/IStream.h
+++ b/src/Common/IStream.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Common/MemoryStream.cpp
+++ b/src/Common/MemoryStream.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "MemoryStream.h"
 

--- a/src/Common/MemoryStream.h
+++ b/src/Common/MemoryStream.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Common/Queue.h
+++ b/src/Common/Queue.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include <atomic>
 #include <functional>

--- a/src/Common/RandomNumberManager.h
+++ b/src/Common/RandomNumberManager.h
@@ -5,7 +5,7 @@
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- ******************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Common/RandomNumberManagerProduction.cpp
+++ b/src/Common/RandomNumberManagerProduction.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "RandomNumberManagerProduction.h"
 

--- a/src/Common/RandomNumberManagerProduction.h
+++ b/src/Common/RandomNumberManagerProduction.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Common/RandomNumberManagerTesting.cpp
+++ b/src/Common/RandomNumberManagerTesting.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "RandomNumberManagerTesting.h"
 

--- a/src/Common/RandomNumberManagerTesting.h
+++ b/src/Common/RandomNumberManagerTesting.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Common/StringUtils.cpp
+++ b/src/Common/StringUtils.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "StringUtils.h"
 

--- a/src/Common/StringUtils.h
+++ b/src/Common/StringUtils.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Common/Zip.cpp
+++ b/src/Common/Zip.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "Zip.h"
 

--- a/src/Common/Zip.h
+++ b/src/Common/Zip.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Creature/CreatureMind.h
+++ b/src/Creature/CreatureMind.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Debug/Console.cpp
+++ b/src/Debug/Console.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "Console.h"
 

--- a/src/Debug/Console.h
+++ b/src/Debug/Console.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Debug/DebugWindow.cpp
+++ b/src/Debug/DebugWindow.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include <utility>
 

--- a/src/Debug/Gui.cpp
+++ b/src/Debug/Gui.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "Gui.h"
 

--- a/src/Debug/Gui.h
+++ b/src/Debug/Gui.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Debug/LHVMViewer.cpp
+++ b/src/Debug/LHVMViewer.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "LHVMViewer.h"
 

--- a/src/Debug/LHVMViewer.h
+++ b/src/Debug/LHVMViewer.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Debug/LandIsland.cpp
+++ b/src/Debug/LandIsland.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "LandIsland.h"
 

--- a/src/Debug/LandIsland.h
+++ b/src/Debug/LandIsland.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "Window.h"
 

--- a/src/Debug/MeshViewer.cpp
+++ b/src/Debug/MeshViewer.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "MeshViewer.h"
 

--- a/src/Debug/MeshViewer.h
+++ b/src/Debug/MeshViewer.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Debug/PathFinding.cpp
+++ b/src/Debug/PathFinding.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "PathFinding.h"
 

--- a/src/Debug/PathFinding.h
+++ b/src/Debug/PathFinding.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Debug/Profiler.cpp
+++ b/src/Debug/Profiler.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "Profiler.h"
 

--- a/src/Debug/Profiler.h
+++ b/src/Debug/Profiler.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Debug/TextureViewer.cpp
+++ b/src/Debug/TextureViewer.cpp
@@ -5,7 +5,7 @@
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- ******************************************************************************/
+ *******************************************************************************/
 
 #include "TextureViewer.h"
 

--- a/src/Debug/TextureViewer.h
+++ b/src/Debug/TextureViewer.h
@@ -5,7 +5,7 @@
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- ******************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Debug/Window.h
+++ b/src/Debug/Window.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Dynamics/LandBlockBulletMeshInterface.h
+++ b/src/Dynamics/LandBlockBulletMeshInterface.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Archetypes/AbodeArchetype.cpp
+++ b/src/ECS/Archetypes/AbodeArchetype.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "AbodeArchetype.h"
 

--- a/src/ECS/Archetypes/AbodeArchetype.h
+++ b/src/ECS/Archetypes/AbodeArchetype.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Archetypes/AnimatedStaticArchetype.cpp
+++ b/src/ECS/Archetypes/AnimatedStaticArchetype.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "AnimatedStaticArchetype.h"
 

--- a/src/ECS/Archetypes/AnimatedStaticArchetype.h
+++ b/src/ECS/Archetypes/AnimatedStaticArchetype.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Archetypes/BigForestArchetype.cpp
+++ b/src/ECS/Archetypes/BigForestArchetype.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "BigForestArchetype.h"
 

--- a/src/ECS/Archetypes/BigForestArchetype.h
+++ b/src/ECS/Archetypes/BigForestArchetype.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Archetypes/BonfireArchetype.cpp
+++ b/src/ECS/Archetypes/BonfireArchetype.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "BonfireArchetype.h"
 

--- a/src/ECS/Archetypes/BonfireArchetype.h
+++ b/src/ECS/Archetypes/BonfireArchetype.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Archetypes/CameraBookmarkArchetype.cpp
+++ b/src/ECS/Archetypes/CameraBookmarkArchetype.cpp
@@ -5,7 +5,7 @@
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- ******************************************************************************/
+ *******************************************************************************/
 
 #include "CameraBookmarkArchetype.h"
 

--- a/src/ECS/Archetypes/CameraBookmarkArchetype.h
+++ b/src/ECS/Archetypes/CameraBookmarkArchetype.h
@@ -5,7 +5,7 @@
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- ******************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Archetypes/CreatureArchetype.cpp
+++ b/src/ECS/Archetypes/CreatureArchetype.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "CreatureArchetype.h"
 

--- a/src/ECS/Archetypes/CreatureArchetype.h
+++ b/src/ECS/Archetypes/CreatureArchetype.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Archetypes/FeatureArchetype.cpp
+++ b/src/ECS/Archetypes/FeatureArchetype.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "FeatureArchetype.h"
 

--- a/src/ECS/Archetypes/FeatureArchetype.h
+++ b/src/ECS/Archetypes/FeatureArchetype.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Archetypes/FieldArchetype.cpp
+++ b/src/ECS/Archetypes/FieldArchetype.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "FieldArchetype.h"
 

--- a/src/ECS/Archetypes/FieldArchetype.h
+++ b/src/ECS/Archetypes/FieldArchetype.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Archetypes/HandArchetype.cpp
+++ b/src/ECS/Archetypes/HandArchetype.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "HandArchetype.h"
 

--- a/src/ECS/Archetypes/HandArchetype.h
+++ b/src/ECS/Archetypes/HandArchetype.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Archetypes/MobileObjectArchetype.cpp
+++ b/src/ECS/Archetypes/MobileObjectArchetype.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "MobileObjectArchetype.h"
 

--- a/src/ECS/Archetypes/MobileObjectArchetype.h
+++ b/src/ECS/Archetypes/MobileObjectArchetype.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Archetypes/MobileStaticArchetype.cpp
+++ b/src/ECS/Archetypes/MobileStaticArchetype.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "MobileStaticArchetype.h"
 

--- a/src/ECS/Archetypes/MobileStaticArchetype.h
+++ b/src/ECS/Archetypes/MobileStaticArchetype.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Archetypes/PotArchetype.cpp
+++ b/src/ECS/Archetypes/PotArchetype.cpp
@@ -5,7 +5,7 @@
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- ******************************************************************************/
+ *******************************************************************************/
 
 #include "PotArchetype.h"
 

--- a/src/ECS/Archetypes/PotArchetype.h
+++ b/src/ECS/Archetypes/PotArchetype.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Archetypes/StreetLanternArchetype.cpp
+++ b/src/ECS/Archetypes/StreetLanternArchetype.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "StreetLanternArchetype.h"
 

--- a/src/ECS/Archetypes/StreetLanternArchetype.h
+++ b/src/ECS/Archetypes/StreetLanternArchetype.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Archetypes/TownArchetype.cpp
+++ b/src/ECS/Archetypes/TownArchetype.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "TownArchetype.h"
 

--- a/src/ECS/Archetypes/TownArchetype.h
+++ b/src/ECS/Archetypes/TownArchetype.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Archetypes/TreeArchetype.cpp
+++ b/src/ECS/Archetypes/TreeArchetype.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "TreeArchetype.h"
 

--- a/src/ECS/Archetypes/TreeArchetype.h
+++ b/src/ECS/Archetypes/TreeArchetype.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Archetypes/Utils.cpp
+++ b/src/ECS/Archetypes/Utils.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "Utils.h"
 

--- a/src/ECS/Archetypes/Utils.h
+++ b/src/ECS/Archetypes/Utils.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include <tuple>
 

--- a/src/ECS/Archetypes/VillagerArchetype.cpp
+++ b/src/ECS/Archetypes/VillagerArchetype.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "VillagerArchetype.h"
 

--- a/src/ECS/Archetypes/VillagerArchetype.h
+++ b/src/ECS/Archetypes/VillagerArchetype.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Components/Abode.h
+++ b/src/ECS/Components/Abode.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Components/AnimatedStatic.h
+++ b/src/ECS/Components/AnimatedStatic.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Components/CameraBookmark.h
+++ b/src/ECS/Components/CameraBookmark.h
@@ -5,7 +5,7 @@
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- ******************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Components/Creature.h
+++ b/src/ECS/Components/Creature.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Components/Feature.h
+++ b/src/ECS/Components/Feature.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Components/Field.h
+++ b/src/ECS/Components/Field.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Components/Fixed.h
+++ b/src/ECS/Components/Fixed.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Components/Footpath.h
+++ b/src/ECS/Components/Footpath.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Components/Forest.h
+++ b/src/ECS/Components/Forest.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Components/Hand.h
+++ b/src/ECS/Components/Hand.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Components/LivingAction.h
+++ b/src/ECS/Components/LivingAction.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Components/Mesh.h
+++ b/src/ECS/Components/Mesh.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Components/Mobile.h
+++ b/src/ECS/Components/Mobile.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Components/MorphWithTerrain.h
+++ b/src/ECS/Components/MorphWithTerrain.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Components/Pot.h
+++ b/src/ECS/Components/Pot.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Components/RigidBody.h
+++ b/src/ECS/Components/RigidBody.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Components/Sprite.h
+++ b/src/ECS/Components/Sprite.h
@@ -5,7 +5,7 @@
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- ******************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Components/StoragePit.h
+++ b/src/ECS/Components/StoragePit.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Components/Stream.h
+++ b/src/ECS/Components/Stream.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Components/Town.h
+++ b/src/ECS/Components/Town.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Components/Transform.h
+++ b/src/ECS/Components/Transform.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Components/Tree.h
+++ b/src/ECS/Components/Tree.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Components/Velocity.h
+++ b/src/ECS/Components/Velocity.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Components/Villager.h
+++ b/src/ECS/Components/Villager.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Components/WallHug.h
+++ b/src/ECS/Components/WallHug.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Map.cpp
+++ b/src/ECS/Map.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "Map.h"
 

--- a/src/ECS/Map.h
+++ b/src/ECS/Map.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Registry.cpp
+++ b/src/ECS/Registry.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "Registry.h"
 

--- a/src/ECS/Registry.h
+++ b/src/ECS/Registry.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/RegistryContext.h
+++ b/src/ECS/RegistryContext.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include <unordered_map>
 

--- a/src/ECS/Systems/CameraBookmarkSystemInterface.h
+++ b/src/ECS/Systems/CameraBookmarkSystemInterface.h
@@ -5,7 +5,7 @@
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- ******************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Systems/DynamicsSystemInterface.h
+++ b/src/ECS/Systems/DynamicsSystemInterface.h
@@ -5,7 +5,7 @@
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- ******************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Systems/Implementations/CameraBookmarkSystem.cpp
+++ b/src/ECS/Systems/Implementations/CameraBookmarkSystem.cpp
@@ -5,7 +5,7 @@
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- ******************************************************************************/
+ *******************************************************************************/
 
 #define LOCATOR_IMPLEMENTATIONS
 

--- a/src/ECS/Systems/Implementations/CameraBookmarkSystem.h
+++ b/src/ECS/Systems/Implementations/CameraBookmarkSystem.h
@@ -5,7 +5,7 @@
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- ******************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Systems/Implementations/DynamicsSystem.cpp
+++ b/src/ECS/Systems/Implementations/DynamicsSystem.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #define LOCATOR_IMPLEMENTATIONS
 

--- a/src/ECS/Systems/Implementations/DynamicsSystem.h
+++ b/src/ECS/Systems/Implementations/DynamicsSystem.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Systems/Implementations/LivingActionSystem.cpp
+++ b/src/ECS/Systems/Implementations/LivingActionSystem.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #define LOCATOR_IMPLEMENTATIONS
 

--- a/src/ECS/Systems/Implementations/LivingActionSystem.h
+++ b/src/ECS/Systems/Implementations/LivingActionSystem.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Systems/Implementations/PathfindingSystem.cpp
+++ b/src/ECS/Systems/Implementations/PathfindingSystem.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #define LOCATOR_IMPLEMENTATIONS
 

--- a/src/ECS/Systems/Implementations/PathfindingSystem.h
+++ b/src/ECS/Systems/Implementations/PathfindingSystem.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Systems/Implementations/RenderingSystem.cpp
+++ b/src/ECS/Systems/Implementations/RenderingSystem.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #define LOCATOR_IMPLEMENTATIONS
 

--- a/src/ECS/Systems/Implementations/RenderingSystem.h
+++ b/src/ECS/Systems/Implementations/RenderingSystem.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Systems/Implementations/TownSystem.cpp
+++ b/src/ECS/Systems/Implementations/TownSystem.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #define LOCATOR_IMPLEMENTATIONS
 

--- a/src/ECS/Systems/Implementations/TownSystem.h
+++ b/src/ECS/Systems/Implementations/TownSystem.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Systems/LivingActionSystemInterface.h
+++ b/src/ECS/Systems/LivingActionSystemInterface.h
@@ -5,7 +5,7 @@
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- ******************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Systems/PathfindingSystemInterface.h
+++ b/src/ECS/Systems/PathfindingSystemInterface.h
@@ -5,7 +5,7 @@
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- ******************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Systems/RenderingSystemInterface.h
+++ b/src/ECS/Systems/RenderingSystemInterface.h
@@ -5,7 +5,7 @@
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- ******************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/ECS/Systems/TownSystemInterface.h
+++ b/src/ECS/Systems/TownSystemInterface.h
@@ -5,7 +5,7 @@
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- ******************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Enums.h
+++ b/src/Enums.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "Game.h"
 

--- a/src/Game.h
+++ b/src/Game.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/GameWindow.cpp
+++ b/src/GameWindow.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "GameWindow.h"
 

--- a/src/GameWindow.h
+++ b/src/GameWindow.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Graphics/DebugLines.cpp
+++ b/src/Graphics/DebugLines.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "DebugLines.h"
 

--- a/src/Graphics/DebugLines.h
+++ b/src/Graphics/DebugLines.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Graphics/FrameBuffer.cpp
+++ b/src/Graphics/FrameBuffer.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "FrameBuffer.h"
 

--- a/src/Graphics/FrameBuffer.h
+++ b/src/Graphics/FrameBuffer.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Graphics/IndexBuffer.cpp
+++ b/src/Graphics/IndexBuffer.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "IndexBuffer.h"
 

--- a/src/Graphics/IndexBuffer.h
+++ b/src/Graphics/IndexBuffer.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Graphics/Mesh.cpp
+++ b/src/Graphics/Mesh.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "Mesh.h"
 

--- a/src/Graphics/Mesh.h
+++ b/src/Graphics/Mesh.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Graphics/MetalViewHelper.mm
+++ b/src/Graphics/MetalViewHelper.mm
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #import <QuartzCore/CAMetalLayer.h>
 #import <Metal/Metal.h>

--- a/src/Graphics/Primitive.cpp
+++ b/src/Graphics/Primitive.cpp
@@ -5,7 +5,7 @@
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- ******************************************************************************/
+ *******************************************************************************/
 
 #include "Primitive.h"
 

--- a/src/Graphics/Primitive.h
+++ b/src/Graphics/Primitive.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Graphics/RenderPass.h
+++ b/src/Graphics/RenderPass.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Graphics/ShaderIncluder.h
+++ b/src/Graphics/ShaderIncluder.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 // https://stackoverflow.com/questions/40062883/how-to-use-a-macro-in-an-include-directive
 

--- a/src/Graphics/ShaderManager.cpp
+++ b/src/Graphics/ShaderManager.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 // How to add a Shader:
 // Shaders in openblack are compiled using bgfx's shaderc compiler. Shaderc

--- a/src/Graphics/ShaderManager.h
+++ b/src/Graphics/ShaderManager.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Graphics/ShaderProgram.cpp
+++ b/src/Graphics/ShaderProgram.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "ShaderProgram.h"
 

--- a/src/Graphics/ShaderProgram.h
+++ b/src/Graphics/ShaderProgram.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Graphics/Texture2D.cpp
+++ b/src/Graphics/Texture2D.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "Texture2D.h"
 

--- a/src/Graphics/Texture2D.h
+++ b/src/Graphics/Texture2D.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Graphics/VertexBuffer.cpp
+++ b/src/Graphics/VertexBuffer.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "VertexBuffer.h"
 

--- a/src/Graphics/VertexBuffer.h
+++ b/src/Graphics/VertexBuffer.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/InfoConstants.cpp
+++ b/src/InfoConstants.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "InfoConstants.h"
 

--- a/src/InfoConstants.h
+++ b/src/InfoConstants.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/LHScriptX/CommandSignature.h
+++ b/src/LHScriptX/CommandSignature.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/LHScriptX/FeatureScriptCommands.cpp
+++ b/src/LHScriptX/FeatureScriptCommands.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "FeatureScriptCommands.h"
 

--- a/src/LHScriptX/FeatureScriptCommands.h
+++ b/src/LHScriptX/FeatureScriptCommands.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/LHScriptX/Lexer.cpp
+++ b/src/LHScriptX/Lexer.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "Lexer.h"
 

--- a/src/LHScriptX/Lexer.h
+++ b/src/LHScriptX/Lexer.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/LHScriptX/MapScriptCommands.cpp
+++ b/src/LHScriptX/MapScriptCommands.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "MapScriptCommands.h"
 

--- a/src/LHScriptX/MapScriptCommands.h
+++ b/src/LHScriptX/MapScriptCommands.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/LHScriptX/Script.cpp
+++ b/src/LHScriptX/Script.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "Script.h"
 

--- a/src/LHScriptX/Script.h
+++ b/src/LHScriptX/Script.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/LHScriptX/ScriptingBindingUtils.h
+++ b/src/LHScriptX/ScriptingBindingUtils.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Level.h
+++ b/src/Level.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Locator.cpp
+++ b/src/Locator.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "Locator.h"
 

--- a/src/Locator.h
+++ b/src/Locator.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Parsers/InfoFile.cpp
+++ b/src/Parsers/InfoFile.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "InfoFile.h"
 

--- a/src/Parsers/InfoFile.h
+++ b/src/Parsers/InfoFile.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Profiler.cpp
+++ b/src/Profiler.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "Profiler.h"
 

--- a/src/Profiler.h
+++ b/src/Profiler.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "Renderer.h"
 

--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Resources/Loaders.cpp
+++ b/src/Resources/Loaders.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "Resources/Loaders.h"
 

--- a/src/Resources/Loaders.h
+++ b/src/Resources/Loaders.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Resources/MeshId.h
+++ b/src/Resources/MeshId.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Resources/ResourceManager.h
+++ b/src/Resources/ResourceManager.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Resources/Resources.h
+++ b/src/Resources/Resources.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Serializer/Common.h
+++ b/src/Serializer/Common.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Serializer/FotFile.cpp
+++ b/src/Serializer/FotFile.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "FotFile.h"
 

--- a/src/Serializer/FotFile.h
+++ b/src/Serializer/FotFile.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/Serializer/GameThingSerializer.cpp
+++ b/src/Serializer/GameThingSerializer.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include "GameThingSerializer.h"
 

--- a/src/Serializer/GameThingSerializer.h
+++ b/src/Serializer/GameThingSerializer.h
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #pragma once
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include <iostream>
 #include <map>

--- a/test/mobile_wall_hug/test_mobile_wall_hug.cpp
+++ b/test/mobile_wall_hug/test_mobile_wall_hug.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include <filesystem>
 #include <fstream>

--- a/test/mock/gen_info.cpp
+++ b/test/mock/gen_info.cpp
@@ -1,11 +1,11 @@
-/*****************************************************************************
+/******************************************************************************
  * Copyright (c) 2018-2023 openblack developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- *****************************************************************************/
+ *******************************************************************************/
 
 #include <cstdlib>
 

--- a/test/test_fixed.cpp
+++ b/test/test_fixed.cpp
@@ -5,7 +5,7 @@
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- ******************************************************************************/
+ *******************************************************************************/
 
 #include <ECS/Archetypes/AbodeArchetype.h>
 #include <ECS/Archetypes/TownArchetype.h>

--- a/test/test_game_initialize.cpp
+++ b/test/test_game_initialize.cpp
@@ -5,7 +5,7 @@
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- ******************************************************************************/
+ *******************************************************************************/
 
 #include <Game.h>
 #include <gtest/gtest.h>

--- a/test/test_load_scene.cpp
+++ b/test/test_load_scene.cpp
@@ -5,7 +5,7 @@
  * Interested in contributing? Visit https://github.com/openblack/openblack
  *
  * openblack is licensed under the GNU General Public License version 3.
- ******************************************************************************/
+ *******************************************************************************/
 
 #include <Game.h>
 #include <LHScriptX/Script.h>


### PR DESCRIPTION
The runner is deprecated and turned into a typescript library.
```
deno run --allow-read https://deno.land/x/license_checker@v3.2.2/main.ts
```
Add suggester and run in quiet mode to only show failing files