### PR TITLE
Implement Fly to bookmarks

### DIFF
--- a/src/Camera/Camera.h
+++ b/src/Camera/Camera.h
@@ -98,6 +98,9 @@ public:
 
 	[[nodiscard]] glm::mat4 GetRotationMatrix() const;
 
+	CameraModel& GetModel() { return *_model; }
+	[[nodiscard]] const CameraModel& GetModel() const { return *_model; }
+
 protected:
 	ZoomInterpolator3f _originInterpolators;
 	ZoomInterpolator3f _focusInterpolators;

--- a/src/Camera/CameraModel.h
+++ b/src/Camera/CameraModel.h
@@ -53,6 +53,7 @@ public:
 
 	virtual std::optional<CameraInterpolationUpdateInfo> Update(std::chrono::microseconds dt, const Camera& camera) = 0;
 	virtual void HandleActions(std::chrono::microseconds dt) = 0;
+	virtual void SetFlight(glm::vec3 origin, glm::vec3 focus) = 0;
 	[[nodiscard]] virtual glm::vec3 GetTargetOrigin() const = 0;
 	[[nodiscard]] virtual glm::vec3 GetTargetFocus() const = 0;
 	[[nodiscard]] virtual std::chrono::seconds GetIdleTime() const = 0;

--- a/src/Camera/DefaultWorldCameraModel.cpp
+++ b/src/Camera/DefaultWorldCameraModel.cpp
@@ -503,15 +503,7 @@ void DefaultWorldCameraModel::UpdateModeFlying(glm::vec3 eulerAngles)
 
 	if (wooshingDistance)
 	{
-		_flightPath = CharterFlight(_targetOrigin, _targetFocus, _currentOrigin, k_FlightHeightFactor);
-		static constexpr auto k_WooshingNoiseIds = std::array<audio::SoundId, 4> {
-		    audio::SoundId::G_Woosh_01,
-		    audio::SoundId::G_Woosh_02,
-		    audio::SoundId::G_Woosh_03,
-		    audio::SoundId::G_Woosh_04,
-		};
-		const auto wooshNoiseId = static_cast<entt::id_type>(Locator::rng::value().Choose(k_WooshingNoiseIds));
-		Locator::audio::value().PlaySound(wooshNoiseId, audio::PlayType::Once);
+		SetFlight(_targetOrigin, _targetFocus);
 	}
 }
 
@@ -750,6 +742,19 @@ void DefaultWorldCameraModel::HandleActions(std::chrono::microseconds dt)
 	{
 		_mode = Mode::Cartesian;
 	}
+}
+
+void DefaultWorldCameraModel::SetFlight(glm::vec3 origin, glm::vec3 focus)
+{
+	_flightPath = CharterFlight(origin, focus, _currentOrigin, k_FlightHeightFactor);
+	static constexpr auto k_WooshingNoiseIds = std::array<audio::SoundId, 4> {
+	    audio::SoundId::G_Woosh_01,
+	    audio::SoundId::G_Woosh_02,
+	    audio::SoundId::G_Woosh_03,
+	    audio::SoundId::G_Woosh_04,
+	};
+	const auto wooshNoiseId = static_cast<entt::id_type>(Locator::rng::value().Choose(k_WooshingNoiseIds));
+	Locator::audio::value().PlaySound(wooshNoiseId, audio::PlayType::Once);
 }
 
 glm::vec3 DefaultWorldCameraModel::GetTargetOrigin() const

--- a/src/Camera/DefaultWorldCameraModel.h
+++ b/src/Camera/DefaultWorldCameraModel.h
@@ -37,6 +37,7 @@ public:
 
 	std::optional<CameraInterpolationUpdateInfo> Update(std::chrono::microseconds dt, const Camera& camera) final;
 	void HandleActions(std::chrono::microseconds dt) final;
+	void SetFlight(glm::vec3 origin, glm::vec3 focus) final;
 	[[nodiscard]] glm::vec3 GetTargetOrigin() const final;
 	[[nodiscard]] glm::vec3 GetTargetFocus() const final;
 	[[nodiscard]] std::chrono::seconds GetIdleTime() const final;

--- a/src/ECS/Components/CameraBookmark.h
+++ b/src/ECS/Components/CameraBookmark.h
@@ -13,12 +13,15 @@
 
 #include <chrono>
 
+#include <glm/vec3.hpp>
+
 namespace openblack::ecs::components
 {
 struct CameraBookmark
 {
 	uint8_t number;
 	float animationTime;
+	glm::vec3 savedOrigin;
 };
 
 } // namespace openblack::ecs::components

--- a/src/ECS/Registry.h
+++ b/src/ECS/Registry.h
@@ -104,6 +104,16 @@ public:
 		return _registry.get<Components...>(entity);
 	}
 	template <typename... Components>
