### PR TITLE
Unifying the filesystem interface (eg. no more check)

### DIFF
--- a/components/ScriptLibrary/include/LHVM/LHVM.h
+++ b/components/ScriptLibrary/include/LHVM/LHVM.h
@@ -54,9 +54,6 @@ protected:
 	/// Error handling
 	void Fail(const std::string& msg);
 
-	/// Read file from the input source
-	virtual void ReadFile(std::istream& stream);
-
 	void LoadVariables(std::istream& stream, std::vector<std::string>& variables);
 	void LoadCode(std::istream& stream);
 	void LoadAuto(std::istream& stream);
@@ -66,6 +63,9 @@ protected:
 public:
 	LHVM();
 	virtual ~LHVM();
+
+	/// Read file from the input source
+	virtual void ReadFile(std::istream& stream);
 
 	/// Read lhvm file from the filesystem
 	void Open(const std::filesystem::path& filepath);

--- a/components/anm/include/ANMFile.h
+++ b/components/anm/include/ANMFile.h
@@ -64,15 +64,15 @@ protected:
 	/// Error handling
 	void Fail(const std::string& msg);
 
-	/// Read file from the input source
-	virtual void ReadFile(std::istream& stream);
-
 	/// Write file to the input source
 	virtual void WriteFile(std::ostream& stream) const;
 
 public:
 	ANMFile();
 	virtual ~ANMFile();
+
+	/// Read file from the input source
+	virtual void ReadFile(std::istream& stream);
 
 	/// Read anm file from the filesystem
 	void Open(const std::filesystem::path& filepath);

--- a/components/anm/include/ANMFile.h
+++ b/components/anm/include/ANMFile.h
@@ -11,6 +11,7 @@
 
 #include <array>
 #include <filesystem>
+#include <iosfwd>
 #include <string>
 #include <vector>
 

--- a/components/l3d/include/L3DFile.h
+++ b/components/l3d/include/L3DFile.h
@@ -304,15 +304,15 @@ protected:
 	/// Error handling
 	void Fail(const std::string& msg);
 
-	/// Read file from the input source
-	virtual void ReadFile(std::istream& stream);
-
 	/// Write file to the input source
 	virtual void WriteFile(std::ostream& stream) const;
 
 public:
 	L3DFile();
 	virtual ~L3DFile();
+
+	/// Read file from the input source
+	virtual void ReadFile(std::istream& stream);
 
 	/// Read l3d file from the filesystem
 	void Open(const std::filesystem::path& filepath);

--- a/components/l3d/include/L3DFile.h
+++ b/components/l3d/include/L3DFile.h
@@ -11,6 +11,7 @@
 
 #include <array>
 #include <filesystem>
+#include <istream>
 #include <optional>
 #include <span>
 #include <string>

--- a/components/l3d/include/L3DFile.h
+++ b/components/l3d/include/L3DFile.h
@@ -11,7 +11,7 @@
 
 #include <array>
 #include <filesystem>
-#include <istream>
+#include <iosfwd>
 #include <optional>
 #include <span>
 #include <string>

--- a/components/lnd/include/LNDFile.h
+++ b/components/lnd/include/LNDFile.h
@@ -181,15 +181,15 @@ protected:
 	/// Error handling
 	void Fail(const std::string& msg);
 
-	/// Read file from the input source
-	virtual void ReadFile(std::istream& stream);
-
 	/// Write file to the input source
 	virtual void WriteFile(std::ostream& stream) const;
 
 public:
 	LNDFile();
 	virtual ~LNDFile();
+
+	/// Read file from the input source
+	virtual void ReadFile(std::istream& stream);
 
 	/// Read lnd file from the filesystem
 	void Open(const std::filesystem::path& filepath);

--- a/components/lnd/include/LNDFile.h
+++ b/components/lnd/include/LNDFile.h
@@ -11,7 +11,7 @@
 
 #include <array>
 #include <filesystem>
-#include <istream>
+#include <iosfwd>
 #include <string>
 #include <vector>
 

--- a/components/lnd/include/LNDFile.h
+++ b/components/lnd/include/LNDFile.h
@@ -11,6 +11,7 @@
 
 #include <array>
 #include <filesystem>
+#include <istream>
 #include <string>
 #include <vector>
 

--- a/components/pack/include/PackFile.h
+++ b/components/pack/include/PackFile.h
@@ -181,9 +181,6 @@ protected:
 	/// Error handling
 	void Fail(const std::string& msg);
 
