### PR TITLE
Reversing the depth

### DIFF
--- a/src/3D/Camera.cpp
+++ b/src/3D/Camera.cpp
@@ -134,11 +134,11 @@ void Camera::ResetVelocities()
 void Camera::SetProjectionMatrixPerspective(float xFov, float aspect, float nearClip, float farClip)
 {
 	const float yFov = (glm::atan(glm::tan(glm::radians(xFov) / 2.0f)) / aspect) * 2.0f;
-	const float h = -1.0f / tan(yFov * 0.5f);
-	const float w = -h / aspect;
+	const float h = 1.0f / glm::tan(yFov * 0.5f);
+	const float w = h / aspect;
 	const float a = nearClip / (farClip - nearClip);
 	const float b = (nearClip * farClip) / (farClip - nearClip);
-	_projectionMatrix = glm::mat4x4(w, 0.f, 0.f, 0.f, 0.f, -h, 0.f, 0.f, 0.f, 0.f, a, 1.f, 0.f, 0.f, b, 0.f);
+	_projectionMatrix = glm::mat4x4(w, 0.f, 0.f, 0.f, 0.f, h, 0.f, 0.f, 0.f, 0.f, a, 1.f, 0.f, 0.f, b, 0.f);
 }
 
 glm::vec3 Camera::GetForward() const

--- a/src/3D/Camera.cpp
+++ b/src/3D/Camera.cpp
@@ -133,8 +133,12 @@ void Camera::ResetVelocities()
 
 void Camera::SetProjectionMatrixPerspective(float xFov, float aspect, float nearClip, float farClip)
 {
-	float yFov = (glm::atan(glm::tan(glm::radians(xFov) / 2.0f)) / aspect) * 2.0f;
-	_projectionMatrix = glm::perspective(yFov, aspect, nearClip, farClip);
+	const float yFov = (glm::atan(glm::tan(glm::radians(xFov) / 2.0f)) / aspect) * 2.0f;
+	const float h = -1.0f / tan(yFov * 0.5f);
+	const float w = -h / aspect;
+	const float a = nearClip / (farClip - nearClip);
+	const float b = (nearClip * farClip) / (farClip - nearClip);
+	_projectionMatrix = glm::mat4x4(w, 0.f, 0.f, 0.f, 0.f, -h, 0.f, 0.f, 0.f, 0.f, a, 1.f, 0.f, 0.f, b, 0.f);
 }
 
 glm::vec3 Camera::GetForward() const

--- a/src/3D/Camera.cpp
+++ b/src/3D/Camera.cpp
@@ -181,7 +181,7 @@ void Camera::DeprojectScreenToWorld(glm::ivec2 screenPosition, glm::ivec2 screen
 	// projection space (z=0 is near, z=1 is far - this gives us better
 	// precision) To get the direction of the ray trace we need to use any z
 	// between the near and the far plane, so let's use (mousex, mousey, 0.5)
-	const glm::vec4 rayStartProjectionSpace = glm::vec4(screenSpaceX, screenSpaceY, 0.0f, 1.0f);
+	const glm::vec4 rayStartProjectionSpace = glm::vec4(screenSpaceX, screenSpaceY, 1.0f, 1.0f);
 	const glm::vec4 rayEndProjectionSpace = glm::vec4(screenSpaceX, screenSpaceY, 0.5f, 1.0f);
 
 	// Calculate our inverse view projection matrix

--- a/src/ECS/Systems/Implementations/DynamicsSystem.cpp
+++ b/src/ECS/Systems/Implementations/DynamicsSystem.cpp
@@ -137,7 +137,11 @@ DynamicsSystem::RayCastClosestHit(const glm::vec3& origin, const glm::vec3& dire
 	auto translation = glm::vec3(callback.m_hitPointWorld.x(), callback.m_hitPointWorld.y(), callback.m_hitPointWorld.z());
 	auto normal = glm::vec3(callback.m_hitNormalWorld.x(), callback.m_hitNormalWorld.y(), callback.m_hitNormalWorld.z());
 	const auto up = glm::vec3(0, 1, 0);
-	auto rotation = glm::orientation(normal, up);
+	auto rotation = glm::mat4(1.f);
+	if (abs(normal) != abs(up))
+	{
+		rotation = glm::orientation(normal, up);
+	}
 
 	return std::make_optional(std::make_pair(
 	    Transform {translation, rotation, glm::vec3(1.0f)},

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -435,7 +435,12 @@ void Renderer::DrawFootprintPass(const DrawSceneDesc& drawDesc) const
 			footprintShaderInstanced->SetTextureSampler("s_footprint", 0, *footprint.texture);
 			footprint.mesh->GetVertexBuffer().Bind();
 			bgfx::setInstanceDataBuffer(renderCtx.instanceUniformBuffer, placers.offset, placers.count);
-			const uint64_t state = k_BgfxDefaultStateInvertedZ;
+			const uint64_t state = 0u                       //
+			                       | BGFX_STATE_WRITE_RGB   //
+			                       | BGFX_STATE_WRITE_A     //
+			                       | BGFX_STATE_BLEND_ALPHA //
+			                       | BGFX_STATE_CULL_CW     //
+			                       | BGFX_STATE_MSAA;
 			bgfx::setState(state);
 			bgfx::submit(static_cast<bgfx::ViewId>(viewId), footprintShaderInstanced->GetRawHandle());
 		}


### PR DESCRIPTION
Reversing (1 for the near plane, 0 for the far plane) the Depth value in order to avoid Z-Fighting as observed in #213  (which will be solved by this PR).

Changes the camera perspective matrix and the BGFX state in the renderer.
Superficial check were done on :
- [x] OpenGL
- [x] OpenGLES
- [x] Vulkan
- [x] Direct3D11
- [x] Direct3D12
- [x] Metal
- ~Gnm~
- ~Nvn~
- ~Noop~

Example of #213
![213notsolargedist](https://github.com/openblack/openblack/assets/83550517/88aea336-3cc0-4d47-8cde-202466b968de)
Same viewpoint now
![screenshot](https://github.com/openblack/openblack/assets/83550517/cb45d098-ac4e-4141-a3d9-8f1a8e3eaae8)

TBD : Checking that the camera does behave the same and that the math are correct.