### PR TITLE
Separate the rendering of the Temple

### DIFF
--- a/src/3D/Camera.cpp
+++ b/src/3D/Camera.cpp
@@ -608,7 +608,10 @@ void Camera::Update(std::chrono::microseconds dt)
 		auto logPosY = log(_position.y + 1.0f);
 		auto handVelHeightMult = logPosY * logPosY;
 		glm::vec3 vecTo = futurePosition - _position;
-		vecTo = glm::min(glm::normalize(vecTo) * handVelHeightMult, glm::vec3(5.0f));
+		if (vecTo != glm::vec3(0.0f))
+		{
+			vecTo = glm::min(glm::normalize(vecTo) * handVelHeightMult, glm::vec3(5.0f));
+		}
 		glm::mat3 mRotation = glm::transpose(GetRotationMatrix());
 		_hVelocity += vecTo * mRotation * 0.00005f;
 		if (GetForward().y > 0.0f) // camera is pointing upwards

--- a/src/3D/TempleInterior.cpp
+++ b/src/3D/TempleInterior.cpp
@@ -105,7 +105,7 @@ void TempleInterior::Activate()
 	}
 
 	Locator::rendereringSystem::emplace<ecs::systems::RenderingSystemTemple>();
-	camera.SetPosition(_templePosition + glm::vec3(0.0f, 1.0f, 0.0f));
+	camera.SetPosition(_templePosition);
 	camera.SetRotation(_templeRotation);
 	_active = true;
 	_currentRoom = TempleRoom::Main;

--- a/src/3D/TempleInterior.cpp
+++ b/src/3D/TempleInterior.cpp
@@ -102,18 +102,15 @@ void TempleInterior::Activate()
 	auto rotation = glm::eulerAngleY(_templeRotation.y);
 	auto scale = glm::vec3(1.0f);
 
-	auto roomType = Indoors::MainRoom;
-	auto bucket = k_TempleInteriorParts.bucket(roomType);
-	for (auto it = k_TempleInteriorParts.begin(bucket); it != k_TempleInteriorParts.end(bucket); it++)
+	for (const auto& [roomType, assetName] : k_TempleInteriorParts)
 	{
-		addRoomToRegistry(it->second, roomType, _templePosition, rotation, scale);
+		addRoomToRegistry(assetName, roomType, _templePosition, rotation, scale);
 	}
 
 	Locator::rendereringSystem::emplace<ecs::systems::RenderingSystemTemple>();
 	camera.SetPosition(_templePosition);
 	camera.SetRotation(_templeRotation);
 	_active = true;
-	_currentRoom = TempleRoom::Main;
 }
 
 void TempleInterior::Deactivate()
@@ -135,42 +132,4 @@ void TempleInterior::Deactivate()
 	camera.SetPosition(_playerPositionOutside);
 	camera.SetRotation(_playerRotationOutside);
 	_active = false;
-}
-
-const std::map<TempleRoom, Indoors> k_RoomComponentMap = {
-    {TempleRoom::Challenge, Indoors::ChallengeRoom}, {TempleRoom::CreatureCave, Indoors::CreatureCave},
-    {TempleRoom::Credits, Indoors::CreditsRoom},     {TempleRoom::Main, Indoors::MainRoom},
-    {TempleRoom::Multi, Indoors::MultiplayerRoom},   {TempleRoom::Options, Indoors::OptionsRoom},
-    {TempleRoom::SaveGame, Indoors::SaveGameRoom}};
-
-void TempleInterior::ChangeRoom(TempleRoom nextRoom)
-{
-	auto rotation = glm::eulerAngleY(_templeRotation.y);
-	auto scale = glm::vec3(1.0f);
-	auto& registry = Locator::entitiesRegistry::value();
-
-	auto nextRoomComponent = k_RoomComponentMap.find(nextRoom)->second;
-
-	registry.Each<const ecs::components::TempleInteriorPart>(
-	    [&registry](const entt::entity entity, const ecs::components::TempleInteriorPart templeRoom) {
-		    if (Indoors::MainRoom != templeRoom.room)
-		    {
-			    registry.Destroy(entity);
-		    }
-	    });
-
-	if (nextRoomComponent != Indoors::MainRoom)
-	{
-		auto bucket = k_TempleInteriorParts.bucket(nextRoomComponent);
-		for (auto it = k_TempleInteriorParts.begin(bucket); it != k_TempleInteriorParts.end(bucket); it++)
-		{
-			addRoomToRegistry(it->second, nextRoomComponent, _templePosition, rotation, scale);
-		}
-	}
-	_currentRoom = nextRoom;
-}
-
-TempleRoom TempleInterior::GetCurrentRoom() const
-{
-	return _currentRoom;
 }

