### PR TITLE
Tests: Fix issues with gradle lint and clang-format lint

### DIFF
--- a/.github/workflows/ci-cross-compile.yml
+++ b/.github/workflows/ci-cross-compile.yml
@@ -167,17 +167,14 @@ jobs:
           mv android/app/src/main/jniLibs/x86_64/Debug/libopenblack_lib.so         android/app/src/main/jniLibs/debug/x86_64
           mv android/app/src/main/jniLibs/x86_64/Release/libopenblack_lib.so       android/app/src/main/jniLibs/release/x86_64
           find android/app/src/main/jniLibs
-      - name: Run Gradle Assemble (Debug)
-        uses: gradle/gradle-build-action@v2
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
         with:
-          arguments: assembleDebug -PusePrebuiltNativeLibs
-          build-root-directory: android
+          build-root-directory: ./android
+      - name: Build with Gradle (Debug)
+        run: ./gradlew build --no-daemon assembleDebug -PusePrebuiltNativeLibs
+        working-directory: ./android
       # TODO(#632): Setup digital signing for Android release build
-      # - name: Run Gradle Assemble (Release)
-      #   uses: gradle/gradle-build-action@v2
-      #   with:
-      #     arguments: assembleRelease -PusePrebuiltNativeLibs
-      #     build-root-directory: android
       - uses: actions/upload-artifact@v3
         with:
           name: openblack-android-apk-${{github.sha}}

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -194,14 +194,18 @@ jobs:
       - name: Add base repo to git config
         run: git remote add upstream ${{ github.event.pull_request.base.repo.html_url }}
         if: startsWith(github.event_name, 'pull_request')
-      - uses: actions/setup-java@v3
+      - name: Setup Java
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
-      - uses: gradle/gradle-build-action@v2
+          java-version: '17'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
         with:
-          arguments: lint
-          build-root-directory: android
+          build-root-directory: ./android
+      - run: echo "ANDROID_NDK_HOME=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV # to use C++23 on 26.2.11394342
+      - run: ./gradlew lint
+        working-directory: ./android
       - uses: actions/upload-artifact@v2
         if: failure()
         with:

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -19,10 +19,10 @@ jobs:
       - name: Add base repo to git config
         run: git remote add upstream ${{ github.event.pull_request.base.repo.html_url }}
         if: startsWith(github.event_name, 'pull_request')
-      - uses: DoozyX/clang-format-lint-action@v0.16
+      - uses: DoozyX/clang-format-lint-action@v0.17
         with:
           source: 'src apps components test'
-          clangFormatVersion: 15
+          clangFormatVersion: 17
           inplace: False
 
   # Run only if a PR and clang-format has failed
@@ -39,10 +39,10 @@ jobs:
       - name: Add base repo to git config
         run: git remote add upstream ${{ github.event.pull_request.base.repo.html_url }}
         if: startsWith(github.event_name, 'pull_request')
-      - uses: DoozyX/clang-format-lint-action@v0.13
+      - uses: DoozyX/clang-format-lint-action@v0.17
         with:
           source: 'src apps components test'
-          clangFormatVersion: 12
+          clangFormatVersion: 17
           inplace: True
       - run: |
           git diff > clang-format.patch
@@ -155,7 +155,7 @@ jobs:
           deno-version: v1.x
       - name: Check License Lines
         run: deno run --allow-read https://deno.land/x/license_checker@v3.2.2/main.ts --quiet
-  
+
   copyright-check-action-suggester:
     name: license_checker fix suggester
     runs-on: ubuntu-latest

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -9,7 +9,7 @@ android {
         applicationId "org.openblack.app"
         minSdk 21
         targetSdk 32
-        ndkVersion "26.2.11394342"
+        ndkVersion "26.3.11579264"
         versionCode 1
         versionName "0.1.0"
         archivesBaseName = "$applicationId-$versionName"


### PR DESCRIPTION
* Clang-format lint is not parsing `requires` correctly
* Gradle lint is failing due to being out of date.