### PR TITLE
Android IsPathValid fix _gamepath used before being set.

### DIFF
--- a/src/FileSystem/AndroidFileSystem.cpp
+++ b/src/FileSystem/AndroidFileSystem.cpp
@@ -56,8 +56,8 @@ std::filesystem::path AndroidFileSystem::FindPath(const std::filesystem::path& p
 
 bool AndroidFileSystem::IsPathValid(const std::filesystem::path& path)
 {
-	jstring jgamePath = _jniEnv->NewStringUTF(_gamePath.c_str());
-	jstring jpath = _jniEnv->NewStringUTF(path.c_str());
+	jstring jgamePath = _jniEnv->NewStringUTF(path.c_str());
+	jstring jpath = _jniEnv->NewStringUTF("/");
 
 	jmethodID midGetDirectoryFromPath =
 	    _jniEnv->GetStaticMethodID(_jniInteropClass, "getDirectoryFromPath",


### PR DESCRIPTION
We tried to use the _gamepath as the `storageUriString`. I set the path as the `storageUriString` and find "/".
Solves
- #747 