### PR TITLE
Camera: Fix the facing angle at map launch

### DIFF
--- a/components/lnd/include/LNDFile.h
+++ b/components/lnd/include/LNDFile.h
@@ -123,19 +123,19 @@ static_assert(sizeof(LNDCountry) == 3076);
 
 struct LNDMaterial
 {
-	struct R5G5B5A1
+	struct B5G5R5A1
 	{
 		uint16_t b : 5;
 		uint16_t g : 5;
 		uint16_t r : 5;
 		uint16_t a : 1;
 	};
-	static_assert(sizeof(R5G5B5A1) == sizeof(uint16_t));
+	static_assert(sizeof(B5G5R5A1) == sizeof(uint16_t));
 	static constexpr uint16_t k_Width = 256;
 	static constexpr uint16_t k_Height = 256;
 
 	uint16_t type; ///< Terrain Type
-	std::array<R5G5B5A1, k_Width * k_Height> texels;
+	std::array<B5G5R5A1, k_Width * k_Height> texels;
 };
 static_assert(sizeof(LNDMaterial) == 0x20002);
 

--- a/components/lnd/src/LNDFile.cpp
+++ b/components/lnd/src/LNDFile.cpp
@@ -269,13 +269,13 @@ void LNDFile::WriteFile(std::ostream& stream) const
 	// Write Blocks
 	stream.write(reinterpret_cast<const char*>(_blocks.data()), _blocks.size() * sizeof(_blocks[0]));
 
-	// Read Countries
+	// Write Countries
 	stream.write(reinterpret_cast<const char*>(_countries.data()), _countries.size() * sizeof(_countries[0]));
 
-	// Read Materials
+	// Write Materials
 	stream.write(reinterpret_cast<const char*>(_materials.data()), _materials.size() * sizeof(_materials[0]));
 
-	// Read Extra textures (noise and bump map)
+	// Write Extra textures (noise and bump map)
 	stream.write(reinterpret_cast<const char*>(&_extra), sizeof(_extra));
 
 	// TODO(bwrsandman): Figure out what the unaccounted bytes are for and write

--- a/components/lnd/src/LNDFile.cpp
+++ b/components/lnd/src/LNDFile.cpp
@@ -332,6 +332,11 @@ void LNDFile::Write(const std::filesystem::path& filepath)
 	_header.materialSize = static_cast<uint32_t>(sizeof(LNDMaterial));
 	_header.countrySize = static_cast<uint32_t>(sizeof(LNDCountry));
 	_header.lowResolutionCount = static_cast<uint32_t>(_lowResolutionTextures.size());
+	for (const auto& block : _blocks)
+	{
+		const auto lookupIndex = block.blockX << 5 | block.blockZ;
+		_header.lookUpTable.at(lookupIndex) = static_cast<uint8_t>(block.index);
+	}
 
 	for (int i = 1; auto& b : _blocks)
 	{
@@ -371,7 +376,7 @@ void LNDFile::AddBumpMap(const LNDBumpMap& bumpMap)
 
 void LNDFile::AddBlock(const LNDBlock& block)
 {
-	_blocks.emplace_back(block);
+	_blocks.emplace_back(block).index = static_cast<uint32_t>(_blocks.size()) + 1;
 }
 
 void LNDFile::AddCountry(const LNDCountry& country)

--- a/src/3D/LandIsland.cpp
+++ b/src/3D/LandIsland.cpp
@@ -221,8 +221,10 @@ const lnd::LNDCell& LandIsland::GetCell(const glm::u16vec2& coordinates) const
 		return k_EmptyCell;
 	}
 
-	const uint16_t lookupIndex = ((coordinates.x & ~0xFU) << 1U) | (coordinates.y >> 4U);
-	const uint16_t cellIndex = (coordinates.x & 0xFU) * 0x11u + (coordinates.y & 0xFU);
+	const auto mapCoordinates = coordinates >> static_cast<uint16_t>(0x4);
+	const auto cellCoordinates = static_cast<glm::u8vec2>(coordinates) & static_cast<uint8_t>(0xF);
+	const auto lookupIndex = mapCoordinates.x << 5u | mapCoordinates.y;
+	const auto cellIndex = cellCoordinates.x * 0x11u + cellCoordinates.y;
 
 	const uint8_t blockIndex = _blockIndexLookup.at(lookupIndex);
 

