### PR TITLE
Set blockPosition through InstanceDataBuffer

### DIFF
--- a/assets/shaders/vs_terrain.sc
+++ b/assets/shaders/vs_terrain.sc
@@ -1,4 +1,4 @@
-$input a_position, a_texcoord1, a_color1, a_color2, a_texcoord2, a_color0, a_color3
+$input a_position, a_texcoord1, a_color1, a_color2, a_texcoord2, a_color0, a_color3, i_data0
 $output v_texcoord0, v_texcoord1, v_weight, v_materialID0, v_materialID1, v_materialBlend, v_lightLevel, v_waterAlpha, v_distToCamera
 
 #include <bgfx_shader.sh>
@@ -9,12 +9,13 @@ $output v_texcoord0, v_texcoord1, v_weight, v_materialID0, v_materialID1, v_mate
 #   define materialIdFix(x) (ivec3(x))
 #endif
 
-uniform vec4 u_blockPositionAndSize;
+// uniform vec4 u_blockPositionAndSize;
 uniform vec4 u_islandExtent;
 
 void main()
 {
 	// Unpack
+	vec4 u_blockPositionAndSize = i_data0;
 	vec2 blockPosition = u_blockPositionAndSize.xy;
 	vec2 blockSize = u_blockPositionAndSize.zw;
 	vec2 extentMin = u_islandExtent.xy;

--- a/assets/shaders/vs_terrain.sc
+++ b/assets/shaders/vs_terrain.sc
@@ -9,7 +9,6 @@ $output v_texcoord0, v_texcoord1, v_weight, v_materialID0, v_materialID1, v_mate
 #   define materialIdFix(x) (ivec3(x))
 #endif
 
-// uniform vec4 u_blockPositionAndSize;
 uniform vec4 u_islandExtent;
 
 void main()

--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -41,16 +41,18 @@ LandIsland::LandIsland(const std::filesystem::path& path)
 	const size_t instanceCount = GetBlocks().size();
 	bgfx::VertexLayout layout;
 	layout.begin().add(bgfx::Attrib::TexCoord7, 4, bgfx::AttribType::Float).end();
+	const auto* mem = bgfx::alloc(static_cast<uint32_t>(sizeof(glm::vec4) * instanceCount));
+	auto* instanceUniforms = reinterpret_cast<glm::vec4*>(mem->data);
+
 	_instanceData = bgfx::createDynamicVertexBuffer(static_cast<uint32_t>(instanceCount), layout);
 	for (size_t idx = 0; idx < instanceCount; idx++)
 	{
 		// pack uniforms
 		const auto& block = GetBlocks()[idx];
 		const glm::vec4 mapPositionAndSize = glm::vec4(block.GetMapPosition(), 160.0f, 160.0f);
-		_instanceUniforms.emplace_back(mapPositionAndSize);
+		instanceUniforms[idx] = mapPositionAndSize;
 	}
-	const auto size = static_cast<uint32_t>(_instanceUniforms.size() * sizeof(glm::vec4));
-	bgfx::update(_instanceData, 0, bgfx::makeRef(_instanceUniforms.data(), size));
+	bgfx::update(_instanceData, 0, mem);
 }
 
 LandIsland::~LandIsland()

--- a/src/3D/LandIsland.h
+++ b/src/3D/LandIsland.h
@@ -39,6 +39,8 @@ private:
 	[[nodiscard]] std::vector<uint8_t> CreateHeightMap() const;
 	std::vector<LandBlock> _landBlocks;
 	std::vector<lnd::LNDCountry> _countries;
+	bgfx::DynamicVertexBufferHandle _instanceData;
+	std::vector<glm::vec4> _instanceUniforms;
 
 	std::array<uint8_t, 1024> _blockIndexLookup {0};
 
@@ -46,6 +48,7 @@ private:
 public:
 	[[nodiscard]] std::vector<LandBlock>& GetBlocks() override { return _landBlocks; }
 	[[nodiscard]] const std::vector<LandBlock>& GetBlocks() const override { return _landBlocks; }
+	[[nodiscard]] const bgfx::DynamicVertexBufferHandle& GetInstanceData() const override { return _instanceData; }
 	[[nodiscard]] const std::vector<lnd::LNDCountry>& GetCountries() const override { return _countries; }
 
 	[[nodiscard]] const graphics::Texture2D& GetAlbedoArray() const override { return *_materialArray; }

--- a/src/3D/LandIsland.h
+++ b/src/3D/LandIsland.h
@@ -40,7 +40,6 @@ private:
 	std::vector<LandBlock> _landBlocks;
 	std::vector<lnd::LNDCountry> _countries;
 	bgfx::DynamicVertexBufferHandle _instanceData;
-	std::vector<glm::vec4> _instanceUniforms;
 
 	std::array<uint8_t, 1024> _blockIndexLookup {0};
 

--- a/src/3D/LandIslandInterface.h
+++ b/src/3D/LandIslandInterface.h
@@ -48,6 +48,7 @@ public:
 
 	[[nodiscard]] virtual std::vector<LandBlock>& GetBlocks() = 0;
 	[[nodiscard]] virtual const std::vector<LandBlock>& GetBlocks() const = 0;
+	[[nodiscard]] virtual const bgfx::DynamicVertexBufferHandle& GetInstanceData() const = 0;
 	[[nodiscard]] virtual const std::vector<lnd::LNDCountry>& GetCountries() const = 0;
 
 	[[nodiscard]] virtual const graphics::Texture2D& GetAlbedoArray() const = 0;

--- a/src/3D/UnloadedIsland.h
+++ b/src/3D/UnloadedIsland.h
@@ -46,6 +46,11 @@ public:
 		throw std::runtime_error("Cannot get landscape before any are loaded");
 	}
 
+	[[nodiscard]] const bgfx::DynamicVertexBufferHandle& GetInstanceData() const override
+	{
+		throw std::runtime_error("Cannot get landscape before any are loaded");
+	}
+
 	[[nodiscard]] const std::vector<lnd::LNDCountry>& GetCountries() const override
 	{
 		throw std::runtime_error("Cannot get landscape before any are loaded");

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -579,13 +579,13 @@ void Renderer::DrawPass(const DrawSceneDesc& desc) const
 			;
 			// clang-format on
 
-			for (const auto& block : island.GetBlocks())
+			const size_t instanceCount = island.GetBlocks().size();
+			for (size_t idx = 0; idx < instanceCount; idx++)
 			{
-				// pack uniforms
-				const glm::vec4 mapPositionAndSize = glm::vec4(block.GetMapPosition(), 160.0f, 160.0f);
-				terrainShader->SetUniformValue("u_blockPositionAndSize", &mapPositionAndSize);
-
+				const auto& block = island.GetBlocks()[idx];
+				const auto instanceData = island.GetInstanceData();
 				block.GetMesh().GetVertexBuffer().Bind();
+				bgfx::setInstanceDataBuffer(instanceData, static_cast<uint32_t>(idx), 1);
 
 				bgfx::setState(defaultState | (desc.cullBack ? BGFX_STATE_CULL_CCW : BGFX_STATE_CULL_CW), 0);
 				bgfx::submit(static_cast<bgfx::ViewId>(desc.viewId), terrainShader->GetRawHandle(), 0, discard);


### PR DESCRIPTION
Use an uniform array in LandIsland to feed the u_blockPositionAndSize uniform as instance data inside vs_terrain.sc.