### PR TITLE
Remove SnapCraft

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -180,21 +180,3 @@ jobs:
           name: openblack-${{ env.GITHUB_REF_NAME_DASHES }}.AppImage
           path: openblack-*.AppImage
           if-no-files-found: error
-
-  snapcraft:
-    name: Package for snap
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Move snap config to project root
-        run: cp -r assets/resource/package/snap .
-      - uses: snapcore/action-build@v1
-        id: snap
-      - run: echo "GITHUB_REF_NAME_DASHES=${GITHUB_REF_NAME/\//-}" >> $GITHUB_ENV
-        shell: bash
-      - uses: actions/upload-artifact@v4
-        with:
-          name: openblack-${{ env.GITHUB_REF_NAME_DASHES }}.snap
-          path: ${{ steps.snap.outputs.snap }}

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ The following are qualified as exprimental. They have base minimum setup such as
 Don't expect to be able to launch without some effort and your own patches.
 
 [![Windows (x86) Build](https://img.shields.io/badge/Build-Windows%20(x86)-0078d4)](https://nightly.link/openblack/openblack/workflows/ci-cross-compile/master/openblack-x86-windows-master.zip)
-[![Windows (arm64) Build](https://img.shields.io/badge/Build-Windows%20(arm64)-0078d4)](https://nightly.link/openblack/openblack/workflows/ci-cross-compile/master/openblack-arm64-windows-master.zip) 
+[![Windows (arm64) Build](https://img.shields.io/badge/Build-Windows%20(arm64)-0078d4)](https://nightly.link/openblack/openblack/workflows/ci-cross-compile/master/openblack-arm64-windows-master.zip)
 
 [![Android](https://img.shields.io/badge/Package-Android-3ddc84)](https://nightly.link/openblack/openblack/workflows/ci-cross-compile/master/openblack-android-apk-master.zip)
 [![iOS](https://img.shields.io/badge/Package-iOS-eeeeee)](https://nightly.link/openblack/openblack/workflows/ci-cross-compile/master/openblack-ios-arm64-vcpkg-master.zip)
@@ -43,7 +43,6 @@ Don't expect to be able to launch without some effort and your own patches.
 [![Linux (x86) Build](https://img.shields.io/badge/Build-Linux%20(x86)-333333)](https://nightly.link/openblack/openblack/workflows/ci-cross-compile/master/openblack-x86-linux-master.zip)
 [![Flatpak](https://img.shields.io/badge/Package-Flatpak-79ADE3)](https://nightly.link/openblack/openblack/workflows/packaging/master/openblack-master.flatpak.zip)
 [![AppImage](https://img.shields.io/badge/Package-AppImage-00BBFF)](https://nightly.link/openblack/openblack/workflows/packaging/master/openblack-master.AppImage.zip)
-[![Snap](https://img.shields.io/badge/Package-Snap-E95420)](https://nightly.link/openblack/openblack/workflows/packaging/master/openblack-master.snap.zip)
 
 
 # Building


### PR DESCRIPTION
Snap takes 20 minutes to build and is often the last job building. To get snap back we would need a way to cache the vcpkg packages. The configuration will be kept.