### PR TITLE
citadel: Skip loading LO variants of meshes

### DIFF
--- a/src/Debug/Gui.cpp
+++ b/src/Debug/Gui.cpp
@@ -961,6 +961,11 @@ void Gui::ShowCameraPositionOverlay(const Game& game)
 			    Locator::entitiesRegistry::value().Get<ecs::components::Transform>(game.GetHand()).position;
 			ImGui::Text("Hand Position: (%.1f,%.1f,%.1f)", handPosition.x, handPosition.y, handPosition.z);
 
+			const auto* stats = bgfx::getStats();
+			const auto* caps = bgfx::getCaps();
+			ImGui::Text("Num Vertex Buffers: %u/%u", stats->numVertexBuffers, caps->limits.maxVertexBuffers);
+			ImGui::Text("Num Textures: %u/%u", stats->numTextures, caps->limits.maxTextures);
+
 			ImGui::Text("Game Turn: %u (%.3f ms)%s", game.GetTurn(), game.GetDeltaTime().count(),
 			            game.IsPaused() ? " - paused" : "");
 		}

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -532,6 +532,13 @@ bool Game::Initialize()
 	    fileSystem.GetPath<filesystem::Path::Citadel>() / "engine", false, [&meshManager](const std::filesystem::path& f) {
 		    if (f.extension() == ".zzz")
 		    {
+			    if (f.stem().string().ends_with("lo_l3d"))
+			    {
+				    SPDLOG_LOGGER_WARN(
+				        spdlog::get("game"),
+				        "Skipping lo duplicate lo meshes. See https://github.com/openblack/openblack/issues/727");
+				    return;
+			    }
 			    SPDLOG_LOGGER_DEBUG(spdlog::get("game"), "Loading interior temple mesh: {}", f.stem().string());
 			    try
 			    {


### PR DESCRIPTION
The multitude of submeshes in the citadel reaches bgfx's limit of 4096
vertex buffers.
This is temporary measure until https://github.com/openblack/openblack/issues/727 is solved to allow loading land2.txt

Added the use and limits to the debug ui overlay.
![image](https://github.com/openblack/openblack/assets/1013356/0dd770ea-e852-41a3-a579-469ccdce7e75)