--- a/src/3D/TempleInterior.cpp
+++ b/src/3D/TempleInterior.cpp
@@ -15,6 +15,8 @@
 
 #include "3D/Camera.h"
 #include "Common/EventManager.h"
+#include "ECS/Systems/Implementations/RenderingSystem.h"
+#include "ECS/Systems/Implementations/RenderingSystemTemple.h"
 #include "ECS/Components/Mesh.h"
 #include "ECS/Registry.h"
 #include "Game.h"
@@ -95,6 +97,7 @@ void TempleInterior::Activate()
 		registry.Assign<ecs::components::Mesh>(entity, meshId, static_cast<int8_t>(0), static_cast<int8_t>(0));
 	}
 
+	Locator::rendereringSystem::emplace<ecs::systems::RenderingSystemTemple>();
 	camera.SetPosition(_templePosition + glm::vec3(0.0f, 1.0f, 0.0f));
 	camera.SetRotation(_templeRotation);
 	_active = true;
@@ -114,6 +117,7 @@ void TempleInterior::Deactivate()
 	registry.Each<const TempleInteriorPart>([&registry](const entt::entity entity, auto&&...) { registry.Destroy(entity); });
 
 	auto& camera = Game::Instance()->GetCamera();
+	Locator::rendereringSystem::emplace<ecs::systems::RenderingSystem>();
 	camera.SetPosition(_playerPositionOutside);
 	camera.SetRotation(_playerRotationOutside);
 	_active = false;

--- a/src/3D/TempleInterior.h
+++ b/src/3D/TempleInterior.h
@@ -30,8 +30,6 @@ public:
 	[[nodiscard]] glm::vec3 GetPosition() const override { return _templePosition; }
 	void Activate() override;
 	void Deactivate() override;
-	void ChangeRoom(TempleRoom nextRoom) override;
-	[[nodiscard]] TempleRoom GetCurrentRoom() const override;
 
 private:
 	bool _active;
@@ -39,6 +37,5 @@ private:
 	glm::vec3 _templeRotation;
 	glm::vec3 _playerPositionOutside;
 	glm::vec3 _playerRotationOutside;
-	TempleRoom _currentRoom;
 };
 } // namespace openblack

--- a/src/3D/TempleInterior.h
+++ b/src/3D/TempleInterior.h
@@ -15,7 +15,6 @@
 #include <glm/vec3.hpp>
 
 #include "3D/TempleInteriorInterface.h"
-#include "ECS/Components/Temple.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
 #warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
@@ -23,53 +22,16 @@
 
 namespace openblack
 {
+
 class TempleInterior final: public TempleInteriorInterface
 {
 public:
-	enum class TempleIndoorPart
-	{
-		Challenge,
-		ChallengeLO,
-		ChallengeDome,
-		ChallengeFloor,
-		ChallengeFloorLO,
-		CreatureCave,
-		CreatureCaveLO,
-		CreatureCaveWater,
-		CreatureCaveWaterLO,
-		Credits,
-		CreditsLO,
-		CreditsDome,
-		CreditsFloor,
-		CreditsFloorLO,
-		Main,
-		MainLO,
-		MainFloor,
-		MainFloorLO,
-		MainWater,
-		MainWaterLO,
-		Movement,
-		Multi,
-		MultiLO,
-		MultiDome,
-		MultiFloor,
-		MultiFloorLO,
-		Options,
-		OptionsLO,
-		OptionsDome,
-		OptionsFloor,
-		OptionsFloorLO,
-		SaveGame,
-		SaveGameLO,
-		SaveGameDome,
-		SaveGameFloor,
-		SaveGameFloorLO,
-	};
-
 	[[nodiscard]] bool Active() const override { return _active; }
 	[[nodiscard]] glm::vec3 GetPosition() const override { return _templePosition; }
 	void Activate() override;
 	void Deactivate() override;
+	void ChangeRoom(TempleRoom nextRoom) override;
+	[[nodiscard]] TempleRoom GetCurrentRoom() const override;
 
 private:
 	bool _active;
@@ -77,5 +39,6 @@ private:
 	glm::vec3 _templeRotation;
 	glm::vec3 _playerPositionOutside;
 	glm::vec3 _playerRotationOutside;
+	TempleRoom _currentRoom;
 };
 } // namespace openblack