-	/// Read file from the input source
-	virtual void ReadFile(std::istream& stream);
-
 	/// Read blocks from pack
 	virtual void ReadBlocks(std::istream& stream);
 
@@ -214,6 +211,9 @@ protected:
 public:
 	PackFile();
 	virtual ~PackFile();
+
+	/// Read file from the input source
+	virtual void ReadFile(std::istream& stream);
 
 	/// Read g3d file from the filesystem
 	void Open(const std::filesystem::path& filepath);

--- a/src/3D/L3DAnim.cpp
+++ b/src/3D/L3DAnim.cpp
@@ -60,7 +60,7 @@ bool L3DAnim::LoadFromFilesystem(const std::filesystem::path& path)
 
 	try
 	{
-		anm.Open(Locator::filesystem::value().ReadAll(path));
+		anm.ReadFile(*Locator::filesystem::value().GetData(path));
 	}
 	catch (std::runtime_error& err)
 	{

--- a/src/3D/L3DAnim.cpp
+++ b/src/3D/L3DAnim.cpp
@@ -53,6 +53,25 @@ void L3DAnim::Load(const anm::ANMFile& anm)
 	}
 }
 
+bool L3DAnim::LoadFromFilesystem(const std::filesystem::path& path)
+{
+	SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "Loading L3DAnim from file: {}", path.generic_string());
+	anm::ANMFile anm;
+
+	try
+	{
+		anm.Open(Locator::filesystem::value().ReadAll(path));
+	}
+	catch (std::runtime_error& err)
+	{
+		SPDLOG_LOGGER_ERROR(spdlog::get("game"), "Failed to open l3d animation from buffer: {}", err.what());
+		return false;
+	}
+
+	Load(anm);
+	return true;
+}
+
 bool L3DAnim::LoadFromFile(const std::filesystem::path& path)
 {
 	SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "Loading L3DAnim from file: {}", path.generic_string());

--- a/src/3D/L3DAnim.cpp
+++ b/src/3D/L3DAnim.cpp
@@ -9,6 +9,9 @@
 
 #include "L3DAnim.h"
 
+#include <filesystem>
+#include <stdexcept>
+
 #include <ANMFile.h>
 #include <glm/gtx/matrix_interpolation.hpp>
 #include <spdlog/spdlog.h>

--- a/src/3D/L3DAnim.h
+++ b/src/3D/L3DAnim.h
@@ -41,6 +41,7 @@ public:
 	virtual ~L3DAnim() = default;
 
 	void Load(const anm::ANMFile& anm);
+	bool LoadFromFilesystem(const std::filesystem::path& path);
 	bool LoadFromFile(const std::filesystem::path& path);
 	void LoadFromBuffer(const std::vector<uint8_t>& data);
 

--- a/src/3D/L3DMesh.cpp
+++ b/src/3D/L3DMesh.cpp
@@ -9,6 +9,7 @@
 
 #include "L3DMesh.h"
 
+#include <filesystem>
 #include <stdexcept>
 
 #include <BulletCollision/CollisionShapes/btConvexHullShape.h>

--- a/src/3D/L3DMesh.cpp
+++ b/src/3D/L3DMesh.cpp
@@ -172,7 +172,7 @@ bool L3DMesh::LoadFromFilesystem(const std::filesystem::path& path)
 
 	try
 	{
-		l3d.Open(Locator::filesystem::value().ReadAll(path));
+		l3d.ReadFile(*Locator::filesystem::value().GetData(path));
 	}
 	catch (std::runtime_error& err)
 	{

--- a/src/3D/L3DMesh.cpp
+++ b/src/3D/L3DMesh.cpp
@@ -165,6 +165,26 @@ void L3DMesh::Load(const l3d::L3DFile& l3d)
 	bgfx::frame();
 }
 
+bool L3DMesh::LoadFromFilesystem(const std::filesystem::path& path)
+{
+	SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "Loading L3DMesh from file: {}", path.generic_string());
+	l3d::L3DFile l3d;
+
+	try
+	{
+		l3d.Open(Locator::filesystem::value().ReadAll(path));
+	}
+	catch (std::runtime_error& err)
+	{
+		SPDLOG_LOGGER_ERROR(spdlog::get("game"), "Failed to open l3d mesh from filesystem {}: {}", path.generic_string(),
+		                    err.what());
+		return false;
+	}
+
+	Load(l3d);
+	return true;
+}
+
 bool L3DMesh::LoadFromFile(const std::filesystem::path& path)
 {
 	SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "Loading L3DMesh from file: {}", path.generic_string());

