### PR TITLE
Move vcpkg back to mainline

### DIFF
--- a/.github/workflows/ci-cross-compile.yml
+++ b/.github/workflows/ci-cross-compile.yml
@@ -19,14 +19,16 @@ jobs:
         os: [ubuntu-24.04]
         # These are additional individual jobs. There are no permutations of these.
         include:
-          - triplet: x86-linux
-            os: ubuntu-24.04
-            preset: ninja-multi-vcpkg
-            setup: |
-              sudo dpkg --add-architecture i386
-              sudo apt-get update
-              sudo apt-get install -y libgl1-mesa-dev libglu1-mesa-dev libx11-dev:i386 libxext-dev:i386 libgl1-mesa-dev:i386 libglu1-mesa-dev:i386 libtool autoconf gcc-multilib g++-multilib libc6-dev-i386 libgpg-error-dev:i386 libltdl-dev:i386
-            additional_args: "`-DCMAKE_C_FLAGS=-m32`, `-DCMAKE_CXX_FLAGS=-m32`, `-DOPENBLACK_CROSSCOMPILING=ON`"
+          # TODO(#785) Cross compiling on linux is broken due to dbus in vcpkg
+          # https://github.com/microsoft/vcpkg/issues/40031
+          # - triplet: x86-linux
+          #   os: ubuntu-24.04
+          #   preset: ninja-multi-vcpkg
+          #   setup: |
+          #     sudo dpkg --add-architecture i386
+          #     sudo apt-get update
+          #     sudo apt-get install -y libgl1-mesa-dev libglu1-mesa-dev libx11-dev:i386 libxext-dev:i386 libgl1-mesa-dev:i386 libglu1-mesa-dev:i386 libtool autoconf gcc-multilib g++-multilib libc6-dev-i386 libgpg-error-dev:i386 libltdl-dev:i386
+          #   additional_args: "`-DCMAKE_C_FLAGS=-m32`, `-DCMAKE_CXX_FLAGS=-m32`, `-DOPENBLACK_CROSSCOMPILING=ON`"
           # - triplet: arm64-linux
           #   os: ubuntu-latest
           #   preset: ninja-multi-vcpkg

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,6 @@ Don't expect to be able to launch without some effort and your own patches.
 [![Android](https://img.shields.io/badge/Package-Android-3ddc84)](https://nightly.link/openblack/openblack/workflows/ci-cross-compile/master/openblack-android-apk-master.zip)
 [![iOS](https://img.shields.io/badge/Package-iOS-eeeeee)](https://nightly.link/openblack/openblack/workflows/ci-cross-compile/master/openblack-ios-arm64-vcpkg-master.zip)
 
-[![Linux (x86) Build](https://img.shields.io/badge/Build-Linux%20(x86)-333333)](https://nightly.link/openblack/openblack/workflows/ci-cross-compile/master/openblack-x86-linux-master.zip)
 [![Flatpak](https://img.shields.io/badge/Package-Flatpak-79ADE3)](https://nightly.link/openblack/openblack/workflows/packaging/master/openblack-master.flatpak.zip)
 [![AppImage](https://img.shields.io/badge/Package-AppImage-00BBFF)](https://nightly.link/openblack/openblack/workflows/packaging/master/openblack-master.AppImage.zip)
 [![Snap](https://img.shields.io/badge/Package-Snap-E95420)](https://nightly.link/openblack/openblack/workflows/packaging/master/openblack-master.snap.zip)


### PR DESCRIPTION
We drop the vcpkg fix for dbus because it is still in draft, we don't control the fix and the fix seems to not be acceptable in the current state by vcpkg devs.

The dbus bug only affects an experimental build so it is acceptable to remove it.

* Closes #769 