### PR TITLE
Bullet: Fix linking with bullet-dp

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,6 +92,7 @@ endif ()
 target_link_directories(
   openblack_lib PRIVATE ${BULLET_ROOT_DIR}/${BULLET_LIBRARY_DIRS}
 )
+target_compile_definitions(openblack_lib PRIVATE ${BULLET_DEFINITIONS})
 target_link_libraries(
   openblack_lib
   PRIVATE "$<$<CXX_COMPILER_ID:MSVC>:-SAFESEH:NO>"


### PR DESCRIPTION
Bullet dp is compiled using `BT_USE_DOUBLE_PRECISION` which turns floats into doubles. If this is not included in the application, it will attempt to link with non-existent float implementations