### PR TITLE
Lh script decoupling

### DIFF
--- a/src/Debug/Console.cpp
+++ b/src/Debug/Console.cpp
@@ -365,7 +365,7 @@ void Console::Draw(Game& game)
 
 		if (s[0] != 0)
 		{
-			ExecCommand(s, game);
+			ExecCommand(s);
 		}
 
 		_inputBuffer[0] = '\0';
@@ -411,7 +411,7 @@ void Console::AddLog(const char* fmt, ...)
 	_items.emplace_back(buf.data());
 }
 
-void Console::ExecCommand(const std::string& commandLine, Game& game)
+void Console::ExecCommand(const std::string& commandLine)
 {
 	AddLog("# %s\n", commandLine.c_str());
 
@@ -453,7 +453,7 @@ void Console::ExecCommand(const std::string& commandLine, Game& game)
 	{
 		try
 		{
-			lhscriptx::Script script(&game);
+			lhscriptx::Script script;
 			script.Load(commandLine);
 		}
 		catch (std::runtime_error& error)

--- a/src/Debug/Console.h
+++ b/src/Debug/Console.h
@@ -46,7 +46,7 @@ protected:
 
 private:
 	void AddLog(const char* fmt, ...);
-	void ExecCommand(const std::string& commandLine, Game& game);
+	void ExecCommand(const std::string& commandLine);
 	int InputTextCallback(ImGuiInputTextCallbackData* data);
 
 	bool _reclaimFocus {false};

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -888,7 +888,7 @@ void Game::LoadMap(const std::filesystem::path& path)
 	_handEntity = ecs::archetypes::HandArchetype::Create(glm::vec3(0.0f), glm::half_pi<float>(), 0.0f, glm::half_pi<float>(),
 	                                                     0.01f, false);
 
-	Script script(this);
+	Script script;
 	script.Load(source);
 
 	// Each released map comes with an optional .fot file which contains the footpath information for the map

--- a/src/LHScriptX/CommandSignature.h
+++ b/src/LHScriptX/CommandSignature.h
@@ -97,25 +97,7 @@ private:
 
 using ScriptCommandParameters = std::vector<ScriptCommandParameter>;
 
-class ScriptCommandContext
-{
-public:
-	ScriptCommandContext(Game* game, const ScriptCommandParameters* parameters)
-	    : _game(game)
-	    , _parameters(parameters)
-	{
-	}
-
-	[[nodiscard]] Game& GetGame() const { return *_game; }
-
-	const ScriptCommandParameter& operator[](uint32_t arg) const { return _parameters->at(arg); }
-
-private:
-	Game* _game;
-	const ScriptCommandParameters* _parameters;
-};
-
-using ScriptCommand = std::function<void(const ScriptCommandContext&)>;
+using ScriptCommand = std::function<void(const ScriptCommandParameters&)>;
 
 struct ScriptCommandSignature
 {

--- a/src/LHScriptX/CommandSignature.h
+++ b/src/LHScriptX/CommandSignature.h
@@ -14,11 +14,6 @@
 #include <string>
 #include <vector>
 
-namespace openblack
-{
-class Game;
-}
-
 namespace openblack::lhscriptx
 {
 enum class ParameterType

--- a/src/LHScriptX/CommandSignature.h
+++ b/src/LHScriptX/CommandSignature.h
@@ -108,8 +108,6 @@ public:
 
 	[[nodiscard]] Game& GetGame() const { return *_game; }
 
-	[[nodiscard]] const ScriptCommandParameters& GetParameters() const { return *_parameters; }
-
 	const ScriptCommandParameter& operator[](uint32_t arg) const { return _parameters->at(arg); }
 
 private:

--- a/src/LHScriptX/Script.cpp
+++ b/src/LHScriptX/Script.cpp
@@ -196,8 +196,7 @@ void Script::RunCommand(const std::string& identifier, const std::vector<Token>&
 		++i;
 	}
 
-	ScriptCommandContext ctx(_game, &parameters);
-	commandSignature->command(ctx);
+	commandSignature->command(parameters);
 }
 
 const Token* Script::PeekToken(Lexer& lexer)

--- a/src/LHScriptX/Script.cpp
+++ b/src/LHScriptX/Script.cpp
@@ -23,6 +23,8 @@
 using namespace openblack;
 using namespace openblack::lhscriptx;
 
+Script::Script() = default;
+
 void Script::Load(const std::string& source)
 {
 	Lexer lexer(source);

--- a/src/LHScriptX/Script.h
+++ b/src/LHScriptX/Script.h
@@ -21,13 +21,6 @@ class Game;
 namespace openblack::lhscriptx
 {
 
-class NotImplemented: public std::logic_error
-{
-public:
-	NotImplemented()
-	    : std::logic_error("Function not yet implemented") {};
-};
-
 class Script
 {
 public:

--- a/src/LHScriptX/Script.h
+++ b/src/LHScriptX/Script.h
@@ -24,7 +24,7 @@ namespace openblack::lhscriptx
 class Script
 {
 public:
-	Script() = default;
+	Script();
 
 	void Load(const std::string&);
 
@@ -35,8 +35,6 @@ private:
 	const Token* PeekToken(Lexer&);
 	const Token* AdvanceToken(Lexer&);
 
-	// Game instance
-	Game* _game;
 	// The current token.
 	Token _token {Token::MakeInvalidToken()};
 };

--- a/src/LHScriptX/Script.h
+++ b/src/LHScriptX/Script.h
@@ -39,14 +39,7 @@ public:
 
 	void Load(const std::string&);
 
-	// void SetCommands(std::unique_ptr<ScriptCommands> &commands) { _commands =
-	// std::move(commands); } ScriptCommands &GetCommands() const { return
-	// *_commands; }
 private:
-	// std::unique_ptr<ScriptCommands> _commands;
-	// void processCommand(const std::string& command, std::vector<std::string>
-	// parameters);
-
 	[[nodiscard]] bool IsCommand(const std::string& identifier) const;
 	void RunCommand(const std::string& identifier, const std::vector<Token>& args);
 

--- a/src/LHScriptX/Script.h
+++ b/src/LHScriptX/Script.h
@@ -13,11 +13,6 @@
 
 #include "Lexer.h"
 
-namespace openblack
-{
-class Game;
-}
-
 namespace openblack::lhscriptx
 {
 

--- a/src/LHScriptX/Script.h
+++ b/src/LHScriptX/Script.h
@@ -31,11 +31,7 @@ public:
 class Script
 {
 public:
-	explicit Script(Game* game)
-	    : _game(game)
-	    , _token(Token::MakeInvalidToken())
-	{
-	}
+	Script() = default;
 
 	void Load(const std::string&);
 
@@ -49,7 +45,7 @@ private:
 	// Game instance
 	Game* _game;
 	// The current token.
-	Token _token;
+	Token _token {Token::MakeInvalidToken()};
 };
 
 } // namespace openblack::lhscriptx

--- a/test/mobile_wall_hug/test_mobile_wall_hug.cpp
+++ b/test/mobile_wall_hug/test_mobile_wall_hug.cpp
@@ -203,7 +203,7 @@ protected:
 		args.logLevels[static_cast<uint8_t>(openblack::LoggingSubsystem::pathfinding)] = spdlog::level::debug;
 		_game = std::make_unique<openblack::Game>(std::move(args));
 		ASSERT_TRUE(_game->Initialize());
-		auto script = openblack::lhscriptx::Script(_game.get());
+		openblack::lhscriptx::Script script;
 		script.Load(_sceneScript);
 
 		_villagerEntt = Locator::entitiesRegistry::value().Front<const ecs::components::Villager>();

--- a/test/test_load_scene.cpp
+++ b/test/test_load_scene.cpp
@@ -16,7 +16,7 @@ class LoadScene: public ::testing::Test
 public:
 	void LoadTestScene(const char* sceneScript)
 	{
-		auto script = openblack::lhscriptx::Script(game_.get());
+		openblack::lhscriptx::Script script;
 		script.Load(sceneScript);
 	}
 


### PR DESCRIPTION
Implement #617 

* [x]  removal of `lhscriptx::NotImplemented`
* [x]  removal of  commented out functions of `lhscriptx::Script`
* [x]  `lhscriptx::Script` constructor set to default (in cpp file), `_token` is set in declaration.
* [x]  removal of  `lhscriptx::ScriptCommandContext::GetParameters`
* [x]  removal of  `lhscriptx::ScriptCommandContext`.

The last point will need a further look into how `lhscriptx::ScriptCommandContext` is used as it should be removable but will need a look as to where and it is used in the different part of lhscriptx.