### PR TITLE
Interpolatiors: Add zoom interpolator

### DIFF
--- a/src/Common/ZoomInterpolator.cpp
+++ b/src/Common/ZoomInterpolator.cpp
@@ -1,0 +1,218 @@
+/*******************************************************************************
+ * Copyright (c) 2018-2024 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *******************************************************************************/
+
+#include "ZoomInterpolator.h"
+
+#include <glm/vec3.hpp>
+
+using namespace openblack;
+
+template <>
+ZoomInterpolator<float>::ZoomInterpolator(float p)
+    : p0(p)
+    , p1(p)
+    , v0(0.0f)
+    , v1(0.0f)
+{
+}
+
+template <>
+ZoomInterpolator<float>::ZoomInterpolator(float p0, float p1, float v0, float v1)
+    : p0(p0)
+    , p1(p1)
+    , v0(v0)
+    , v1(v1)
+{
+}
+
+template <>
+ZoomInterpolator<double>::ZoomInterpolator(double p)
+    : p0(p)
+    , p1(p)
+    , v0(0.0)
+    , v1(0.0)
+{
+}
+
+template <>
+ZoomInterpolator<double>::ZoomInterpolator(double p0, double p1, double v0, double v1)
+    : p0(p0)
+    , p1(p1)
+    , v0(v0)
+    , v1(v1)
+{
+}
+
+template <>
+ZoomInterpolator3f::ZoomInterpolatorVec(glm::vec3 p)
+    : p0(p)
+    , p1(p)
+    , v0(0.0f)
+    , v1(0.0f)
+{
+}
+
+template <>
+ZoomInterpolator3f::ZoomInterpolatorVec(glm::vec3 p0, glm::vec3 p1, glm::vec3 v0, glm::vec3 v1)
+    : p0(p0)
+    , p1(p1)
+    , v0(v0)
+    , v1(v1)
+{
+}
+
+template <typename T>
+    requires std::floating_point<T>
+inline T PositionAtImpl(T p0, T p1, T v0, T v1, T t)
+{
+	// Catch singularity
+	if (p0 == p1)
+	{
+		return p0;
+	}
+
+	const auto pr = p1 - p0;
+
+	// Turn velocities into slopes. Can divide by pr since t goes from 0 to 1
+	const auto m0 = v0 / pr;
+	const auto m1 = v1 / pr;
+
+	// Compute point on scaled down curve
+	const auto t2 = t * t;
+	const auto t3 = t2 * t;
+	const auto t4 = t2 * t2;
+	const auto result = //
+	    t * m0 +        //
+	    t2 * (static_cast<T>(-3) * m0 - static_cast<T>(3) * m1 + static_cast<T>(6)) +
+	    t3 * (static_cast<T>(3) * m0 + static_cast<T>(5) * m1 - static_cast<T>(8)) +
+	    t4 * (-m0 - static_cast<T>(2) * m1 + static_cast<T>(3));
+
+	// Scale and translate point on curve
+	return result * pr + p0;
+}
+
+template <typename T>
+    requires std::floating_point<T>
+inline T VelocityAtImpl(T p0, T p1, T v0, T v1, T t)
+{
+	if (p0 == p1)
+	{
+		return 0;
+	}
+
+	const auto pr = p1 - p0;
+
+	// Turn velocities into slopes. Can divide by pr since t goes from 0 to 1
+	const auto m0 = v0 / pr;
+	const auto m1 = v1 / pr;
+
+	// Derivative of position function with respect to t
+	const auto t2 = t * t;
+	const auto t3 = t2 * t;
+	const auto result = //
+	    m0 +            //
+	    t * 2 * (static_cast<T>(-3) * m0 - static_cast<T>(3) * m1 + static_cast<T>(6)) +
+	    t2 * 3 * (static_cast<T>(3) * m0 + static_cast<T>(5) * m1 - static_cast<T>(8)) +
+	    t3 * 4 * (-m0 - static_cast<T>(2) * m1 + static_cast<T>(3));
+
+	// Scale back to the original problem's units (since m0 and m1 were scaled down by dp)
+	return result * pr;
+}
+
+template <typename T>
+    requires std::floating_point<T>
+inline T AccelerationAtImpl(T p0, T p1, T v0, T v1, T t)
+{
+	if (p0 == p1)
+	{
+		return 0;
+	}
+
+	const auto pr = p1 - p0;
+
+	// Turn velocities into slopes. Can divide by pr since t goes from 0 to 1
+	const auto m0 = v0 / pr;
+	const auto m1 = v1 / pr;
+
+	// Second derivative of position function with respect to t to find acceleration
+	const auto t2 = t * t;
+	const auto result = //
+	    2 * (static_cast<T>(-3) * m0 - static_cast<T>(3) * m1 + static_cast<T>(6)) +
+	    t * 6 * (static_cast<T>(3) * m0 + static_cast<T>(5) * m1 - static_cast<T>(8)) +
+	    t2 * 12 * (-m0 - static_cast<T>(2) * m1 + static_cast<T>(3));
+
+	// Scale back to the original problem's units (since m0 and m1 were scaled down by pr)
+	return result * pr;
+}
+
+template <>
+float ZoomInterpolator<float>::PositionAt(float t) const
+{
+	return PositionAtImpl(p0, p1, v0, v1, t);
+}
+
+template <>
+double ZoomInterpolator<double>::PositionAt(double t) const
+{
+	return PositionAtImpl(p0, p1, v0, v1, t);
+}
+
+template <>
+float ZoomInterpolator<float>::VelocityAt(float t) const
+{
+	return VelocityAtImpl(p0, p1, v0, v1, t);
+}
+
+template <>
+double ZoomInterpolator<double>::VelocityAt(double t) const
+{
+	return VelocityAtImpl(p0, p1, v0, v1, t);
+}
+
+template <>
+float ZoomInterpolator<float>::AccelerationAt(float t) const
+{
+	return AccelerationAtImpl(p0, p1, v0, v1, t);
+}
+
+template <>
+double ZoomInterpolator<double>::AccelerationAt(double t) const
+{
+	return AccelerationAtImpl(p0, p1, v0, v1, t);
+}
+
+template <>
+glm::vec3 ZoomInterpolator3f::PositionAt(float t) const
+{
+	return {
+	    PositionAtImpl(p0.x, p1.x, v0.x, v1.x, t),
+	    PositionAtImpl(p0.y, p1.y, v0.y, v1.y, t),
+	    PositionAtImpl(p0.z, p1.z, v0.z, v1.z, t),
+	};
+}
+
+template <>
+glm::vec3 ZoomInterpolator3f::VelocityAt(float t) const
+{
+	return {
+	    VelocityAtImpl(p0.x, p1.x, v0.x, v1.x, t),
+	    VelocityAtImpl(p0.y, p1.y, v0.y, v1.y, t),
+	    VelocityAtImpl(p0.z, p1.z, v0.z, v1.z, t),
+	};
+}
+
+template <>
+glm::vec3 ZoomInterpolator3f::AccelerationAt(float t) const
+{
+	return {
+	    AccelerationAtImpl(p0.x, p1.x, v0.x, v1.x, t),
+	    AccelerationAtImpl(p0.y, p1.y, v0.y, v1.y, t),
+	    AccelerationAtImpl(p0.z, p1.z, v0.z, v1.z, t),
+	};
+}