+	decltype(auto) TryGet(entt::entity entity)
+	{
+		return _registry.try_get<Components...>(entity);
+	}
+	template <typename... Components>
+	[[nodiscard]] decltype(auto) TryGet(entt::entity entity) const
+	{
+		return _registry.try_get<Components...>(entity);
+	}
+	template <typename... Components>
 	[[nodiscard]] decltype(auto) Front() const
 	{
 		return _registry.view<Components...>().front();

--- a/src/ECS/Systems/CameraBookmarkSystemInterface.h
+++ b/src/ECS/Systems/CameraBookmarkSystemInterface.h
@@ -25,7 +25,9 @@ public:
 	virtual bool Initialize() = 0;
 	virtual void Update(const std::chrono::microseconds& dt) const = 0;
 	[[nodiscard]] virtual const std::array<entt::entity, 8>& GetBookmarks() const = 0;
-	virtual void SetBookmark(uint8_t index, const glm::vec3& position) const = 0;
+	/// When flying to a bookmark, the bookmark position becomes the camera focus
+	/// and the saved camera origin is restored. The original focus is lost.
+	virtual void SetBookmark(uint8_t index, const glm::vec3& position, const glm::vec3& savedCameraOrigin) const = 0;
 	virtual void ClearBookmark(uint8_t index) const = 0;
 };
 

--- a/src/ECS/Systems/Implementations/CameraBookmarkSystem.cpp
+++ b/src/ECS/Systems/Implementations/CameraBookmarkSystem.cpp
@@ -37,7 +37,7 @@ void CameraBookmarkSystem::Update(const std::chrono::microseconds& dt) const
 	});
 }
 
-void CameraBookmarkSystem::SetBookmark(uint8_t index, const glm::vec3& position) const
+void CameraBookmarkSystem::SetBookmark(uint8_t index, const glm::vec3& position, const glm::vec3& savedCameraOrigin) const
 {
 	if (index < _bookmarks.size())
 	{
@@ -46,6 +46,7 @@ void CameraBookmarkSystem::SetBookmark(uint8_t index, const glm::vec3& position)
 		registry.AssignOrReplace<Transform>(entity, position + glm::vec3(0.0f, 1.0f, 0.0f), glm::mat3(1.0f), glm::vec3(1.0f));
 		auto& bookmark = registry.Get<CameraBookmark>(entity);
 		bookmark.animationTime = 0.0f;
+		bookmark.savedOrigin = savedCameraOrigin;
 	}
 	else
 	{

--- a/src/ECS/Systems/Implementations/CameraBookmarkSystem.h
+++ b/src/ECS/Systems/Implementations/CameraBookmarkSystem.h
@@ -30,7 +30,7 @@ public:
 
 	[[nodiscard]] const std::array<entt::entity, 8>& GetBookmarks() const override { return _bookmarks; }
 
-	void SetBookmark(uint8_t index, const glm::vec3& position) const override;
+	void SetBookmark(uint8_t index, const glm::vec3& position, const glm::vec3& savedCameraOrigin) const override;
 	void ClearBookmark(uint8_t index) const override;
 
 private:

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -34,6 +34,7 @@
 #include "Debug/Gui.h"
 #include "ECS/Archetypes/HandArchetype.h"
 #include "ECS/Archetypes/PlayerArchetype.h"
+#include "ECS/Components/CameraBookmark.h"
 #include "ECS/Components/Mobile.h"
 #include "ECS/Components/Transform.h"
 #include "ECS/Map.h"
@@ -254,9 +255,18 @@ bool Game::ProcessEvents(const SDL_Event& event)
 				const auto index = static_cast<uint8_t>(event.key.keysym.sym - SDLK_1);
 				Locator::cameraBookmarkSystem::value().SetBookmark(index, handPosition, _camera->GetOrigin());
 			}
-			else if (event.key.keysym.mod == 0)
+			else
 			{
-				// TODO(#348): Fly-to the bookmark
+				const auto& entitiesRegistry = Locator::entitiesRegistry::value();
+				const size_t index = event.key.keysym.sym - SDLK_1;
+				const auto& bookmarkEntities = Locator::cameraBookmarkSystem::value().GetBookmarks();
+				const auto entity = bookmarkEntities.at(index);
+				const auto [transform, bookmark] =
+				    entitiesRegistry.TryGet<ecs::components::Transform, ecs::components::CameraBookmark>(entity);
+				if (transform != nullptr && bookmark != nullptr)
+				{
+					_camera->GetModel().SetFlight(bookmark->savedOrigin, transform->position);
+				}
 			}
 			break;
 		}

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -250,9 +250,9 @@ bool Game::ProcessEvents(const SDL_Event& event)
 		case SDLK_8:
 			if ((event.key.keysym.mod & KMOD_CTRL) != 0)
 			{
-				auto handPosition = _handPose * glm::vec4(0.0f, 0.0f, 0.0f, 1.0f);
+				const auto handPosition = _handPose * glm::vec4(0.0f, 0.0f, 0.0f, 1.0f);
 				const auto index = static_cast<uint8_t>(event.key.keysym.sym - SDLK_1);
-				Locator::cameraBookmarkSystem::value().SetBookmark(index, handPosition);
+				Locator::cameraBookmarkSystem::value().SetBookmark(index, handPosition, _camera->GetOrigin());
 			}
 			else if (event.key.keysym.mod == 0)
 			{


### PR DESCRIPTION
Exposed functionality to enqueue a fly-to with the camera model.
Added the camera origin to the saved data of a bookmark.

The way bookmarks work is that when you assign one, the hand position sets the position of the bookmark which will act as the camera's focus point. The camera's origin is also saved. Both these are used for fly-to when you restore the bookmark,
The original focus is lost.

Implements #348
Supersedes #356 