### PR TITLE
android: Build and sign release APK

### DIFF
--- a/.github/workflows/ci-cross-compile.yml
+++ b/.github/workflows/ci-cross-compile.yml
@@ -187,9 +187,20 @@ jobs:
       - name: Build with Gradle (Debug)
         run: ./gradlew build --no-daemon assembleDebug -PusePrebuiltNativeLibs
         working-directory: ./android
+      - name: Write signing key
+        id: write_key
+        uses: timheuer/base64-to-file@v1.2
+        with:
+          fileName: 'keystore/signing_keystore.jks'
+          encodedString: ${{ secrets.ANDROID_SIGNING_STORE_KEY_B64 }}
       - name: Build with Gradle (Release)
         run: ./gradlew build --no-daemon assembleRelease -PusePrebuiltNativeLibs
         working-directory: ./android
+        env:
+          STORE_KEY: ${{ steps.write_key.outputs.filePath }}
+          STORE_PASSWORD: ${{ secrets.ANDROID_SIGNING_STORE_PASSWORD }}
+          STORE_KEY_ALIAS: ${{ secrets.ANDROID_SIGNING_STORE_KEY_ALIAS }}
+          STORE_KEY_PASSWORD: ${{ secrets.ANDROID_SIGNING_STORE_PASSWORD }}
       - uses: actions/upload-artifact@v4
         with:
           name: openblack-android-apk-${{ env.GITHUB_REF_NAME_DASHES }}

--- a/.github/workflows/ci-cross-compile.yml
+++ b/.github/workflows/ci-cross-compile.yml
@@ -187,7 +187,9 @@ jobs:
       - name: Build with Gradle (Debug)
         run: ./gradlew build --no-daemon assembleDebug -PusePrebuiltNativeLibs
         working-directory: ./android
-      # TODO(#632): Setup digital signing for Android release build
+      - name: Build with Gradle (Release)
+        run: ./gradlew build --no-daemon assembleRelease -PusePrebuiltNativeLibs
+        working-directory: ./android
       - uses: actions/upload-artifact@v4
         with:
           name: openblack-android-apk-${{ env.GITHUB_REF_NAME_DASHES }}

--- a/.linelint.yml
+++ b/.linelint.yml
@@ -1,0 +1,4 @@
+autofix: true
+rules:
+  end-of-file:
+    enable: true

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -12,7 +12,7 @@ android {
         ndkVersion "26.3.11579264"
         versionCode 1
         versionName "0.1.0"
-        archivesBaseName = "$applicationId-$versionName"
+        archivesBaseName = "${applicationId}-${versionName}"
 
         // To use this configuration, pre-built native libraries must be placed into the respective directories:
         // For debug build variant, place libraries in 'src/main/jniLibs/Debug' and call ./gradlew assembleDebug -PusePrebuiltNativeLibs
@@ -43,10 +43,24 @@ android {
         }
     }
 
+    signingConfigs {
+        create("release") {
+            if (System.getenv("STORE_KEY") != null) {
+                storeFile = file(System.getenv("STORE_KEY"))
+                storePassword = System.getenv("STORE_PASSWORD")
+                keyAlias = System.getenv("STORE_KEY_ALIAS")
+                keyPassword = System.getenv("STORE_PASSWORD")
+            }
+        }
+    }
+
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            if (System.getenv("STORE_KEY") != null) {
+                signingConfig = signingConfigs.getByName("release")
+            }
         }
     }
     compileOptions {

--- a/android/app/src/main/java/org/libsdl/app/HIDDeviceBLESteamController.java
+++ b/android/app/src/main/java/org/libsdl/app/HIDDeviceBLESteamController.java
@@ -647,3 +647,4 @@ class HIDDeviceBLESteamController extends BluetoothGattCallback implements HIDDe
     }
 
 }
+

--- a/android/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -61,7 +61,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     private static final String TAG = "SDL";
     private static final int SDL_MAJOR_VERSION = 2;
     private static final int SDL_MINOR_VERSION = 30;
-    private static final int SDL_MICRO_VERSION = 0;
+    private static final int SDL_MICRO_VERSION = 1;
 /*
     // Display InputType.SOURCE/CLASS of events and devices
     //
@@ -311,7 +311,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
         mNextNativeState = NativeState.INIT;
         mCurrentNativeState = NativeState.INIT;
     }
-
+    
     protected SDLSurface createSDLSurface(Context context) {
         return new SDLSurface(context);
     }
@@ -2114,3 +2114,4 @@ class SDLClipboardHandler implements
         SDLActivity.onNativeClipboardChanged();
     }
 }
+

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">OpenBlack</string>
+    <string name="app_name">openblack</string>
 </resources>


### PR DESCRIPTION
Added signing secrets to the repo which allows us to build and sign release APKs for android. Without signing, it's not possible to install the release apk.

Note: The bad whitespace in java comes from SDL and I'm not going to change it since everything in the `org/libsdl` folder is verbatim the same as the release of SDL.

Note: We will have to update the java source for SDL at every SDL version update.

Closes #632