### PR TITLE
Camera issues

### DIFF
--- a/src/Camera/Camera.cpp
+++ b/src/Camera/Camera.cpp
@@ -12,6 +12,7 @@
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtx/euler_angles.hpp>
 #include <glm/gtx/intersect.hpp>
+#include <glm/gtx/transform.hpp>
 #include <glm/gtx/vec_swizzle.hpp>
 
 #include "3D/LandIsland.h"
@@ -98,11 +99,8 @@ Camera& Camera::SetProjectionMatrixPerspective(float xFov, float aspect, float n
 {
 	_xFov = glm::radians(xFov);
 	const float yFov = (glm::atan(glm::tan(_xFov / 2.0f)) / aspect) * 2.0f;
-	const float h = 1.0f / glm::tan(yFov * 0.5f);
-	const float w = h / aspect;
-	const float a = nearClip / (farClip - nearClip);
-	const float b = (nearClip * farClip) / (farClip - nearClip);
-	_projectionMatrix = glm::mat4x4(w, 0.f, 0.f, 0.f, 0.f, h, 0.f, 0.f, 0.f, 0.f, a, 1.f, 0.f, 0.f, b, 0.f);
+	// Inverse near and far for reverse z, we need to translate z by 1 to get back to the [0 1] range
+	_projectionMatrix = glm::translate(glm::vec3(0.f, 0.f, 1.f)) * glm::perspective(yFov, aspect, farClip, nearClip);
 
 	return *this;
 }

--- a/src/Camera/Camera.cpp
+++ b/src/Camera/Camera.cpp
@@ -149,7 +149,7 @@ void Camera::DeprojectScreenToWorld(glm::vec2 screenCoord, glm::vec3& outWorldOr
 	// projection space (z=1 is near, z=0 is far - this gives us better
 	// precision) To get the direction of the ray trace we need to use any z
 	// between the near and the far plane, so let's use (mousex, mousey, 0.5)
-	const glm::vec4 rayStartProjectionSpace = glm::vec4(screenSpaceX, screenSpaceY, 1.0f, 1.0f);
+	const glm::vec4 rayStartProjectionSpace = glm::vec4(screenSpaceX, screenSpaceY, 0.999f, 1.0f);
 	const glm::vec4 rayEndProjectionSpace = glm::vec4(screenSpaceX, screenSpaceY, 0.5f, 1.0f);
 
 	// Calculate our inverse view projection matrix

--- a/src/Camera/Camera.cpp
+++ b/src/Camera/Camera.cpp
@@ -12,7 +12,6 @@
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtx/euler_angles.hpp>
 #include <glm/gtx/intersect.hpp>
-#include <glm/gtx/transform.hpp>
 #include <glm/gtx/vec_swizzle.hpp>
 
 #include "3D/LandIsland.h"
@@ -28,7 +27,8 @@ using namespace openblack;
 namespace
 {
 constexpr auto k_DefaultCameraOriginOffset = glm::vec3(0.0f, 0.0f, 120.0f);
-}
+constexpr auto k_ReverseZMatrix = glm::mat4(1.f, 0.f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 0.f, 0.f, -1.f, 0.f, 0.f, 0.f, 1.f, 1.f);
+} // namespace
 
 Camera::Camera(glm::vec3 focus)
     // Maybe a struct is not the right thing... Maybe an optional?
@@ -59,6 +59,11 @@ glm::mat4 Camera::GetViewMatrix(Interpolation interpolation) const
 glm::mat4 Camera::GetViewProjectionMatrix(Interpolation interpolation) const
 {
 	return GetProjectionMatrix() * GetViewMatrix(interpolation);
+}
+
+glm::mat4 Camera::GetViewProjectionMatrix(Projection projection, Interpolation interpolation) const
+{
+	return GetProjectionMatrix(projection) * GetViewMatrix(interpolation);
 }
 
 std::optional<ecs::components::Transform> Camera::RaycastMouseToLand(bool includeWater, Interpolation interpolation) const
@@ -100,7 +105,8 @@ Camera& Camera::SetProjectionMatrixPerspective(float xFov, float aspect, float n
 	_xFov = glm::radians(xFov);
 	const float yFov = (glm::atan(glm::tan(_xFov / 2.0f)) / aspect) * 2.0f;
 	// Inverse near and far for reverse z, we need to translate z by 1 to get back to the [0 1] range
-	_projectionMatrix = glm::translate(glm::vec3(0.f, 0.f, 1.f)) * glm::perspective(yFov, aspect, farClip, nearClip);
+	_projectionMatrix = glm::perspective(yFov, aspect, nearClip, farClip);
+	_projectionMatrixReversedZ = k_ReverseZMatrix * _projectionMatrix;
 
 	return *this;
 }
@@ -147,11 +153,11 @@ void Camera::DeprojectScreenToWorld(glm::vec2 screenCoord, glm::vec3& outWorldOr
 	// projection space (z=1 is near, z=0 is far - this gives us better
 	// precision) To get the direction of the ray trace we need to use any z
 	// between the near and the far plane, so let's use (mousex, mousey, 0.5)
-	const glm::vec4 rayStartProjectionSpace = glm::vec4(screenSpaceX, screenSpaceY, 0.999f, 1.0f);
+	const glm::vec4 rayStartProjectionSpace = glm::vec4(screenSpaceX, screenSpaceY, 0.0f, 1.0f);
 	const glm::vec4 rayEndProjectionSpace = glm::vec4(screenSpaceX, screenSpaceY, 0.5f, 1.0f);
 
 	// Calculate our inverse view projection matrix
-	auto inverseViewProj = glm::inverse(GetViewProjectionMatrix(interpolation));
+	auto inverseViewProj = glm::inverse(GetViewProjectionMatrix(Projection::Normal, interpolation));
 
 	// Get our homogeneous coordinates for our start and end ray positions
 	const glm::vec4 hgRayStartWorldSpace = inverseViewProj * rayStartProjectionSpace;
@@ -186,7 +192,8 @@ bool Camera::ProjectWorldToScreen(glm::vec3 worldPosition, glm::vec4 viewport, g
 		outScreenPosition = glm::vec3(glm::lerp(glm::xy(viewport), glm::zw(viewport), {0.5f, 0.5f}), 0.0f);
 		return true; // Right at the camera position
 	}
-	outScreenPosition = glm::project(worldPosition, GetViewMatrix(interpolation), GetProjectionMatrix(), viewport);
+	outScreenPosition =
+	    glm::project(worldPosition, GetViewMatrix(interpolation), GetProjectionMatrix(Projection::Normal), viewport);
 	if (outScreenPosition.x < viewport.x || outScreenPosition.y < viewport.y || glm::round(outScreenPosition.x) > viewport.z ||
 	    glm::round(outScreenPosition.y) > viewport.w)
 	{
@@ -194,11 +201,11 @@ bool Camera::ProjectWorldToScreen(glm::vec3 worldPosition, glm::vec4 viewport, g
 	}
 	if (outScreenPosition.z > 1.0f)
 	{
-		return false; // Behind Camera
+		return false; // Clipped
 	}
 	if (outScreenPosition.z < 0.0f)
 	{
-		return false; // Clipped
+		return false; // Behind Camera
 	}
 	outScreenPosition.y = viewport.w - (outScreenPosition.y - viewport.y) + viewport.y;
 	return true;
@@ -239,7 +246,28 @@ void Camera::HandleActions(std::chrono::microseconds dt)
 
 const glm::mat4& Camera::GetProjectionMatrix() const
 {
-	return _projectionMatrix;
+	return GetProjectionMatrix(_cameraProjection);
+}
+
+const glm::mat4& Camera::GetProjectionMatrix(Projection projection) const
+{
+	switch (projection)
+	{
+	case Projection::Normal:
+		return _projectionMatrix;
+	case Projection::ReversedZ:
+		return _projectionMatrixReversedZ;
+#ifdef __cpp_lib_unreachable
+	default:
+		// TODO(#656): Remove check in C++23 and just use unreachable
+		assert(false);
+		std::unreachable();
+#else
+	default:
+		assert(false);
+		return _projectionMatrix;
+#endif
+	}
 }
 
 glm::vec3 Camera::GetOrigin(Interpolation interpolation) const
@@ -410,6 +438,11 @@ Camera& Camera::SetInterpolatorDuration(std::chrono::microseconds duration)
 Camera& Camera::SetProjectionMatrix(const glm::mat4& projection)
 {
 	_projectionMatrix = projection;
+	_projectionMatrixReversedZ = k_ReverseZMatrix * _projectionMatrix;
 
 	return *this;
+}
+Camera::Projection Camera::GetCameraProjection() const
+{
+	return _cameraProjection;
 }

--- a/src/Camera/Camera.cpp
+++ b/src/Camera/Camera.cpp
@@ -146,10 +146,10 @@ void Camera::DeprojectScreenToWorld(glm::vec2 screenCoord, glm::vec3& outWorldOr
 	const float screenSpaceY = ((1.0f - screenCoord.y) - 0.5f) * 2.0f;
 
 	// The start of the ray trace is defined to be at mousex,mousey,1 in
-	// projection space (z=0 is near, z=1 is far - this gives us better
+	// projection space (z=1 is near, z=0 is far - this gives us better
 	// precision) To get the direction of the ray trace we need to use any z
 	// between the near and the far plane, so let's use (mousex, mousey, 0.5)
-	const glm::vec4 rayStartProjectionSpace = glm::vec4(screenSpaceX, screenSpaceY, 0.0f, 1.0f);
+	const glm::vec4 rayStartProjectionSpace = glm::vec4(screenSpaceX, screenSpaceY, 1.0f, 1.0f);
 	const glm::vec4 rayEndProjectionSpace = glm::vec4(screenSpaceX, screenSpaceY, 0.5f, 1.0f);
 
 	// Calculate our inverse view projection matrix

--- a/src/Camera/Camera.h
+++ b/src/Camera/Camera.h
@@ -33,13 +33,21 @@ public:
 		Start,
 		Target,
 	};
+	enum class Projection : uint8_t
+	{
+		Normal,
+		ReversedZ,
+	};
 	explicit Camera(glm::vec3 focus = glm::vec3(1000.0f, 0.0f, 1000.0f));
 	virtual ~Camera();
 
 	[[nodiscard]] float GetHorizontalFieldOfView() const;
 	[[nodiscard]] virtual glm::mat4 GetViewMatrix(Interpolation interpolation) const;
 	[[nodiscard]] const glm::mat4& GetProjectionMatrix() const;
+	[[nodiscard]] const glm::mat4& GetProjectionMatrix(Projection projection) const;
 	[[nodiscard]] glm::mat4 GetViewProjectionMatrix(Interpolation interpolation = Camera::Interpolation::Current) const;
+	[[nodiscard]] glm::mat4 GetViewProjectionMatrix(Projection projection,
+	                                                Interpolation interpolation = Camera::Interpolation::Current) const;
 
 	[[nodiscard]] std::optional<ecs::components::Transform>
 	RaycastMouseToLand(bool includeWater = true, Interpolation interpolation = Camera::Interpolation::Current) const;
@@ -97,6 +105,7 @@ public:
 	void HandleActions(std::chrono::microseconds dt);
 
 	[[nodiscard]] glm::mat4 GetRotationMatrix() const;
+	[[nodiscard]] Projection GetCameraProjection() const;
 
 	CameraModel& GetModel() { return *_model; }
 	[[nodiscard]] const CameraModel& GetModel() const { return *_model; }
@@ -109,7 +118,9 @@ protected:
 	std::chrono::microseconds _interpolatorDuration = std::chrono::microseconds::zero();
 	float _xFov = 0.0f; // TODO(#707): This should be a zoomer for animations
 	glm::mat4 _projectionMatrix = glm::mat4 {1.0f};
+	glm::mat4 _projectionMatrixReversedZ = glm::mat4 {1.0f};
 	std::unique_ptr<CameraModel> _model;
+	Projection _cameraProjection = Projection::ReversedZ;
 };
 
 } // namespace openblack

--- a/src/Camera/DefaultWorldCameraModel.cpp
+++ b/src/Camera/DefaultWorldCameraModel.cpp
@@ -439,7 +439,7 @@ void DefaultWorldCameraModel::UpdateModeDragging(const Camera& camera, glm::u16v
 
 void DefaultWorldCameraModel::UpdateModeFlying(glm::vec3 eulerAngles)
 {
-	if (!_handPosition.has_value() && !_screenSpaceCenterRaycastHit.has_value())
+	if (!_screenSpaceCenterRaycastHit.has_value())
 	{
 		return;
 	}

--- a/src/Camera/DefaultWorldCameraModel.cpp
+++ b/src/Camera/DefaultWorldCameraModel.cpp
@@ -249,7 +249,12 @@ void DefaultWorldCameraModel::UpdateFocusPointInteractionParameters(glm::vec3 or
                                                                     const Camera& camera)
 {
 	_focusAtClick = _targetFocus;
-	_screenSpaceMouseRaycastHitAtClick = _screenSpaceMouseRaycastHit;
+	// TODO(#656) in c++23 use camera.RaycastMouseToLand().and_then
+	_screenSpaceMouseRaycastHitAtClick = std::nullopt;
+	if (auto hit = camera.RaycastMouseToLand(true, Camera::Interpolation::Target))
+	{
+		_screenSpaceMouseRaycastHitAtClick = hit->position;
+	}
 	if (_screenSpaceMouseRaycastHitAtClick.has_value())
 	{
 		_arcBallRadius = PointDistanceAlongLineSegment(origin, focus, *_screenSpaceMouseRaycastHitAtClick);
@@ -529,10 +534,6 @@ void DefaultWorldCameraModel::UpdateRaycastHitPoints(const Camera& camera)
 	if (const auto hit = camera.RaycastScreenCoordToLand({0.5f, 0.5f}, false, Camera::Interpolation::Target))
 	{
 		_screenSpaceCenterRaycastHit = hit->position;
-	}
-	else
-	{
-		_screenSpaceCenterRaycastHit = std::nullopt;
 	}
 }
 

--- a/src/Camera/DefaultWorldCameraModel.cpp
+++ b/src/Camera/DefaultWorldCameraModel.cpp
@@ -522,11 +522,11 @@ void DefaultWorldCameraModel::UpdateRaycastHitPoints(const Camera& camera)
 	// TODO(#656) in c++23 use camera.RaycastMouseToLand().and_then
 	_screenSpaceMouseRaycastHit = std::nullopt;
 	_screenSpaceCenterRaycastHit = std::nullopt;
-	if (const auto hit = camera.RaycastMouseToLand(true, Camera::Interpolation::Target))
+	if (const auto hit = camera.RaycastMouseToLand(false, Camera::Interpolation::Target))
 	{
 		_screenSpaceMouseRaycastHit = hit->position;
 	}
-	if (const auto hit = camera.RaycastScreenCoordToLand({0.5f, 0.5f}, true, Camera::Interpolation::Target))
+	if (const auto hit = camera.RaycastScreenCoordToLand({0.5f, 0.5f}, false, Camera::Interpolation::Target))
 	{
 		_screenSpaceCenterRaycastHit = hit->position;
 	}

--- a/src/Camera/DefaultWorldCameraModel.cpp
+++ b/src/Camera/DefaultWorldCameraModel.cpp
@@ -522,11 +522,11 @@ void DefaultWorldCameraModel::UpdateRaycastHitPoints(const Camera& camera)
 	// TODO(#656) in c++23 use camera.RaycastMouseToLand().and_then
 	_screenSpaceMouseRaycastHit = std::nullopt;
 	_screenSpaceCenterRaycastHit = std::nullopt;
-	if (const auto hit = camera.RaycastMouseToLand(false, Camera::Interpolation::Target))
+	if (const auto hit = camera.RaycastMouseToLand(true, Camera::Interpolation::Target))
 	{
 		_screenSpaceMouseRaycastHit = hit->position;
 	}
-	if (const auto hit = camera.RaycastScreenCoordToLand({0.5f, 0.5f}, false, Camera::Interpolation::Target))
+	if (const auto hit = camera.RaycastScreenCoordToLand({0.5f, 0.5f}, true, Camera::Interpolation::Target))
 	{
 		_screenSpaceCenterRaycastHit = hit->position;
 	}


### PR DESCRIPTION
Solves a collection of issues found while testing the new camera that didn't warrant locking the PR or weren't found.

In order \:
- There where an invalid access to optional that was not caught during test (In my test i was on release so assert on the * operator were not checked).
- There where strange behavior when clicking on the sky.
- Arcballing ~and flying~ did not work on water.

So i \:
- Changed the check in `UpdateModeFlying` in `DefaultWorldCameraModel.cpp:442` so it check that `_screenSpaceCenterRaycastHit` and removed the check for `_handPosition` as it takes `_screenSpaceCenterRaycastHit` if empty.
- ~In `DeprojectScreenToWorld` at `camera.cpp:142` i used 1 instead of 0 as z value for `rayStartProjectionSpace`, as the depth buffer is reversed due to (#665).~
- I saved both the normal and Z reversed projection matrix in camera and use Z reverse for rendering and normal projection for raycasting.
- ~In `UpdateRaycastHitPoints` at `DefaultWorldCameraModel.cpp:527` i allowed the `RaycastMouseToLand` and `RaycastScreenCoordToLand` to take into account water using the parameter boolean.~
- In `UpdateFocusPointInteractionParameters` at `DefaultWorldCameraModel.cpp:248` i used `RaycastMouseToLand` including the water to compute `_screenSpaceMouseRaycastHitAtClick`

I know there where an issue how slow zooming was with the mouse wheel, but i don't want to have to decide what is a confortable zooming speed.