--- a/src/Common/ZoomInterpolator.h
+++ b/src/Common/ZoomInterpolator.h
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2018-2024 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *******************************************************************************/
+
+#pragma once
+
+#include <concepts>
+
+#include <glm/detail/qualifier.hpp>
+
+namespace openblack
+{
+
+// Called Zoomer in vanilla, this is a 5 degree (quintic) polynomial.
+// It has degrees of freedom in start and end position, velocity.
+// The acceleration, jerk and snap are based off the first 5 taylor series
+// expansion elements of the exp function.
+// It takes as input t as an interpolation factor between 0 and 1
+template <typename T>
+    requires std::floating_point<T>
+struct ZoomInterpolator
+{
+	T p0;
+	T p1;
+	T v0;
+	T v1;
+
+	explicit ZoomInterpolator(T p);
+	ZoomInterpolator(T p0, T p1, T v0, T v1);
+
+	[[nodiscard]] T PositionAt(T t) const;
+	[[nodiscard]] T VelocityAt(T t) const;
+	[[nodiscard]] T AccelerationAt(T t) const;
+};
+
+template <glm::length_t L, typename T, glm::qualifier Q = glm::defaultp>
+    requires std::floating_point<T>
+struct ZoomInterpolatorVec
+{
+	glm::vec<L, T, Q> p0;
+	glm::vec<L, T, Q> p1;
+	glm::vec<L, T, Q> v0;
+	glm::vec<L, T, Q> v1;
+
+	explicit ZoomInterpolatorVec(glm::vec<L, T, Q> p);
+	ZoomInterpolatorVec(glm::vec<L, T, Q> p0, glm::vec<L, T, Q> p1, glm::vec<L, T, Q> v0, glm::vec<L, T, Q> v1);
+
+	[[nodiscard]] glm::vec<L, T, Q> PositionAt(T t) const;
+	[[nodiscard]] glm::vec<L, T, Q> VelocityAt(T t) const;
+	[[nodiscard]] glm::vec<L, T, Q> AccelerationAt(T t) const;
+};
+
+using ZoomInterpolator3f = ZoomInterpolatorVec<3, float, glm::defaultp>;
+
+} // namespace openblack

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,6 +41,7 @@ endmacro ()
 openblack_setup_and_add_test(test_game_initialize test_game_initialize.cpp)
 openblack_setup_and_add_test(test_load_scene test_load_scene.cpp)
 openblack_setup_and_add_test(test_fixed test_fixed.cpp)
