### PR TITLE
filesystem: Move pre-compiler checks to interface

### DIFF
--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -48,12 +48,14 @@ void LandIsland::LoadFromFile(const std::filesystem::path& path)
 
 	try
 	{
-#if __ANDROID__
-		//  Android has a complicated permissions API, must call java code to read contents.
-		lnd.Open(Locator::filesystem::value().ReadAll(path));
-#else
-		lnd.Open(path);
-#endif
+		if (Locator::filesystem::value().PreferBuffer())
+		{
+			lnd.Open(Locator::filesystem::value().ReadAll(path));
+		}
+		else
+		{
+			lnd.Open(path);
+		}
 	}
 	catch (std::runtime_error& err)
 	{

--- a/src/3D/Sky.cpp
+++ b/src/3D/Sky.cpp
@@ -33,13 +33,15 @@ Sky::Sky()
 
 	// load in the mesh
 	_model = std::make_unique<L3DMesh>("Sky");
-#if __ANDROID__
-	//  Android has a complicated permissions API, must call java code to read contents.
-	_model->LoadFromBuffer(
-	    Locator::filesystem::value().ReadAll(fileSystem.GetPath<filesystem::Path::WeatherSystem>() / "sky.l3d"));
-#else
-	_model->LoadFromFile(fileSystem.GetPath<filesystem::Path::WeatherSystem>() / "sky.l3d");
-#endif
+	if (Locator::filesystem::value().PreferBuffer())
+	{
+		_model->LoadFromBuffer(
+		    Locator::filesystem::value().ReadAll(fileSystem.GetPath<filesystem::Path::WeatherSystem>() / "sky.l3d"));
+	}
+	else
+	{
+		_model->LoadFromFile(fileSystem.GetPath<filesystem::Path::WeatherSystem>() / "sky.l3d");
+	}
 
 	for (uint32_t idx = 0; const auto& alignment : k_Alignments)
 	{

--- a/src/FileSystem/AndroidFileSystem.h
+++ b/src/FileSystem/AndroidFileSystem.h
@@ -26,6 +26,8 @@ public:
 	AndroidFileSystem();
 	~AndroidFileSystem();
 
+	// Android has a complicated permissions API, must call java code to read contents.
+	[[nodiscard]] bool PreferBuffer() const override { return true; }
 	[[nodiscard]] std::filesystem::path FindPath(const std::filesystem::path& path) const override;
 	std::unique_ptr<Stream> Open(const std::filesystem::path& path, Stream::Mode mode) override;
 	bool Exists(const std::filesystem::path& path) const override;

--- a/src/FileSystem/DefaultFileSystem.h
+++ b/src/FileSystem/DefaultFileSystem.h
@@ -23,6 +23,7 @@ namespace openblack::filesystem
 class DefaultFileSystem: public FileSystemInterface
 {
 public:
+	[[nodiscard]] bool PreferBuffer() const override { return false; }
 	[[nodiscard]] std::filesystem::path FindPath(const std::filesystem::path& path) const override;
 	std::unique_ptr<Stream> Open(const std::filesystem::path& path, Stream::Mode mode) override;
 	[[nodiscard]] bool Exists(const std::filesystem::path& path) const override;

--- a/src/FileSystem/FileSystemInterface.h
+++ b/src/FileSystem/FileSystemInterface.h
@@ -107,6 +107,7 @@ public:
 		return withGamePath ? (GetGamePath() / result) : result;
 	}
 
+	[[nodiscard]] virtual bool PreferBuffer() const = 0;
 	[[nodiscard]] virtual std::filesystem::path FindPath(const std::filesystem::path& path) const = 0;
 	virtual std::unique_ptr<Stream> Open(const std::filesystem::path& path, Stream::Mode mode) = 0;
 	[[nodiscard]] virtual bool Exists(const std::filesystem::path& path) const = 0;

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -543,12 +543,16 @@ bool Game::Initialize()
 	    });
 
 	pack::PackFile pack;
-#if __ANDROID__
-	//  Android has a complicated permissions API, must call java code to read contents.
-	pack.Open(fileSystem.ReadAll(fileSystem.GetPath<Path::Data>(true) / "AllMeshes.g3d"));
-#else
-	pack.Open(fileSystem.GetPath<Path::Data>(true) / "AllMeshes.g3d");
-#endif
+
+	if (Locator::filesystem::value().PreferBuffer())
+	{
+		pack.Open(fileSystem.ReadAll(fileSystem.GetPath<Path::Data>(true) / "AllMeshes.g3d"));
+	}
+	else
+	{
+		pack.Open(fileSystem.GetPath<Path::Data>(true) / "AllMeshes.g3d");
+	}
+
 	const auto& meshes = pack.GetMeshes();
 	for (size_t i = 0; const auto& mesh : meshes)
 	{
@@ -564,12 +568,15 @@ bool Game::Initialize()
 	}
 
 	pack::PackFile animationPack;