--- a/src/3D/TempleInteriorInterface.h
+++ b/src/3D/TempleInteriorInterface.h
@@ -33,5 +33,7 @@ public:
 	[[nodiscard]] virtual glm::vec3 GetPosition() const = 0;
 	virtual void Activate() = 0;
 	virtual void Deactivate() = 0;
+	virtual void ChangeRoom(TempleRoom nextRoom) = 0;
+	[[nodiscard]] virtual TempleRoom GetCurrentRoom() const = 0;
 };
 } // namespace openblack

--- a/src/3D/TempleInteriorInterface.h
+++ b/src/3D/TempleInteriorInterface.h
@@ -33,7 +33,5 @@ public:
 	[[nodiscard]] virtual glm::vec3 GetPosition() const = 0;
 	virtual void Activate() = 0;
 	virtual void Deactivate() = 0;
-	virtual void ChangeRoom(TempleRoom nextRoom) = 0;
-	[[nodiscard]] virtual TempleRoom GetCurrentRoom() const = 0;
 };
 } // namespace openblack

--- a/src/Debug/Temple.cpp
+++ b/src/Debug/Temple.cpp
@@ -22,12 +22,6 @@ TempleInterior::TempleInterior()
 {
 }
 
-const std::unordered_map<openblack::TempleRoom, std::string_view> k_RoomComponentMap = {
-    {openblack::TempleRoom::Challenge, "Challenge Room"}, {openblack::TempleRoom::CreatureCave, "Creature Cave"},
-    {openblack::TempleRoom::Credits, "Creature Cave"},    {openblack::TempleRoom::Main, "Main Room"},
-    {openblack::TempleRoom::Multi, "Multi Room"},         {openblack::TempleRoom::Options, "Option Room"},
-    {openblack::TempleRoom::SaveGame, "Save Game Room"}};
-
 void TempleInterior::Draw([[maybe_unused]] openblack::Game& game)
 {
 	if (Locator::temple::has_value())
@@ -44,30 +38,6 @@ void TempleInterior::Draw([[maybe_unused]] openblack::Game& game)
 			else
 			{
 				temple.Deactivate();
-			}
-		}
-		if (!active)
-		{
-			if (temple.GetCurrentRoom() == openblack::TempleRoom::Main)
-			{
-				for (const auto& [room, name] : k_RoomComponentMap)
-				{
-					if (room != openblack::TempleRoom::Main)
-					{
-						if (ImGui::Button(name.data()))
-						{
-							temple.ChangeRoom(room);
-						}
-					}
-				}
-			}
-			else
-			{
-				auto roomView = k_RoomComponentMap.at(openblack::TempleRoom::Main);
-				if (ImGui::Button(roomView.data()))
-				{
-					temple.ChangeRoom(openblack::TempleRoom::Main);
-				}
 			}
 		}
 	}

--- a/src/Debug/Temple.cpp
+++ b/src/Debug/Temple.cpp
@@ -9,6 +9,8 @@
 
 #include "Temple.h"
 
+#include <unordered_map>
+
 #include "3D/TempleInteriorInterface.h"
 #include "Game.h"
 #include "Locator.h"
@@ -19,6 +21,12 @@ TempleInterior::TempleInterior()
     : Window("Citadel", ImVec2(250.0f, 165.0f))
 {
 }