--- a/src/3D/L3DMesh.h
+++ b/src/3D/L3DMesh.h
@@ -86,6 +86,7 @@ public:
 	virtual ~L3DMesh();
 
 	void Load(const l3d::L3DFile& l3d);
+	bool LoadFromFilesystem(const std::filesystem::path& path);
 	bool LoadFromFile(const std::filesystem::path& path);
 	bool LoadFromBuffer(const std::vector<uint8_t>& data);
 

--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -48,12 +48,7 @@ void LandIsland::LoadFromFile(const std::filesystem::path& path)
 
 	try
 	{
-#if __ANDROID__
-		//  Android has a complicated permissions API, must call java code to read contents.
 		lnd.Open(Locator::filesystem::value().ReadAll(path));
-#else
-		lnd.Open(path);
-#endif
 	}
 	catch (std::runtime_error& err)
 	{

--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -48,7 +48,7 @@ void LandIsland::LoadFromFile(const std::filesystem::path& path)
 
 	try
 	{
-		lnd.Open(Locator::filesystem::value().ReadAll(path));
+		lnd.ReadFile(*Locator::filesystem::value().GetData(path));
 	}
 	catch (std::runtime_error& err)
 	{

--- a/src/3D/Sky.cpp
+++ b/src/3D/Sky.cpp
@@ -33,13 +33,7 @@ Sky::Sky()
 
 	// load in the mesh
 	_model = std::make_unique<L3DMesh>("Sky");
-#if __ANDROID__
-	//  Android has a complicated permissions API, must call java code to read contents.
-	_model->LoadFromBuffer(
-	    Locator::filesystem::value().ReadAll(fileSystem.GetPath<filesystem::Path::WeatherSystem>() / "sky.l3d"));
-#else
-	_model->LoadFromFile(fileSystem.GetPath<filesystem::Path::WeatherSystem>() / "sky.l3d");
-#endif
+	_model->LoadFromFilesystem(fileSystem.GetPath<filesystem::Path::WeatherSystem>() / "sky.l3d");
 
 	// TODO (#749) Maybe use std::views::enumerate
 	for (uint32_t idx = 0; const auto& alignment : k_Alignments)

--- a/src/FileSystem/AndroidFileSystem.cpp
+++ b/src/FileSystem/AndroidFileSystem.cpp
@@ -25,6 +25,61 @@
 
 using namespace openblack::filesystem;
 
+namespace
+{
+// Adapted from https://stackoverflow.com/a/13059195/10604387
+//          and https://stackoverflow.com/a/46069245/10604387
+struct membuf: std::streambuf
+{
+	membuf(char const* base, size_t size)
+	{
+		char* p(const_cast<char*>(base));
+		this->setg(p, p, p + size);
+	}
+	std::streampos seekoff(off_type off, std::ios_base::seekdir way, [[maybe_unused]] std::ios_base::openmode which) override
+	{
+		if (way == std::ios_base::cur)
+		{
+			gbump(static_cast<int>(off));
+		}
+		else if (way == std::ios_base::end)
+		{
+			setg(eback(), egptr() + off, egptr());
+		}
+		else if (way == std::ios_base::beg)
+		{
+			setg(eback(), eback() + off, egptr());
+		}
+		return gptr() - eback();
+	}
+
+	std::streampos seekpos([[maybe_unused]] pos_type pos, [[maybe_unused]] std::ios_base::openmode which) override
+	{
+		return seekoff(pos - static_cast<off_type>(0), std::ios_base::beg, which);
+	}
+};
+struct imemstream: virtual membuf, std::istream
+{
+	imemstream(std::vector<uint8_t> data)
+	    : membuf(reinterpret_cast<const char*>(data.data()), data.size())
+	    , std::istream(dynamic_cast<std::streambuf*>(this))
+	    , _data(data)
+	{
+		auto p = reinterpret_cast<char*>(_data.data());
+		this->setg(p, p, p + data.size());
+	}
+
+	imemstream(char const* base, size_t size)
+	    : membuf(base, size)
+	    , std::istream(dynamic_cast<std::streambuf*>(this))
+	{
+	}
+
+private:
+	std::vector<uint8_t> _data;
+};
+} // namespace
+
 AndroidFileSystem::AndroidFileSystem()
     : _jniEnv(static_cast<JNIEnv*>(SDL_AndroidGetJNIEnv()))
     , _jniActivity(static_cast<jobject>(SDL_AndroidGetActivity()))
@@ -153,6 +208,11 @@ void AndroidFileSystem::Iterate(const std::filesystem::path& path, bool recursiv
 		// Don't forget to release the string
 		_jniEnv->ReleaseStringUTFChars(filePath, rawString);
 	}
+}
+
+std::unique_ptr<std::istream> AndroidFileSystem::GetData(const std::filesystem::path& path)
+{
+	return std::make_unique<imemstream>(ReadAll(path));
 }
 
 #endif

--- a/src/FileSystem/AndroidFileSystem.h
+++ b/src/FileSystem/AndroidFileSystem.h
@@ -26,8 +26,10 @@ public:
 	AndroidFileSystem();
 	~AndroidFileSystem();
 
+	// Android has a complicated permissions API, must call java code to read contents.
 	[[nodiscard]] std::filesystem::path FindPath(const std::filesystem::path& path) const override;
 	[[nodiscard]] bool IsPathValid(const std::filesystem::path& path) override;
+	std::unique_ptr<std::istream> GetData(const std::filesystem::path& path) override;
 	std::unique_ptr<Stream> Open(const std::filesystem::path& path, Stream::Mode mode) override;
 	bool Exists(const std::filesystem::path& path) const override;
 	void SetGamePath(const std::filesystem::path& path) override { _gamePath = path; }

--- a/src/FileSystem/DefaultFileSystem.cpp
+++ b/src/FileSystem/DefaultFileSystem.cpp
@@ -11,14 +11,9 @@
 
 #include "DefaultFileSystem.h"
 
-#include <cctype>
-#include <cstddef>
-
 #include <filesystem>
 #include <fstream>
 #include <system_error>
-
-#include <spdlog/spdlog.h>
 
 #include "FileStream.h"
 #include "fmt/format.h"
@@ -177,4 +172,8 @@ void DefaultFileSystem::SetGamePath(const std::filesystem::path& path)
 	{
 		throw std::runtime_error(fmt::format("GamePath does not exist: '{}'", _gamePath.generic_string()));
 	}
+}
+std::unique_ptr<std::istream> DefaultFileSystem::GetData(const std::filesystem::path& path)
+{
+	return std::make_unique<std::ifstream>(FindPath(path), std::ios::binary);
 }

