### PR TITLE
Faster Transformation matrix for entities

### DIFF
--- a/src/ECS/Systems/Implementations/RenderingSystem.cpp
+++ b/src/ECS/Systems/Implementations/RenderingSystem.cpp
@@ -112,11 +112,11 @@ void RenderingSystem::PrepareDrawUploadUniforms(bool drawBoundingBox)
 		    auto offset = uniformOffsets.insert(std::make_pair(mesh.id, 0));
 		    auto desc = _renderContext.instancedDrawDescs.find(mesh.id);
 
-			glm::mat4 modelMatrix = glm::mat4(transform.rotation);
-			modelMatrix = glm::translate(modelMatrix, transform.position * transform.rotation);
+		    auto modelMatrix = glm::mat4(transform.rotation);
+		    modelMatrix = glm::translate(modelMatrix, transform.position * transform.rotation);
 		    modelMatrix = glm::scale(modelMatrix, transform.scale);
 
-		    uint32_t idx = desc->second.offset + offset.first->second;
+		    const uint32_t idx = desc->second.offset + offset.first->second;
 		    _renderContext.instanceUniforms[idx] = modelMatrix;
 		    if (drawBoundingBox)
 		    {

--- a/src/ECS/Systems/Implementations/RenderingSystem.cpp
+++ b/src/ECS/Systems/Implementations/RenderingSystem.cpp
@@ -112,9 +112,8 @@ void RenderingSystem::PrepareDrawUploadUniforms(bool drawBoundingBox)
 		    auto offset = uniformOffsets.insert(std::make_pair(mesh.id, 0));
 		    auto desc = _renderContext.instancedDrawDescs.find(mesh.id);
 
-		    glm::mat4 modelMatrix = glm::mat4(1.0f);
-		    modelMatrix = glm::translate(modelMatrix, transform.position);
-		    modelMatrix *= glm::mat4(transform.rotation);
+			glm::mat4 modelMatrix = glm::mat4(transform.rotation);
+			modelMatrix = glm::translate(modelMatrix, transform.position * transform.rotation);
 		    modelMatrix = glm::scale(modelMatrix, transform.scale);
 
 		    uint32_t idx = desc->second.offset + offset.first->second;


### PR DESCRIPTION
When preparing transformation of entities for the draw call we currently create a 4x4 identity matrix translate and multiply it by the rotation as a 4x4.
Here we build a 4x4 matrix with the rotation of the transform then translate it by `position x transform` and use a smaller multiplication.

| Debug Master | Debug Fast |
|----------------|----------------|
|![masterDebug](https://github.com/openblack/openblack/assets/83550517/2c324f2a-7eb5-4aed-bc80-50ec898f24db)|![fastermatrix](https://github.com/openblack/openblack/assets/83550517/6cf3dd08-cef4-45ca-a328-1677b1363091)|
| Release Master | Release Fast |
|![releasedMaster](https://github.com/openblack/openblack/assets/83550517/c620e9df-631a-4c9d-9731-11948dfe87a1)|![realeaseFast](https://github.com/openblack/openblack/assets/83550517/bf05fdba-30e4-47d0-af15-6c84b4f7b088)|