+
+const std::unordered_map<openblack::TempleRoom, std::string_view> k_RoomComponentMap = {
+    {openblack::TempleRoom::Challenge, "Challenge Room"}, {openblack::TempleRoom::CreatureCave, "Creature Cave"},
+    {openblack::TempleRoom::Credits, "Creature Cave"},    {openblack::TempleRoom::Main, "Main Room"},
+    {openblack::TempleRoom::Multi, "Multi Room"},         {openblack::TempleRoom::Options, "Option Room"},
+    {openblack::TempleRoom::SaveGame, "Save Game Room"}};
 
 void TempleInterior::Draw([[maybe_unused]] openblack::Game& game)
 {
@@ -36,6 +44,30 @@ void TempleInterior::Draw([[maybe_unused]] openblack::Game& game)
 			else
 			{
 				temple.Deactivate();
+			}
+		}
+		if (!active)
+		{
+			if (temple.GetCurrentRoom() == openblack::TempleRoom::Main)
+			{
+				for (const auto& [room, name] : k_RoomComponentMap)
+				{
+					if (room != openblack::TempleRoom::Main)
+					{
+						if (ImGui::Button(name.data()))
+						{
+							temple.ChangeRoom(room);
+						}
+					}
+				}
+			}
+			else
+			{
+				auto roomView = k_RoomComponentMap.at(openblack::TempleRoom::Main);
+				if (ImGui::Button(roomView.data()))
+				{
+					temple.ChangeRoom(openblack::TempleRoom::Main);
+				}
 			}
 		}
 	}

--- a/src/ECS/Systems/Implementations/RenderingSystem.cpp
+++ b/src/ECS/Systems/Implementations/RenderingSystem.cpp
@@ -28,22 +28,6 @@
 using namespace openblack::ecs::systems;
 using namespace openblack::ecs::components;
 
-RenderContext::RenderContext()
-    : instanceUniformBuffer(BGFX_INVALID_HANDLE)
-{
-}
-RenderContext::~RenderContext()
-{
-	if (bgfx::isValid(instanceUniformBuffer))
-	{
-		bgfx::destroy(instanceUniformBuffer);
-		bgfx::frame();
-		bgfx::frame();
-	}
-}
-
-// RenderingSystemInterface::~RenderingSystemInterface() = default;
-
 RenderingSystem::~RenderingSystem() = default;
 
 void RenderingSystem::PrepareDrawDescs(bool drawBoundingBox)