--- a/src/FileSystem/DefaultFileSystem.cpp
+++ b/src/FileSystem/DefaultFileSystem.cpp
@@ -13,6 +13,9 @@
 
 #include <filesystem>
 #include <fstream>
+#include <ios>
+#include <istream>
+#include <memory>
 #include <system_error>
 
 #include "FileStream.h"

--- a/src/FileSystem/DefaultFileSystem.h
+++ b/src/FileSystem/DefaultFileSystem.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <istream>
 #include <vector>
 
 #include "FileSystemInterface.h"

--- a/src/FileSystem/DefaultFileSystem.h
+++ b/src/FileSystem/DefaultFileSystem.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <istream>
+#include <iosfwd>
 #include <vector>
 
 #include "FileSystemInterface.h"

--- a/src/FileSystem/DefaultFileSystem.h
+++ b/src/FileSystem/DefaultFileSystem.h
@@ -26,6 +26,7 @@ public:
 	[[nodiscard]] std::filesystem::path FindPath(const std::filesystem::path& path) const override;
 	[[nodiscard]] bool IsPathValid(const std::filesystem::path& path) override;
 	std::unique_ptr<Stream> Open(const std::filesystem::path& path, Stream::Mode mode) override;
+	std::unique_ptr<std::istream> GetData(const std::filesystem::path& path) override;
 	[[nodiscard]] bool Exists(const std::filesystem::path& path) const override;
 	void SetGamePath(const std::filesystem::path& path) override;
 	[[nodiscard]] const std::filesystem::path& GetGamePath() const override { return _gamePath; }

--- a/src/FileSystem/FileSystemInterface.h
+++ b/src/FileSystem/FileSystemInterface.h
@@ -108,6 +108,7 @@ public:
 	}
 
 	[[nodiscard]] virtual std::filesystem::path FindPath(const std::filesystem::path& path) const = 0;