--- a/src/Debug/Gui.cpp
+++ b/src/Debug/Gui.cpp
@@ -545,6 +545,7 @@ bool Gui::ShowMenu(Game& game)
 
 			if (ImGui::BeginMenu("View"))
 			{
+				ImGui::Checkbox("Game Detail Overlay", &config.viewDetailOverlay);
 				ImGui::Checkbox("Sky", &config.drawSky);
 				ImGui::Checkbox("Water", &config.drawWater);
 				ImGui::Checkbox("Island", &config.drawIsland);
@@ -935,30 +936,34 @@ void Gui::ShowCameraPositionOverlay(const Game& game)
 	ImGui::SetNextWindowPos(ImVec2(displaySize.x - 8.0f, displaySize.y - 8.0f), ImGuiCond_Always, ImVec2(1.0f, 1.0f));
 	ImGui::SetNextWindowBgAlpha(0.35f);
 
-	if (ImGui::Begin("Camera position overlay", nullptr, cameraPositionOverlayFlags))
+	if (game.GetConfig().viewDetailOverlay)
 	{
-		const auto camOrigin = game.GetCamera().GetOrigin();
-		const auto camFocus = game.GetCamera().GetFocus();
-		const auto camRot = glm::degrees(game.GetCamera().GetRotation());
-		ImGui::Text("Camera Origin: (%.1f,%.1f,%.1f)", camOrigin.x, camOrigin.y, camOrigin.z);
-		ImGui::Text("Camera Focus: (%.1f,%.1f,%.1f)", camFocus.x, camFocus.y, camFocus.z);
-		ImGui::Text("Camera Rotation: (%.1f,%.1f,%.1f)", camRot.x, camRot.y, camRot.z);
-
-		if (ImGui::IsMousePosValid())
+		if (ImGui::Begin("Game Details Overlay", nullptr, cameraPositionOverlayFlags))
 		{
-			const auto& mousePos = ImGui::GetIO().MousePos;
-			ImGui::Text("Mouse Position: (%.1f,%.1f)", mousePos.x, mousePos.y);
-		}
-		else
-		{
-			ImGui::Text("Mouse Position: <invalid>");
-		}
+			const auto camOrigin = game.GetCamera().GetOrigin();
+			const auto camFocus = game.GetCamera().GetFocus();
+			const auto camRot = glm::degrees(game.GetCamera().GetRotation());
+			ImGui::Text("Camera Origin: (%.1f,%.1f,%.1f)", camOrigin.x, camOrigin.y, camOrigin.z);
+			ImGui::Text("Camera Focus: (%.1f,%.1f,%.1f)", camFocus.x, camFocus.y, camFocus.z);
+			ImGui::Text("Camera Rotation: (%.1f,%.1f,%.1f)", camRot.x, camRot.y, camRot.z);
 
-		const auto& handPosition = Locator::entitiesRegistry::value().Get<ecs::components::Transform>(game.GetHand()).position;
-		ImGui::Text("Hand Position: (%.1f,%.1f,%.1f)", handPosition.x, handPosition.y, handPosition.z);
+			if (ImGui::IsMousePosValid())
+			{
+				const auto& mousePos = ImGui::GetIO().MousePos;
+				ImGui::Text("Mouse Position: (%.1f,%.1f)", mousePos.x, mousePos.y);
+			}
+			else
+			{
+				ImGui::Text("Mouse Position: <invalid>");
+			}
 
-		ImGui::Text("Game Turn: %u (%.3f ms)%s", game.GetTurn(), game.GetDeltaTime().count(),
-		            game.IsPaused() ? " - paused" : "");
+			const auto& handPosition =
+			    Locator::entitiesRegistry::value().Get<ecs::components::Transform>(game.GetHand()).position;
+			ImGui::Text("Hand Position: (%.1f,%.1f,%.1f)", handPosition.x, handPosition.y, handPosition.z);
+
+			ImGui::Text("Game Turn: %u (%.3f ms)%s", game.GetTurn(), game.GetDeltaTime().count(),
+			            game.IsPaused() ? " - paused" : "");
+		}
+		ImGui::End();
 	}