@@ -133,87 +117,5 @@ void RenderingSystem::PrepareDrawUploadUniforms(bool drawBoundingBox)
 	{
 		const auto size = static_cast<uint32_t>(_renderContext.instanceUniforms.size() * sizeof(glm::mat4));
 		bgfx::update(_renderContext.instanceUniformBuffer, 0, bgfx::makeRef(_renderContext.instanceUniforms.data(), size));
-	}
-}
-
-void RenderingSystem::SetDirty()
-{
-	_renderContext.dirty = true;
-}
-
-void RenderingSystem::PrepareDraw(bool drawBoundingBox, bool drawFootpaths, bool drawStreams)
-{
-	auto& registry = Locator::entitiesRegistry::value();
-
-	if (_renderContext.dirty || _renderContext.hasBoundingBoxes != drawBoundingBox ||
-	    (_renderContext.footpaths != nullptr) != drawFootpaths || (_renderContext.streams != nullptr) != drawStreams)
-	{
-		PrepareDrawDescs(drawBoundingBox);
-		PrepareDrawUploadUniforms(drawBoundingBox);
-
-		_renderContext.boundingBox.reset();
-		if (drawBoundingBox)
-		{
-			_renderContext.boundingBox = graphics::DebugLines::CreateBox(glm::vec4(1.0f, 0.0f, 0.0f, 0.5f));
-		}
-
-		_renderContext.footpaths.reset();
-		if (drawFootpaths)
-		{
-			uint32_t nodeCount = 0;
-			registry.Each<const Footpath>(
-			    [&nodeCount](const Footpath& ent) { nodeCount += 2 * std::max(static_cast<int>(ent.nodes.size()) - 1, 0); });
-
-			std::vector<graphics::DebugLines::Vertex> edges;
-			edges.reserve(nodeCount);
-			registry.Each<const Footpath>([&edges](const Footpath& ent) {
-				const auto color = glm::vec4(0, 1, 0, 1);
-				const auto offset = glm::vec3(0, 1, 0);
-				for (int i = 0; i < static_cast<int>(ent.nodes.size()) - 1; ++i)
-				{
-					edges.push_back({glm::vec4(ent.nodes[i].position + offset, 1.0f), color});
-					edges.push_back({glm::vec4(ent.nodes[i + 1].position + offset, 1.0f), color});
-				}
-			});
-			if (!edges.empty())
-			{
-				_renderContext.footpaths =
-				    graphics::DebugLines::CreateDebugLines(edges.data(), static_cast<uint32_t>(edges.size()));
-			}
-		}
-
-		_renderContext.streams.reset();
-		if (drawStreams)
-		{
-			uint32_t edgeCount = 0;
-			registry.Each<const Stream>([&edgeCount](const Stream& ent) {
-				for (const auto& from : ent.nodes)
-				{
-					edgeCount += static_cast<uint32_t>(from.edges.size());
-				}
-			});
-			std::vector<graphics::DebugLines::Vertex> edges;
-			edges.reserve(edgeCount * 2);
-			registry.Each<const Stream>([&edges](const Stream& ent) {
-				const auto color = glm::vec4(1, 0, 0, 1);
-				for (const auto& from : ent.nodes)
-				{
-					for (const auto& to : from.edges)
-					{
-						edges.push_back({glm::vec4(from.position, 1.0f), color});
-						edges.push_back({glm::vec4(to.position, 1.0f), color});
-					}
-				}
-			});
-
-			if (!edges.empty())
-			{
-				_renderContext.streams =
-				    graphics::DebugLines::CreateDebugLines(edges.data(), static_cast<uint32_t>(edges.size()));
-			}
-		}
-
-		_renderContext.dirty = false;
-		_renderContext.hasBoundingBoxes = drawBoundingBox;
 	}
 }

--- a/src/ECS/Systems/Implementations/RenderingSystem.cpp
+++ b/src/ECS/Systems/Implementations/RenderingSystem.cpp
@@ -17,8 +17,8 @@
 #include "ECS/Components/Mesh.h"
 #include "ECS/Components/MorphWithTerrain.h"
 #include "ECS/Components/Stream.h"
-#include "ECS/Components/Transform.h"
 #include "ECS/Components/Temple.h"
+#include "ECS/Components/Transform.h"
 #include "ECS/Registry.h"
 #include "Graphics/DebugLines.h"
 #include "Graphics/ShaderManager.h"
@@ -63,8 +63,8 @@ void RenderingSystem::PrepareDrawDescs(bool drawBoundingBox)
 	registry.Each<const Mesh, const Transform>([&prep](const Mesh& mesh, const Transform& /*unused*/) { prep(mesh, false); },
 	                                           entt::exclude<MorphWithTerrain, TempleInteriorPart>);
 	registry.Each<const Mesh, const Transform, const MorphWithTerrain>(
-	     [&prep](const Mesh& mesh, const Transform& /*unused*/, const MorphWithTerrain& /*unused*/) { prep(mesh, true); });
-	
+	    [&prep](const Mesh& mesh, const Transform& /*unused*/, const MorphWithTerrain& /*unused*/) { prep(mesh, true); });
+
 	if (drawBoundingBox)
 	{
 		instanceCount *= 2;
@@ -126,7 +126,8 @@ void RenderingSystem::PrepareDrawUploadUniforms(bool drawBoundingBox)
 			    _renderContext.instanceUniforms[idx + _renderContext.instanceUniforms.size() / 2] = boxMatrix;
 		    }
 		    offset.first->second++;
