### PR TITLE
Draw the terrain using an instanced call

### DIFF
--- a/assets/shaders/fs_terrain.sc
+++ b/assets/shaders/fs_terrain.sc
@@ -1,22 +1,22 @@
-$input v_texcoord0, v_texcoord1, v_weight, v_materialID0, v_materialID1, v_materialBlend, v_lightLevel, v_waterAlpha, v_distToCamera
+$input v_texcoord0, v_texcoord1, v_weight, v_materialID0, v_materialID1, v_materialBlend, v_lightLevel, v_waterAlpha, v_distToCamera, v_skyABump
 
 #include <bgfx_shader.sh>
 
 #define M_PI 3.1415926535897932384626433832795
 
-SAMPLER2DARRAY(s0_materials, 0);
-SAMPLER2D(s1_bump, 1);
-SAMPLER2D(s2_smallBump, 2);
-SAMPLER2D(s3_footprints, 3);
+SAMPLER2DARRAY(s0_materials, 1);
+SAMPLER2D(s1_bump, 2);
+SAMPLER2D(s2_smallBump, 3);
+SAMPLER2D(s3_footprints, 4);
 
-uniform vec4 u_skyAndBump;
+// uniform vec4 u_skyAndBump;
 
 void main()
 {
 	// unpack uniforms
-	float skyType = u_skyAndBump.x;
-	float bumpMapStrength = u_skyAndBump.y;
-	float smallBumpMapStrength = u_skyAndBump.z;
+	float skyType = v_skyABump.x;
+	float bumpMapStrength = v_skyABump.y;
+	float smallBumpMapStrength = v_skyABump.z;
 
 	// do each vert with both materials
 	vec4 colOne = mix(

--- a/assets/shaders/varying.def.sc
+++ b/assets/shaders/varying.def.sc
@@ -22,6 +22,7 @@ vec3 v_weight            : COLOR5;
 flat ivec3 v_materialID0 : COLOR0;
 flat ivec3 v_materialID1 : COLOR1;
 vec3 v_materialBlend     : COLOR2;
+vec4 v_skyABump          : COLOR6;
 float v_lightLevel       : COLOR3;
 float v_waterAlpha       : COLOR4;
 float v_distToCamera     : DEPTH0;

--- a/assets/shaders/vs_terrain.sc
+++ b/assets/shaders/vs_terrain.sc
@@ -1,39 +1,45 @@
-$input a_position, a_texcoord1, a_color1, a_color2, a_texcoord2, a_color0, a_color3
-$output v_texcoord0, v_texcoord1, v_weight, v_materialID0, v_materialID1, v_materialBlend, v_lightLevel, v_waterAlpha, v_distToCamera
+$input a_position, a_texcoord1, a_color1, a_color2, a_texcoord2, a_color0, a_color3, i_data0, i_data1, i_data2
+$output v_texcoord0, v_texcoord1, v_weight, v_materialID0, v_materialID1, v_materialBlend, v_lightLevel, v_waterAlpha, v_distToCamera, v_skyABump
 
 #include <bgfx_shader.sh>
 
-#if BGFX_SHADER_LANGUAGE_HLSL > 300 || BGFX_SHADER_LANGUAGE_SPIRV
+# if BGFX_SHADER_LANGUAGE_HLSL > 300 || BGFX_SHADER_LANGUAGE_SPIRV
 #   define materialIdFix(x) (floatBitsToInt(x))
-#else
+# else
 #   define materialIdFix(x) (ivec3(x))
-#endif
+# endif
 
-uniform vec4 u_blockPositionAndSize;
-uniform vec4 u_islandExtent;
+SAMPLER2D(t0_heightmap, 0);
 
 void main()
 {
 	// Unpack
-	vec2 blockPosition = u_blockPositionAndSize.xy;
-	vec2 blockSize = u_blockPositionAndSize.zw;
-	vec2 extentMin = u_islandExtent.xy;
-	vec2 extentMax = u_islandExtent.zw;
+	vec2 blockPosition = i_data0.xy;
+	vec2 blockSize = i_data0.zw;
+	vec2 extentMin = i_data1.xy;
+	vec2 extentMax = i_data1.zw;
 
+	v_skyABump = vec4(i_data2);
+
+	vec2 normalizedPos = (a_position.xz + blockPosition);
 	v_texcoord0 = vec4(a_position.zx / blockSize.yx, 0.0f, 0.0f);
 	vec2 blockStartUv = (blockPosition + a_position.xz - extentMin) / (extentMax - extentMin);
 	#if !BGFX_SHADER_LANGUAGE_GLSL
 		blockStartUv.y = 1.0f - blockStartUv.y;
 	#endif
 	v_texcoord1 = vec4(blockStartUv, 0.0f, 0.0f);
-	v_weight = a_texcoord1;
 	v_materialID0 = materialIdFix(a_color1);
 	v_materialID1 = materialIdFix(a_color2);
 	v_materialBlend = a_texcoord2;
+	v_weight = a_texcoord1;
 	v_lightLevel = a_color0.x;
 	v_waterAlpha = a_color3;
+	vec2 uv_pos = blockStartUv;
+	uv_pos.y = 1.0 - uv_pos.y;
 
-	vec3 transformedPosition = vec3(a_position.x + blockPosition.x, a_position.y, a_position.z + blockPosition.y);
+	vec3 transformedPosition = vec3(a_position.x + blockPosition.x, 15.0f, a_position.z + blockPosition.y);
+	vec4 height = texture2DLod(t0_heightmap, uv_pos, 0);
+	transformedPosition.y = height.r * 255.0;
 
 	vec4 cs_position = mul(u_view, vec4(transformedPosition, 1.0f));
 	v_distToCamera = cs_position.z;

--- a/assets/shaders/vs_terrain.sc
+++ b/assets/shaders/vs_terrain.sc
@@ -39,7 +39,7 @@ void main()
 
 	vec3 transformedPosition = vec3(a_position.x + blockPosition.x, 15.0f, a_position.z + blockPosition.y);
 	vec4 height = texture2DLod(t0_heightmap, uv_pos, 0);
-	transformedPosition.y = height.r * 255.0;
+	transformedPosition.y = height.r * 255.0 * v_skyABump.w;
 
 	vec4 cs_position = mul(u_view, vec4(transformedPosition, 1.0f));
 	v_distToCamera = cs_position.z;

--- a/assets/shaders/vs_terrain.sc
+++ b/assets/shaders/vs_terrain.sc
@@ -21,9 +21,8 @@ void main()
 
 	v_skyABump = vec4(i_data2);
 
-	vec2 normalizedPos = (a_position.xz + blockPosition);
-	v_texcoord0 = vec4(a_position.zx / blockSize.yx, 0.0f, 0.0f);
 	vec2 blockStartUv = (blockPosition + a_position.xz - extentMin) / (extentMax - extentMin);
+	v_texcoord0 = vec4(a_position.zx / blockSize.yx, 0.0f, 0.0f);
 	#if !BGFX_SHADER_LANGUAGE_GLSL
 		blockStartUv.y = 1.0f - blockStartUv.y;
 	#endif
@@ -40,6 +39,8 @@ void main()
 	vec3 transformedPosition = vec3(a_position.x + blockPosition.x, 15.0f, a_position.z + blockPosition.y);
 	vec4 height = texture2DLod(t0_heightmap, uv_pos, 0);
 	transformedPosition.y = height.r * 255.0 * v_skyABump.w;
+
+	v_waterAlpha = clamp(transformedPosition.y, 0.0f , 1.0f);
 
 	vec4 cs_position = mul(u_view, vec4(transformedPosition, 1.0f));
 	v_distToCamera = cs_position.z;

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -552,8 +552,11 @@ void Renderer::DrawPass(const DrawSceneDesc& desc) const
 			glm::vec2 extentMax;
 			desc.island.GetExtent(extentMin, extentMax);
 			auto islandExtent = glm::vec4(extentMin, extentMax);
+			auto k_HeightUnit = desc.island.k_HeightUnit;
 
 			auto texture = Locator::resources::value().GetTextures().Handle(LandIsland::k_SmallBumpTextureId);
+			const glm::vec4 u_skyAndBump = {desc.sky.GetCurrentSkyType(), desc.bumpMapStrength, desc.smallBumpMapStrength,
+				                                0.0f};
 
 			terrainShader->SetTextureSampler("t0_heightmap", 0, desc.island.GetHeightMap());
 
@@ -576,8 +579,6 @@ void Renderer::DrawPass(const DrawSceneDesc& desc) const
 			{
 				// pack uniforms
 				const glm::vec4 mapPositionAndSize = glm::vec4(block.GetMapPosition(), 160.0f, 160.0f);
-				const glm::vec4 u_skyAndBump = {desc.sky.GetCurrentSkyType(), desc.bumpMapStrength, desc.smallBumpMapStrength,
-				                                0.0f};
 
 				// Pack mapPositionAndSize
 				auto* mpz = reinterpret_cast<float *>(data);
@@ -593,16 +594,17 @@ void Renderer::DrawPass(const DrawSceneDesc& desc) const
 				is[2] = islandExtent.z;
 				is[3] = islandExtent.w;
 
-				// Pack u_skyAndBump
+				// Pack u_skyAndBump and k_HeightUnit
 				auto* sab = reinterpret_cast<float *>(&data[32]);
 				sab[0] = u_skyAndBump.x;
 				sab[1] = u_skyAndBump.y;
 				sab[2] = u_skyAndBump.z;
+				sab[3] = k_HeightUnit;
 
 				data += instanceStride;
 			}
 
-			desc.island.GetBlocks()[20].GetMesh().GetVertexBuffer().Bind();
+			desc.island.GetBlocks()[16].GetMesh().GetVertexBuffer().Bind();
 			bgfx::setInstanceDataBuffer(&idb);
 
 			// clang-format off


### PR DESCRIPTION
If completed should close #81 #470 and #218, replace #613.

As of now the uniforms in the shader have been set up as instance input (islandExtent and u_skyAndBump) probably should go back to uniform.
In the shader the height of the vertex is computed by looking at the heighmap (given through a 2DSampler) and multiplying the height map value by the heightunit (given though an instance input, it probably could be turned into a uniform).
At the moment a single call is made with the vertexBuffer of an arbitray block as the blending data is given through data inside the LandVertex it means all block share the same texture.
WaterAlpha is computed arbitraly inside the shader by clamping altitude between 0 and 1.

![image](https://github.com/openblack/openblack/assets/83550517/3868b6c5-993d-41ea-80ff-eb248436d61f)

- [ ] Make texture blending works in an instanced call.
- [ ] Make waterAlpha use cell properties in shader