+	virtual std::unique_ptr<std::istream> GetData(const std::filesystem::path& path) = 0;
 	[[nodiscard]] virtual bool IsPathValid(const std::filesystem::path& path) = 0;
 	virtual std::unique_ptr<Stream> Open(const std::filesystem::path& path, Stream::Mode mode) = 0;
 	[[nodiscard]] virtual bool Exists(const std::filesystem::path& path) const = 0;

--- a/src/FileSystem/FileSystemInterface.h
+++ b/src/FileSystem/FileSystemInterface.h
@@ -14,6 +14,8 @@
 
 #include <filesystem>
 #include <functional>
+#include <istream>
+#include <memory>
 #include <vector>
 
 #include "Stream.h"

--- a/src/FileSystem/FileSystemInterface.h
+++ b/src/FileSystem/FileSystemInterface.h
@@ -14,7 +14,7 @@
 
 #include <filesystem>
 #include <functional>
-#include <istream>
+#include <iosfwd>
 #include <memory>
 #include <vector>
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -564,12 +564,9 @@ bool Game::Initialize()
 	    });
 
 	pack::PackFile pack;
-#if __ANDROID__
-	//  Android has a complicated permissions API, must call java code to read contents.
+
 	pack.Open(fileSystem.ReadAll(fileSystem.GetPath<Path::Data>() / "AllMeshes.g3d"));
-#else
-	pack.Open(fileSystem.GetPath<Path::Data>(true) / "AllMeshes.g3d");
-#endif
+
 	const auto& meshes = pack.GetMeshes();
 	// TODO (#749) use std::views::enumerate
 	for (size_t i = 0; const auto& mesh : meshes)
@@ -586,12 +583,8 @@ bool Game::Initialize()
 	}
 
 	pack::PackFile animationPack;
-#if __ANDROID__
-	//  Android has a complicated permissions API, must call java code to read contents.
 	animationPack.Open(fileSystem.ReadAll(fileSystem.GetPath<Path::Data>() / "AllAnims.anm"));
-#else
-	animationPack.Open(fileSystem.GetPath<Path::Data>(true) / "AllAnims.anm");
-#endif
+
 	const auto& animations = animationPack.GetAnimations();
 	// TODO (#749) use std::views::enumerate
 	for (size_t i = 0; i < animations.size(); i++)
@@ -778,12 +771,7 @@ bool Game::Run()
 	if (fileSystem.Exists(challengePath))
 	{
 		_lhvm = std::make_unique<LHVM::LHVM>();
-#if __ANDROID__
-		//  Android has a complicated permissions API, must call java code to read contents.
-		_lhvm->Open(fileSystem.ReadAll(fileSystem.FindPath(challengePath)));
-#else
-		_lhvm->Open(fileSystem.FindPath(challengePath));
-#endif
+		_lhvm->Open(fileSystem.ReadAll(challengePath));
 	}
 	else
 	{

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -565,7 +565,7 @@ bool Game::Initialize()
 
 	pack::PackFile pack;
 
-	pack.Open(fileSystem.ReadAll(fileSystem.GetPath<Path::Data>() / "AllMeshes.g3d"));
+	pack.ReadFile(*fileSystem.GetData(fileSystem.GetPath<Path::Data>() / "AllMeshes.g3d"));
 
 	const auto& meshes = pack.GetMeshes();
 	// TODO (#749) use std::views::enumerate
@@ -583,7 +583,7 @@ bool Game::Initialize()
 	}
 
 	pack::PackFile animationPack;
-	animationPack.Open(fileSystem.ReadAll(fileSystem.GetPath<Path::Data>() / "AllAnims.anm"));
+	animationPack.ReadFile(*fileSystem.GetData(fileSystem.GetPath<Path::Data>() / "AllAnims.anm"));
 
 	const auto& animations = animationPack.GetAnimations();
 	// TODO (#749) use std::views::enumerate
@@ -692,7 +692,7 @@ bool Game::Initialize()
 
 		    pack::PackFile soundPack;
 		    SPDLOG_LOGGER_DEBUG(spdlog::get("audio"), "Opening sound pack {}", f.filename().string());
-		    soundPack.Open(fileSystem.ReadAll(f));
+		    soundPack.ReadFile(*fileSystem.GetData(f));
 		    const auto& audioHeaders = soundPack.GetAudioSampleHeaders();
 		    const auto& audioData = soundPack.GetAudioSamplesData();
 		    auto soundName = std::filesystem::path(audioHeaders[0].name.data());