-#if __ANDROID__
-	//  Android has a complicated permissions API, must call java code to read contents.
-	animationPack.Open(fileSystem.ReadAll(fileSystem.GetPath<Path::Data>(true) / "AllAnims.anm"));
-#else
-	animationPack.Open(fileSystem.GetPath<Path::Data>(true) / "AllAnims.anm");
-#endif
+
+	if (Locator::filesystem::value().PreferBuffer())
+	{
+		animationPack.Open(fileSystem.ReadAll(fileSystem.GetPath<Path::Data>(true) / "AllAnims.anm"));
+	}
+	else
+	{
+		animationPack.Open(fileSystem.GetPath<Path::Data>(true) / "AllAnims.anm");
+	}
 	const auto& animations = animationPack.GetAnimations();
 	for (size_t i = 0; i < animations.size(); i++)
 	{
@@ -760,12 +767,15 @@ bool Game::Run()
 	if (fileSystem.Exists(challengePath))
 	{
 		_lhvm = std::make_unique<LHVM::LHVM>();
-#if __ANDROID__
-		//  Android has a complicated permissions API, must call java code to read contents.
-		_lhvm->Open(fileSystem.ReadAll(fileSystem.FindPath(challengePath)));
-#else
-		_lhvm->Open(fileSystem.FindPath(challengePath));
-#endif
+
+		if (Locator::filesystem::value().PreferBuffer())
+		{
+			_lhvm->Open(fileSystem.ReadAll(fileSystem.FindPath(challengePath)));
+		}
+		else
+		{
+			_lhvm->Open(fileSystem.FindPath(challengePath));
+		}
 	}
 	else
 	{

--- a/src/Parsers/InfoFile.cpp
+++ b/src/Parsers/InfoFile.cpp
@@ -26,13 +26,15 @@ bool InfoFile::LoadFromFile(const std::filesystem::path& path, InfoConstants& in
 	try
 	{
 		pack::PackFile pack;
-#if __ANDROID__
-		//  Android has a complicated permissions API, must call java code to read contents.
-		auto bytes = Locator::filesystem::value().ReadAll(Locator::filesystem::value().FindPath(path));
-		pack.Open(bytes);
-#else
-		pack.Open(Locator::filesystem::value().FindPath(path));
-#endif
+		if (Locator::filesystem::value().PreferBuffer())
+		{
+			auto bytes = Locator::filesystem::value().ReadAll(Locator::filesystem::value().FindPath(path));
+			pack.Open(bytes);
+		}
+		else
+		{
+			pack.Open(Locator::filesystem::value().FindPath(path));
+		}
 		data = pack.GetBlock("Info");
 		if (data.size() != sizeof(InfoConstants))
 		{

--- a/src/Resources/Loaders.cpp
+++ b/src/Resources/Loaders.cpp
@@ -41,14 +41,17 @@ L3DLoader::result_type L3DLoader::operator()(FromDiskTag, const std::filesystem:
 
 	if (pathExt == ".l3d")
 	{
-#if __ANDROID__
-		mesh->LoadFromBuffer(Locator::filesystem::value().ReadAll(path));
-#else
-		if (!mesh->LoadFromFile(path))
+		if (Locator::filesystem::value().PreferBuffer())
 		{
-			throw std::runtime_error("Unable to load mesh");
+			mesh->LoadFromBuffer(Locator::filesystem::value().ReadAll(path));
 		}
-#endif
+		else
+		{
+			if (!mesh->LoadFromFile(path))
+			{
+				throw std::runtime_error("Unable to load mesh");
+			}
+		}
 	}
 	else if (pathExt == ".zzz")
 	{
@@ -154,14 +157,17 @@ L3DAnimLoader::result_type L3DAnimLoader::operator()(FromBufferTag, const std::v
 L3DAnimLoader::result_type L3DAnimLoader::operator()(FromDiskTag, const std::filesystem::path& path) const
 {
 	auto animation = std::make_shared<L3DAnim>();
-#if __ANDROID__
-	animation->LoadFromBuffer(Locator::filesystem::value().ReadAll(path));
-#else
-	if (!animation->LoadFromFile(path))
+	if (Locator::filesystem::value().PreferBuffer())
 	{
-		throw std::runtime_error("Unable to load animation");
+		animation->LoadFromBuffer(Locator::filesystem::value().ReadAll(path));
 	}
-#endif
+	else
+	{
+		if (!animation->LoadFromFile(path))
+		{
+			throw std::runtime_error("Unable to load animation");
+		}
+	}
 
 	return animation;
 }


### PR DESCRIPTION
This allows for more interfaces to use custom read functions than android.
Such a usecase would be single ISO reads.