### PR TITLE
Ci tests/gradle report upload

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -202,3 +202,7 @@ jobs:
         with:
           arguments: lint
           build-root-directory: android
+      - uses: actions/upload-artifact@v2
+        with:
+          name: lint-report-upload
+          path: app/build/reports/lint-results-debug.html

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -206,4 +206,4 @@ jobs:
         if: failure()
         with:
           name: lint-report-upload
-          path: app/build/reports/lint-results-debug.html
+          path: android/app/build/reports/lint-results-debug.html

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -203,6 +203,7 @@ jobs:
           arguments: lint
           build-root-directory: android
       - uses: actions/upload-artifact@v2
+        if: failure()
         with:
           name: lint-report-upload
           path: app/build/reports/lint-results-debug.html

--- a/android/app/lint.xml
+++ b/android/app/lint.xml
@@ -1,5 +1,5 @@
 <lint>
     <issue id="all">
-        <ignore path="app/java/org/libsdl.app" />
+        <ignore path="src/main/java/org/libsdl/app" />
     </issue>
 </lint>

--- a/android/app/lint.xml
+++ b/android/app/lint.xml
@@ -1,0 +1,5 @@
+<lint>
+    <issue id="all">
+        <ignore path="app/java/org/libsdl.app" />
+    </issue>
+</lint>


### PR DESCRIPTION
Required for #691 
Upload the report from gradle lint as an artefact in case of failure of the lint check.

As it is a bit hastily/lazily made this PR should be squashed.