-	    }, entt::exclude<TempleInteriorPart>);
+	    },
+	    entt::exclude<TempleInteriorPart>);
 
 	if (!_renderContext.instanceUniforms.empty())
 	{

--- a/src/ECS/Systems/Implementations/RenderingSystemCommon.cpp
+++ b/src/ECS/Systems/Implementations/RenderingSystemCommon.cpp
@@ -1,0 +1,127 @@
+/******************************************************************************
+ * Copyright (c) 2018-2023 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *******************************************************************************/
+
+#define LOCATOR_IMPLEMENTATIONS
+
+#include "RenderingSystemCommon.h"
+
+#include <glm/gtx/transform.hpp>
+
+#include "3D/L3DMesh.h"
+#include "ECS/Components/Mesh.h"
+#include "ECS/Components/MorphWithTerrain.h"
+#include "ECS/Components/Stream.h"
+#include "ECS/Components/Temple.h"
+#include "ECS/Components/Transform.h"
+#include "ECS/Registry.h"
+#include "Graphics/DebugLines.h"
+#include "Graphics/ShaderManager.h"
+#include "Locator.h"
+#include "Resources/ResourcesInterface.h"
+
+using namespace openblack::ecs::systems;
+using namespace openblack::ecs::components;
+
+RenderContext::RenderContext()
+    : instanceUniformBuffer(BGFX_INVALID_HANDLE)
+{
+}
+RenderContext::~RenderContext()
+{
+	if (bgfx::isValid(instanceUniformBuffer))
+	{
+		bgfx::destroy(instanceUniformBuffer);
+		bgfx::frame();
+		bgfx::frame();
+	}
+}
+
+RenderingSystemCommon::~RenderingSystemCommon() = default;
+
+void RenderingSystemCommon::SetDirty()
+{
+	_renderContext.dirty = true;
+}
+
+void RenderingSystemCommon::PrepareDraw(bool drawBoundingBox, bool drawFootpaths, bool drawStreams)
+{
+	auto& registry = Locator::entitiesRegistry::value();
+
+	if (_renderContext.dirty || _renderContext.hasBoundingBoxes != drawBoundingBox ||
+	    (_renderContext.footpaths != nullptr) != drawFootpaths || (_renderContext.streams != nullptr) != drawStreams)
+	{
+		PrepareDrawDescs(drawBoundingBox);
+		PrepareDrawUploadUniforms(drawBoundingBox);
+
+		_renderContext.boundingBox.reset();
+		if (drawBoundingBox)
+		{
+			_renderContext.boundingBox = graphics::DebugLines::CreateBox(glm::vec4(1.0f, 0.0f, 0.0f, 0.5f));
+		}
+
+		_renderContext.footpaths.reset();
+		if (drawFootpaths)
+		{
+			uint32_t nodeCount = 0;
+			registry.Each<const Footpath>(
+			    [&nodeCount](const Footpath& ent) { nodeCount += 2 * std::max(static_cast<int>(ent.nodes.size()) - 1, 0); });
+
+			std::vector<graphics::DebugLines::Vertex> edges;
+			edges.reserve(nodeCount);
+			registry.Each<const Footpath>([&edges](const Footpath& ent) {
+				const auto color = glm::vec4(0, 1, 0, 1);
+				const auto offset = glm::vec3(0, 1, 0);
+				for (int i = 0; i < static_cast<int>(ent.nodes.size()) - 1; ++i)
+				{
+					edges.push_back({glm::vec4(ent.nodes[i].position + offset, 1.0f), color});
+					edges.push_back({glm::vec4(ent.nodes[i + 1].position + offset, 1.0f), color});
+				}
+			});
+			if (!edges.empty())
+			{
+				_renderContext.footpaths =
+				    graphics::DebugLines::CreateDebugLines(edges.data(), static_cast<uint32_t>(edges.size()));
+			}
+		}
+
+		_renderContext.streams.reset();
+		if (drawStreams)
+		{
+			uint32_t edgeCount = 0;
+			registry.Each<const Stream>([&edgeCount](const Stream& ent) {
+				for (const auto& from : ent.nodes)
+				{
+					edgeCount += static_cast<uint32_t>(from.edges.size());
+				}
+			});
+			std::vector<graphics::DebugLines::Vertex> edges;
+			edges.reserve(edgeCount * 2);
+			registry.Each<const Stream>([&edges](const Stream& ent) {
+				const auto color = glm::vec4(1, 0, 0, 1);
+				for (const auto& from : ent.nodes)
+				{
+					for (const auto& to : from.edges)
+					{
+						edges.push_back({glm::vec4(from.position, 1.0f), color});
+						edges.push_back({glm::vec4(to.position, 1.0f), color});
+					}
+				}
+			});
+
+			if (!edges.empty())
+			{
+				_renderContext.streams =
+				    graphics::DebugLines::CreateDebugLines(edges.data(), static_cast<uint32_t>(edges.size()));
+			}
+		}
+
+		_renderContext.dirty = false;
+		_renderContext.hasBoundingBoxes = drawBoundingBox;
+	}
+}

--- a/src/ECS/Systems/Implementations/RenderingSystemCommon.h
+++ b/src/ECS/Systems/Implementations/RenderingSystemCommon.h
@@ -17,7 +17,7 @@
 #include <glm/mat4x4.hpp>
 
 #include "3D/AllMeshes.h"
-#include "RenderingSystemCommon.h"
+#include "ECS/Systems/RenderingSystemInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
 #warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
@@ -26,13 +26,19 @@
 namespace openblack::ecs::systems
 {
 
-class RenderingSystem final: public RenderingSystemCommon
+class RenderingSystemCommon: public RenderingSystemInterface
 {
 public:
-	~RenderingSystem();
+	~RenderingSystemCommon();
+	void SetDirty() override;
+	void PrepareDraw(bool drawBoundingBox, bool drawFootpaths, bool drawStreams) override;
+	const RenderContext& GetContext() override { return _renderContext; }
 
 private:
-	void PrepareDrawDescs(bool drawBoundingBox) override;
-	void PrepareDrawUploadUniforms(bool drawBoundingBox) override;
+	virtual void PrepareDrawDescs(bool drawBoundingBox) = 0;
+	virtual void PrepareDrawUploadUniforms(bool drawBoundingBox) = 0;
+
+protected:
+	RenderContext _renderContext;
 };
 } // namespace openblack::ecs::systems

--- a/src/ECS/Systems/Implementations/RenderingSystemTemple.cpp
+++ b/src/ECS/Systems/Implementations/RenderingSystemTemple.cpp
@@ -16,8 +16,8 @@
 #include "3D/L3DMesh.h"
 #include "ECS/Components/Mesh.h"
 #include "ECS/Components/Stream.h"
-#include "ECS/Components/Transform.h"
 #include "ECS/Components/Temple.h"
+#include "ECS/Components/Transform.h"
 #include "ECS/Registry.h"
 #include "Graphics/DebugLines.h"
 #include "Graphics/ShaderManager.h"
@@ -45,8 +45,9 @@ void RenderingSystemTemple::PrepareDrawDescs(bool drawBoundingBox)
 		instanceCount++;
 	};
 