-	ImGui::End();
 }

--- a/src/Debug/Gui.cpp
+++ b/src/Debug/Gui.cpp
@@ -937,9 +937,11 @@ void Gui::ShowCameraPositionOverlay(const Game& game)
 
 	if (ImGui::Begin("Camera position overlay", nullptr, cameraPositionOverlayFlags))
 	{
-		const auto camPos = game.GetCamera().GetOrigin();
+		const auto camOrigin = game.GetCamera().GetOrigin();
+		const auto camFocus = game.GetCamera().GetFocus();
 		const auto camRot = glm::degrees(game.GetCamera().GetRotation());
-		ImGui::Text("Camera Position: (%.1f,%.1f,%.1f)", camPos.x, camPos.y, camPos.z);
+		ImGui::Text("Camera Origin: (%.1f,%.1f,%.1f)", camOrigin.x, camOrigin.y, camOrigin.z);
+		ImGui::Text("Camera Focus: (%.1f,%.1f,%.1f)", camFocus.x, camFocus.y, camFocus.z);
 		ImGui::Text("Camera Rotation: (%.1f,%.1f,%.1f)", camRot.x, camRot.y, camRot.z);
 
 		if (ImGui::IsMousePosValid())

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -887,10 +887,7 @@ void Game::LoadMap(const std::filesystem::path& path)
 
 	// create our camera
 	const auto aspect = Locator::windowing::has_value() ? Locator::windowing::value().GetAspectRatio() : 1.0f;
-	(*_camera)
-	    .SetProjectionMatrixPerspective(_config.cameraXFov, aspect, _config.cameraNearClip, _config.cameraFarClip)
-	    .SetOrigin(glm::vec3(1441.56f, 24.764f, 2081.76f))
-	    .SetFocus(glm::vec3(1442.27f, 24.764f, 2082.47f));
+	_camera->SetProjectionMatrixPerspective(_config.cameraXFov, aspect, _config.cameraNearClip, _config.cameraFarClip);
 
 	Script script;
 	script.Load(source);

--- a/src/Game.h
+++ b/src/Game.h
@@ -119,6 +119,7 @@ public:
 		bool debugVillagerNames {false};
 		bool debugVillagerStates {false};
 
+		bool viewDetailOverlay {false};
 		bool drawSky {true};
 		bool drawWater {true};
 		bool drawIsland {true};

--- a/src/LHScriptX/FeatureScriptCommands.cpp
+++ b/src/LHScriptX/FeatureScriptCommands.cpp
@@ -12,6 +12,7 @@
 #include <tuple>
 
 #include <glm/gtx/euler_angles.hpp>
+#include <glm/gtx/polar_coordinates.hpp>
 #include <glm/gtx/string_cast.hpp>
 #include <spdlog/spdlog.h>
 
@@ -571,12 +572,14 @@ void FeatureScriptCommands::CreateArea([[maybe_unused]] glm::vec3 position, floa
 	// __func__);
 }
 
-void FeatureScriptCommands::StartCameraPos(glm::vec3 position)
+void FeatureScriptCommands::StartCameraPos(glm::vec3 focus)
 {
+	static constexpr auto k_DefaultCameraOriginOffset = 120.0f;
+	static constexpr auto k_DefaultCameraOriginOffsetAngles = glm::radians(glm::vec2(12.8571f, 157.51f));
+
 	auto& camera = Game::Instance()->GetCamera();
-	const auto offset = glm::vec3(0.0f, 10.0f, 0.0f);
-	const auto focusOffset = camera.GetFocus() - camera.GetOrigin();
-	camera.SetOrigin(position + offset).SetFocus(position + offset + focusOffset);
+	const auto offset = k_DefaultCameraOriginOffset * glm::euclidean(k_DefaultCameraOriginOffsetAngles);
+	camera.SetFocus(focus).SetOrigin(focus + offset);
 }
 
 void FeatureScriptCommands::FlyByFile([[maybe_unused]] const std::string& path)

--- a/src/LHScriptX/FeatureScriptCommands.h
+++ b/src/LHScriptX/FeatureScriptCommands.h
@@ -86,7 +86,7 @@ public:
 	static void LoadLandscape(const std::string& path);
 	static void Version(float version);
 	static void CreateArea(glm::vec3 position, float);
-	static void StartCameraPos(glm::vec3 position);
+	static void StartCameraPos(glm::vec3 focus);
 	static void FlyByFile(const std::string& path);
 	static void TownNeedsPos(int32_t townId, glm::vec3 position);
 	static void CreateFurniture(glm::vec3 position, int32_t, float);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,6 +42,7 @@ openblack_setup_and_add_test(test_game_initialize test_game_initialize.cpp)
 openblack_setup_and_add_test(test_load_scene test_load_scene.cpp)
 openblack_setup_and_add_test(test_fixed test_fixed.cpp)
 openblack_setup_and_add_test(test_interpolator test_interpolator.cpp)
+openblack_setup_and_add_test(test_set_camera_pos camera/test_set_camera_pos.cpp)
 openblack_setup_and_add_json_test(
   test_mobile_wall_hug mobile_wall_hug/test_mobile_wall_hug.cpp
 )

--- a/test/camera/test_set_camera_pos.cpp
+++ b/test/camera/test_set_camera_pos.cpp
@@ -1,0 +1,105 @@
+/******************************************************************************
+ * Copyright (c) 2018-2024 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *******************************************************************************/
+
+#include <3D/LandIsland.h>
+#include <Camera/Camera.h>
+#include <gtest/gtest.h>
+
+#include "Game.h"
+#include "LHScriptX/Script.h"
+#include "Locator.h"
+
+class SetCameraPos: public ::testing::Test
+{
+protected:
+	void SetUp() override
+	{
+		static const auto mockGamePath = std::filesystem::path(TEST_BINARY_DIR) / "mock";
+		auto args = openblack::Arguments {
+		    .rendererType = bgfx::RendererType::Enum::Noop,
+		    .gamePath = mockGamePath.string(),
+		    .logFile = "stdout",
+		};
+		std::fill_n(args.logLevels.begin(), args.logLevels.size(), spdlog::level::warn);
+		_game = std::make_unique<openblack::Game>(std::move(args));
+		ASSERT_TRUE(_game->Initialize());
+	}
+	void TearDown() override { _game.reset(); }
+	std::unique_ptr<openblack::Game> _game;
+
+public:
+	void LoadTestScene(const char* sceneScript)
+	{
+		openblack::lhscriptx::Script script;
+		script.Load(sceneScript);
+	}
+
+	void LoadSceneWithCameraPos(glm::vec2 cameraPos, glm::vec2 citadelPos)
+	{
+		std::array<char, 0x100> script;
+		snprintf(script.data(), script.size(),
+		         "VERSION(2.300000)\n"
+		         "LOAD_LANDSCAPE(\".\\Data\\Landscape\\Land1.lnd\")\n"
+		         "START_CAMERA_POS(\"%.02f,%.02f\")\n"
+		         "CREATE_CITADEL(\"%.02f,%.02f\", 0, \"PLAYER_ONE\", 0, 1000)\n",
+		         cameraPos.x, cameraPos.y, citadelPos.x, citadelPos.y);
+		LoadTestScene(script.data());
+	}
+
+	void AssertCameraPos(glm::vec3 expectedPos)
+	{
+		const auto actualPos = _game->GetCamera().GetPosition();
+		ASSERT_FLOAT_EQ(actualPos.x, expectedPos.x);
+		ASSERT_FLOAT_EQ(actualPos.z, expectedPos.z);
+		ASSERT_FLOAT_EQ(actualPos.y, expectedPos.y);
+	}
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables): external macro
+TEST_F(SetCameraPos, setCameraZero)
+{
+	LoadSceneWithCameraPos({0.0f, 0.0f}, {0.0f, 0.0f});
+	AssertCameraPos({44.7591362f, 26.7025127f, -108.090675f});
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables): external macro
+TEST_F(SetCameraPos, setCameraLand1)
+{
+	// Since the land island is mocked, the land is flat and the altitude is the same
+	const auto cameraPos = glm::vec2(1788.40f, 2710.00f);
+	LoadSceneWithCameraPos(cameraPos, {1915.05f, 2508.89f});
+	const auto altitude = openblack::Locator::terrainSystem::value().GetHeightAt(cameraPos);
+	ASSERT_FLOAT_EQ(altitude, 28.81); // Actual vanilla value 28.9173050f
+	AssertCameraPos({1833.1592f, 55.512512f /*55.6197281f*/, 2601.9094f});
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables): external macro
+TEST_F(SetCameraPos, setCameraTwoGods)
+{
+	// Since the land island is mocked, the land is flat and the altitude is the same
+	LoadSceneWithCameraPos({2185.72f, 2315.78f}, {1989.46f, 2356.52f});
+	AssertCameraPos({2230.47900f, 26.7025127f, 2207.68945f});
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables): external macro
+TEST_F(SetCameraPos, setCameraThreeGods)
+{
+	// Since the land island is mocked, the land is flat and the altitude is the same
+	LoadSceneWithCameraPos({2816.90f, 2740.75f}, {2641.66f, 2381.22f});
+	AssertCameraPos({2861.65894f, 26.7025127f, 2632.65942f});
+}
+
+// TODO(#562)
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables): external macro
+TEST_F(SetCameraPos, DISABLED_setCameraFourGods)
+{
+	// Since the land island is mocked, the land is flat and the altitude is the same
+	LoadSceneWithCameraPos({0.0f, 0.0f}, {3159.89f, 1934.44f});
+	AssertCameraPos({3159.89f, 26.7025127f, 1934.44f});
+}