+openblack_setup_and_add_test(test_interpolator test_interpolator.cpp)
 openblack_setup_and_add_json_test(
   test_mobile_wall_hug mobile_wall_hug/test_mobile_wall_hug.cpp
 )

--- a/test/test_interpolator.cpp
+++ b/test/test_interpolator.cpp
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2018-2024 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *******************************************************************************/
+
+#include <cmath>
+
+#include <array>
+#include <numeric>
+
+#include <Common/ZoomInterpolator.h>
+#include <gtest/gtest.h>
+
+template <typename T>
+    requires std::is_floating_point_v<T>
+constexpr std::array<T, 5> ExpTaylorSeries(std::chrono::duration<T> time)
+{
+	std::array<T, 5> res;
+	res[0] = static_cast<T>(1.0);
+	res[1] = time.count() * res[0] * static_cast<T>(1.0) / static_cast<T>(1.0);
+	res[2] = time.count() * res[1] * static_cast<T>(1.0) / static_cast<T>(2.0);
+	res[3] = time.count() * res[2] * static_cast<T>(1.0) / static_cast<T>(3.0);
+	res[4] = time.count() * res[3] * static_cast<T>(1.0) / static_cast<T>(6.0);
+	return res;
+}
+
+template <typename T, size_t N>
+constexpr T SumOfArray(const std::array<T, N>& array)
+{
+	return std::accumulate(array.cbegin(), array.cend(), static_cast<T>(0.0));
+}
+
+TEST(TestInterpolator, TestExpTaylorSeries)
+{
+	ASSERT_FLOAT_EQ(SumOfArray(ExpTaylorSeries(std::chrono::duration<float>(0.001f))), 1.0010005f);
+	ASSERT_FLOAT_EQ(SumOfArray(ExpTaylorSeries(std::chrono::duration<float>(0.015f))), 1.0151131f);
+	ASSERT_FLOAT_EQ(SumOfArray(ExpTaylorSeries(std::chrono::duration<float>(0.016f))), 1.0161288f);
+	ASSERT_FLOAT_EQ(SumOfArray(ExpTaylorSeries(std::chrono::duration<float>(0.032f))), 1.0325174f);
+}
+
+TEST(TestInterpolator, TestExpTaylorSeriesStd)
+{
+	const float epsilon = 5e-5f;
+	ASSERT_NEAR(SumOfArray(ExpTaylorSeries(std::chrono::duration<float>(0.001f))), std::exp(0.001f), epsilon);
+	ASSERT_NEAR(SumOfArray(ExpTaylorSeries(std::chrono::duration<float>(0.015f))), std::exp(0.015f), epsilon);
+	ASSERT_NEAR(SumOfArray(ExpTaylorSeries(std::chrono::duration<float>(0.016f))), std::exp(0.016f), epsilon);
+	ASSERT_NEAR(SumOfArray(ExpTaylorSeries(std::chrono::duration<float>(0.032f))), std::exp(0.032f), epsilon);
+}
+
+TEST(TestInterpolator, ExpValues)
+{
+	const openblack::ZoomInterpolator interpolator(0.0f, 1.0f, 0.0f, 1.0f);
+
+	const std::array<float, 102> expectedValues = {
+	    0.0f,        0.0002970099f, 0.0011761596f, 0.0026198092f, 0.0046105585f, 0.007131247f, 0.010164955f, 0.013695003f,
+	    0.01770495f, 0.022178598f,  0.027099982f,  0.032453388f,  0.038223337f,  0.044394586f, 0.050952133f, 0.05788123f,
+	    0.06516734f, 0.07279619f,   0.08075373f,   0.08902619f,   0.09759998f,   0.10646179f,  0.115598544f, 0.12499741f,
+	    0.13464576f, 0.14453122f,   0.15464173f,   0.16496536f,   0.1754905f,    0.18620574f,  0.19709992f,  0.2081621f,
+	    0.21938165f, 0.23074806f,   0.24225119f,   0.2538811f,    0.26562795f,   0.2774824f,   0.28943512f,  0.3014772f,
+	    0.31359977f, 0.32579434f,   0.33805263f,   0.3503667f,    0.3627286f,    0.3751309f,   0.3875662f,   0.40002745f,
+	    0.41250777f, 0.42500058f,   0.43749958f,   0.44999853f,   0.46249175f,   0.47497338f,  0.4874381f,   0.4998808f,
+	    0.51229644f, 0.52468055f,   0.53702843f,   0.549336f,     0.5615994f,    0.57381487f,  0.58597875f,  0.59808797f,
+	    0.6101395f,  0.6221305f,    0.6340587f,    0.6459215f,    0.65771705f,   0.6694435f,   0.6810993f,   0.6926831f,
+	    0.7041937f,  0.71563053f,   0.72699296f,   0.73828053f,   0.749493f,     0.7606305f,   0.7716938f,   0.7826829f,
+	    0.7935991f,  0.80444336f,   0.815217f,     0.8259213f,    0.83655834f,   0.8471303f,   0.8576393f,   0.86808753f,
+	    0.8784783f,  0.88881457f,   0.899099f,     0.90933526f,   0.91952777f,   0.9296801f,   0.93979585f,  0.94988f,
+	    0.95993733f, 0.96997285f,   0.97999096f,   0.98999786f,   0.9999989f,    1.0f,
+	};
+
+	const float epsilon = 1e-2f;
+	for (uint32_t i = 0; i < expectedValues.size(); ++i)
+	{
+		ASSERT_NEAR(interpolator.PositionAt(i / static_cast<float>(expectedValues.size() - 1)), expectedValues.at(i), epsilon);
+	}
+}
+
+TEST(TestInterpolator, RealWorldValues)
+{
+	auto duration = 0.3f;
+	const openblack::ZoomInterpolator interpolator(3.00015593f, 3.0f, -0.00141694723f * duration, 0.0f);
+
+	const float epsilon = 1e-8f;
+	ASSERT_NEAR(interpolator.PositionAt(0.016f / duration), 3.00013423f, epsilon);
+}
+
+TEST(TestInterpolator, RealWorldVelocities)
+{
+	const auto value0 = 1000.0f;
+	const auto value1 = -368.455078f;
+	const auto value2 = -769.054199f;
+	const auto duration1 = 1.39680004f;
+	const auto duration2 = 1.36159992f;
+	const auto position1 = 961.825683f;
+	const auto velocity1 = -725.472473f;
+	const auto position2 = 961.096191f;
+	const auto velocity2 = -733.466064f;
+	const auto dt1 = 0.1f;
+	const auto dt2 = 0.001f;
+	const float epsilon = 1e-3f;
+
+	const openblack::ZoomInterpolator interpolator1(value0, value1, 0.0f, 0.0f);
+	ASSERT_NEAR(interpolator1.PositionAt(dt1 / duration1), position1, epsilon);
+	ASSERT_NEAR(interpolator1.VelocityAt(dt1 / duration1), velocity1 * duration1, epsilon);
+
+	const openblack::ZoomInterpolator interpolator2(position1, value2, velocity1 * duration2, 0.0f);
+	ASSERT_NEAR(interpolator2.PositionAt(dt2 / duration2), position2, epsilon);
+	ASSERT_NEAR(interpolator2.VelocityAt(dt2 / duration2), velocity2 * duration2, epsilon);
+}


### PR DESCRIPTION
Depends on #697 for support of concepts

I was able to reverse engineer the animation used in vanilla black and white.

The curve is a 5d polynomial that tries to approximate a sigmoid function. There are four degrees of freedom when generating a curve: start value (`p0`), end value (`p1`), start slope (`v0`) and end slope (`v1`). Vanilla also stored duration, start current time and current state. None of those are required as the curve is time scale invariant. Any duration can be mapped on a 0 to 1 range. Current state can be tracked by tracking the value `t` in that range.

Duration and current time must be divided into a 0 to 1 range. Velocities must also be scaled by duration to get slopes. Same thing applies to acceleration.

![image](https://github.com/openblack/openblack/assets/1013356/1e02e825-8da6-4d08-8d6e-2ef447a3a77b)

https://www.desmos.com/calculator/zutyj4djtl