-	registry.Each<const Mesh, const Transform, const TempleInteriorPart>([&prep](const Mesh& mesh, const Transform& /*unused*/, const TempleInteriorPart& /* unused */) { prep(mesh, false); });
-	
+	registry.Each<const Mesh, const Transform, const TempleInteriorPart>(
+	    [&prep](const Mesh& mesh, const Transform& /*unused*/, const TempleInteriorPart& /* unused */) { prep(mesh, false); });
+
 	if (drawBoundingBox)
 	{
 		instanceCount *= 2;
@@ -90,7 +91,8 @@ void RenderingSystemTemple::PrepareDrawUploadUniforms(bool drawBoundingBox)
 
 	// Set transforms for instanced draw at offsets
 	registry.Each<const Mesh, const Transform, const TempleInteriorPart>(
-	    [this, &uniformOffsets, drawBoundingBox](const Mesh& mesh, const Transform& transform, const TempleInteriorPart& /* unused */) {
+	    [this, &uniformOffsets, drawBoundingBox](const Mesh& mesh, const Transform& transform,
+	                                             const TempleInteriorPart& /* unused */) {
 		    auto offset = uniformOffsets.insert(std::make_pair(mesh.id, 0));
 		    auto desc = _renderContext.instancedDrawDescs.find(mesh.id);
 

--- a/src/ECS/Systems/Implementations/RenderingSystemTemple.h
+++ b/src/ECS/Systems/Implementations/RenderingSystemTemple.h
@@ -17,6 +17,7 @@
 #include <glm/mat4x4.hpp>
 
 #include "3D/AllMeshes.h"
+#include "ECS/Components/Temple.h"
 #include "RenderingSystemCommon.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
@@ -34,5 +35,6 @@ public:
 private:
 	void PrepareDrawDescs(bool drawBoundingBox) override;
 	void PrepareDrawUploadUniforms(bool drawBoundingBox) override;
+	std::set<ecs::components::TempleRoom> _loadedRooms;
 };
 } // namespace openblack::ecs::systems

--- a/src/ECS/Systems/Implementations/RenderingSystemTemple.h
+++ b/src/ECS/Systems/Implementations/RenderingSystemTemple.h
@@ -26,10 +26,10 @@
 namespace openblack::ecs::systems
 {
 
-class RenderingSystem final: public RenderingSystemInterface
+class RenderingSystemTemple final: public RenderingSystemInterface
 {
 public:
-	~RenderingSystem();
+	~RenderingSystemTemple();
 	void SetDirty() override;
 	void PrepareDraw(bool drawBoundingBox, bool drawFootpaths, bool drawStreams) override;
 	const RenderContext& GetContext() override { return _renderContext; }

--- a/src/ECS/Systems/Implementations/RenderingSystemTemple.h
+++ b/src/ECS/Systems/Implementations/RenderingSystemTemple.h
@@ -17,7 +17,7 @@
 #include <glm/mat4x4.hpp>
 
 #include "3D/AllMeshes.h"
-#include "ECS/Systems/RenderingSystemInterface.h"
+#include "RenderingSystemCommon.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
 #warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
@@ -26,18 +26,13 @@
 namespace openblack::ecs::systems
 {
 
-class RenderingSystemTemple final: public RenderingSystemInterface
+class RenderingSystemTemple final: public RenderingSystemCommon
 {
 public:
 	~RenderingSystemTemple();
-	void SetDirty() override;
-	void PrepareDraw(bool drawBoundingBox, bool drawFootpaths, bool drawStreams) override;
-	const RenderContext& GetContext() override { return _renderContext; }
 
 private:
-	void PrepareDrawDescs(bool drawBoundingBox);
-	void PrepareDrawUploadUniforms(bool drawBoundingBox);
-
-	RenderContext _renderContext;
+	void PrepareDrawDescs(bool drawBoundingBox) override;
+	void PrepareDrawUploadUniforms(bool drawBoundingBox) override;
 };
 } // namespace openblack::ecs::systems

--- a/src/ECS/Systems/RenderingSystemInterface.h
+++ b/src/ECS/Systems/RenderingSystemInterface.h
@@ -66,6 +66,6 @@ public:
 	virtual void SetDirty() = 0;
 	virtual void PrepareDraw(bool drawBoundingBox, bool drawFootpaths, bool drawStreams) = 0;
 	virtual const RenderContext& GetContext() = 0;
-	virtual ~RenderingSystemInterface();
+	inline ~RenderingSystemInterface() = default;
 };
 } // namespace openblack::ecs::systems


### PR DESCRIPTION
Try to implement #646, this try to leverage the locator and renderingSystem and switch the rendering system when activating the temple.
The normal rendering system filter out temple interior entity, the temple rendering system filter out all that is not a temple interior entity.

- [x] Create a specific renderer only for the temple interior.
- - [x] This renderer need only to render Interior part currently used by the game.
- - [x] The normal renderer need to not render interior part.

EDIT
Here is an example of the temple without island entities rendered.
![templeAlone](https://github.com/openblack/openblack/assets/83550517/a0765dda-6e96-49ff-9c0c-266459f72cec)
Be aware, dynamic loading of the temple not being implemented entering the temple is still not possible on vulkan.