--- a/test/camera/test_set_camera_pos.cpp
+++ b/test/camera/test_set_camera_pos.cpp
@@ -52,12 +52,13 @@ public:
 		LoadTestScene(script.data());
 	}
 
-	void AssertCameraPos(glm::vec3 expectedPos)
+	void ExpectCameraPos(glm::vec3 expectedPos)
 	{
-		const auto actualPos = _game->GetCamera().GetPosition();
-		ASSERT_FLOAT_EQ(actualPos.x, expectedPos.x);
-		ASSERT_FLOAT_EQ(actualPos.z, expectedPos.z);
-		ASSERT_FLOAT_EQ(actualPos.y, expectedPos.y);
+		constexpr float k_Ep = 1e-2;
+		const auto actualPos = _game->GetCamera().GetOrigin();
+		EXPECT_NEAR(actualPos.x, expectedPos.x, k_Ep);
+		EXPECT_NEAR(actualPos.y, expectedPos.y, k_Ep);
+		EXPECT_NEAR(actualPos.z, expectedPos.z, k_Ep);
 	}
 };
 
@@ -65,7 +66,7 @@ public:
 TEST_F(SetCameraPos, setCameraZero)
 {
 	LoadSceneWithCameraPos({0.0f, 0.0f}, {0.0f, 0.0f});
-	AssertCameraPos({44.7591362f, 26.7025127f, -108.090675f});
+	ExpectCameraPos({44.7591362f, 26.7025127f, -108.090675f});
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables): external macro
@@ -76,7 +77,7 @@ TEST_F(SetCameraPos, setCameraLand1)
 	LoadSceneWithCameraPos(cameraPos, {1915.05f, 2508.89f});
 	const auto altitude = openblack::Locator::terrainSystem::value().GetHeightAt(cameraPos);
 	ASSERT_FLOAT_EQ(altitude, 28.81); // Actual vanilla value 28.9173050f