--- a/src/Parsers/InfoFile.cpp
+++ b/src/Parsers/InfoFile.cpp
@@ -26,13 +26,8 @@ bool InfoFile::LoadFromFile(const std::filesystem::path& path, InfoConstants& in
 	try
 	{
 		pack::PackFile pack;
-#if __ANDROID__
-		//  Android has a complicated permissions API, must call java code to read contents.
-		auto bytes = Locator::filesystem::value().ReadAll(Locator::filesystem::value().FindPath(path));
-		pack.Open(bytes);
-#else
-		pack.Open(Locator::filesystem::value().FindPath(path));
-#endif
+		pack.Open(Locator::filesystem::value().ReadAll(path));
+
 		data = pack.GetBlock("Info");
 		if (data.size() == sizeof(v100::InfoConstants))
 		{

--- a/src/Parsers/InfoFile.cpp
+++ b/src/Parsers/InfoFile.cpp
@@ -26,7 +26,7 @@ bool InfoFile::LoadFromFile(const std::filesystem::path& path, InfoConstants& in
 	try
 	{
 		pack::PackFile pack;
-		pack.Open(Locator::filesystem::value().ReadAll(path));
+		pack.ReadFile(*Locator::filesystem::value().GetData(path));
 
 		data = pack.GetBlock("Info");
 		if (data.size() == sizeof(v100::InfoConstants))

--- a/src/Resources/Loaders.cpp
+++ b/src/Resources/Loaders.cpp
@@ -43,14 +43,10 @@ L3DLoader::result_type L3DLoader::operator()(FromDiskTag, const std::filesystem:
 
 	if (pathExt == ".l3d")
 	{
-#if __ANDROID__
-		mesh->LoadFromBuffer(Locator::filesystem::value().ReadAll(path));
-#else
-		if (!mesh->LoadFromFile(path))
+		if (!mesh->LoadFromFilesystem(path))
 		{
 			throw std::runtime_error("Unable to load mesh");
 		}
-#endif
 	}
 	else if (pathExt == ".zzz")
 	{
@@ -156,14 +152,11 @@ L3DAnimLoader::result_type L3DAnimLoader::operator()(FromBufferTag, const std::v
 L3DAnimLoader::result_type L3DAnimLoader::operator()(FromDiskTag, const std::filesystem::path& path) const
 {
 	auto animation = std::make_shared<L3DAnim>();
-#if __ANDROID__
-	animation->LoadFromBuffer(Locator::filesystem::value().ReadAll(path));
-#else
-	if (!animation->LoadFromFile(path))
+
+	if (!animation->LoadFromFilesystem(path))
 	{
 		throw std::runtime_error("Unable to load animation");
 	}
-#endif
 
 	return animation;
 }


### PR DESCRIPTION
The purpose of this PR is to remove the need of checking what type of filesystem to use before reading a file either at compile type (as we have currently to handle android) or at runtime (as proposed in #673).

It divides responsibility as follows \:
- Parsers get data from a stream and build game asset from it.
- The filesystem look for the data and organise it as a istream.
- The stream handles direct access to the data.

As a first draft i moved `void ReadFile(std::istream& stream)` in all parsers from a private to a public method.
Added a `std::unique_ptr<std::istream> GetData(const std::filesystem::path& path)` as the method to ask access to data from the filesystem.
Replaced place where we had to choose between `Open(Locator::filesystem::value().ReadAll(path));` and `Open(path)` with `ReadFile(*Locator::filesystem::value().GetData(path));`
Copied the membuf from the component into android and made it own a copy of the file data (mostly a lazy way to ensure the data was there while being read by the buffer) i also allowed it to be initialized by a vector of byte.

I propose this as draft as i wish to have comment about change that would be necessary or better to implement this (and if such a change is agreeable). Once/while implementation detail are discussed apps and parsers still need to be changed before this gets ready for merge (removing the possibility to read file from parsers and the implied changes it will need on apps).

This would replace #673 if merged before. I didn't look if it would be a pain to modify #674 to make it work with the changes brought here if it is merging #674 should take priority and this PR should be responsible to make it work (tbc i presume it means i will do it).

This PR has been tested by launching the game on an android emulator and windows (both x86_64).