### PR TITLE
Temple misc fixes

### DIFF
--- a/src/3D/TempleInterior.cpp
+++ b/src/3D/TempleInterior.cpp
@@ -108,7 +108,7 @@ void TempleInterior::Deactivate()
 	auto& config = Game::Instance()->GetConfig();
 	config.drawIsland = true;
 	config.drawWater = true;
-	registry.Each<const TempleInterior>([&registry](const entt::entity entity, auto&&...) { registry.Destroy(entity); });
+	registry.Each<const TempleInteriorPart>([&registry](const entt::entity entity, auto&&...) { registry.Destroy(entity); });
 
 	auto& camera = Game::Instance()->GetCamera();
 	camera.SetPosition(_playerPositionOutside);

--- a/src/3D/TempleInterior.cpp
+++ b/src/3D/TempleInterior.cpp
@@ -74,11 +74,15 @@ void TempleInterior::Activate()
 	auto& registry = Locator::entitiesRegistry::value();
 	auto& config = Game::Instance()->GetConfig();
 	auto& camera = Game::Instance()->GetCamera();
+
+	_playerPositionOutside = camera.GetPosition();
+	_playerRotationOutside = camera.GetRotation();
+
 	config.drawIsland = false;
 	config.drawWater = false;
 
 	// Create temple entities
-	auto rotation = glm::eulerAngleY(glm::radians(0.0f));
+	auto rotation = glm::eulerAngleY(_templeRotation.y);
 	auto scale = glm::vec3(1.0f);
 
 	for (const auto& [assetName, indoorPartType] : k_TempleInteriorParts)
@@ -91,9 +95,8 @@ void TempleInterior::Activate()
 		registry.Assign<ecs::components::Mesh>(entity, meshId, static_cast<int8_t>(0), static_cast<int8_t>(0));
 	}
 
-	_playerPositionOutside = camera.GetPosition();
-	_playerRotationOutside = camera.GetRotation();
-	camera.SetPosition(_templePosition);
+	camera.SetPosition(_templePosition + glm::vec3(0.0f, 1.0f, 0.0f));
+	camera.SetRotation(_templeRotation);
 	_active = true;
 }
 

--- a/src/3D/TempleInterior.h
+++ b/src/3D/TempleInterior.h
@@ -74,6 +74,7 @@ public:
 private:
 	bool _active;
 	glm::vec3 _templePosition;
+	glm::vec3 _templeRotation;
 	glm::vec3 _playerPositionOutside;
 	glm::vec3 _playerRotationOutside;
 };


### PR DESCRIPTION
Fixes #642 by moving the camera from the temple position by one on the Y axis so no zero vector appears in calculation.
Fix a bug where the Desactivation of the interior do not lead to the removal of interior entity.

Add a _templeRotation so the camera rotation is set when entering and aligned with the temple.