-	AssertCameraPos({1833.1592f, 55.512512f /*55.6197281f*/, 2601.9094f});
+	ExpectCameraPos({1833.1592f, 55.512512f /*55.6197281f*/, 2601.9094f});
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables): external macro
@@ -84,7 +85,7 @@ TEST_F(SetCameraPos, setCameraTwoGods)
 {
 	// Since the land island is mocked, the land is flat and the altitude is the same
 	LoadSceneWithCameraPos({2185.72f, 2315.78f}, {1989.46f, 2356.52f});
-	AssertCameraPos({2230.47900f, 26.7025127f, 2207.68945f});
+	ExpectCameraPos({2230.47900f, 26.7025127f, 2207.68945f});
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables): external macro
@@ -92,7 +93,7 @@ TEST_F(SetCameraPos, setCameraThreeGods)
 {
 	// Since the land island is mocked, the land is flat and the altitude is the same
 	LoadSceneWithCameraPos({2816.90f, 2740.75f}, {2641.66f, 2381.22f});
-	AssertCameraPos({2861.65894f, 26.7025127f, 2632.65942f});
+	ExpectCameraPos({2861.65894f, 26.7025127f, 2632.65942f});
 }
 
 // TODO(#562)
@@ -101,5 +102,5 @@ TEST_F(SetCameraPos, DISABLED_setCameraFourGods)
 {
 	// Since the land island is mocked, the land is flat and the altitude is the same
 	LoadSceneWithCameraPos({0.0f, 0.0f}, {3159.89f, 1934.44f});
-	AssertCameraPos({3159.89f, 26.7025127f, 1934.44f});
+	ExpectCameraPos({3159.89f, 26.7025127f, 1934.44f});
 }

--- a/test/mock/CMakeLists.txt
+++ b/test/mock/CMakeLists.txt
@@ -155,7 +155,8 @@ add_custom_target(
   COMMAND
     lndtool write -o ${TERRAIN_LAND_1_OUTPUT} --terrain-type ${TERRAIN_TYPE}
     --noise-map ${TERRAIN_NOISE_MAP} --bump-map ${TERRAIN_BUMP_MAP}
-    --material-array=${TERRAIN_MATERIAL_LIST}
+    --material-array=${TERRAIN_MATERIAL_LIST} --points
+    "1788.40 28.9173050 2710.00"
   COMMAND
     lndtool write -o ${TERRAIN_LAND_MPM_2P_1_OUTPUT} --terrain-type
     ${TERRAIN_TYPE} --noise-map ${TERRAIN_NOISE_MAP} --bump-map

--- a/test/mock/CMakeLists.txt
+++ b/test/mock/CMakeLists.txt
@@ -122,9 +122,7 @@ add_custom_target(
   COMMAND Python3::Interpreter ${CMAKE_CURRENT_SOURCE_DIR}/gen_zeroed_file.py
           --output-files "${RAW_TEXTURES_0x30000}" --size 0x30000
   # Generate Citadel files
-  COMMAND
-    Python3::Interpreter ${CMAKE_CURRENT_SOURCE_DIR}/gen_zeroed_file.py
-    --output-files "${CITADEL_OUTSIDE_BINARY_DIR}/Entrance_l3d.zzz" --size 0x616
+  COMMAND ${CMAKE_COMMAND} -E touch ${CITADEL_OUTSIDE_BINARY_DIR}/placeholder
   # Data/AllMeshes.g3d
   # Dummy mesh for 626 meshes
   COMMAND Python3::Interpreter ${CMAKE_CURRENT_SOURCE_DIR}/gen_meshes.py


### PR DESCRIPTION
Depends on:
- [x] #714 
- [x] #726
- [x]  #561

The position described in `START_CAMERA_POS` is actually the focus location
that the camera faces.
The origin of the camera is 120 units away and at a latitude of 12.8571 and
longitude of 157.51.

Also moved the game details overlay to a menu option
![image](https://github.com/openblack/openblack/assets/1013356/0b878eac-bb68-47c0-ae9a-18da6e31495c)


With these new changes, the comparison screenshots will start looking a lot more like the vanilla versions.