### PR TITLE
camera: Fix math error in xFov to yFov conversion

### DIFF
--- a/src/Camera/Camera.cpp
+++ b/src/Camera/Camera.cpp
@@ -103,7 +103,7 @@ std::optional<ecs::components::Transform> Camera::RaycastScreenCoordToLand(glm::
 Camera& Camera::SetProjectionMatrixPerspective(float xFov, float aspect, float nearClip, float farClip)
 {
 	_xFov = glm::radians(xFov);
-	const float yFov = (glm::atan(glm::tan(_xFov / 2.0f)) / aspect) * 2.0f;
+	const float yFov = (glm::atan(glm::tan(_xFov / 2.0f) / aspect)) * 2.0f;
 	// Inverse near and far for reverse z, we need to translate z by 1 to get back to the [0 1] range
 	_projectionMatrix = glm::perspective(yFov, aspect, nearClip, farClip);
 	_projectionMatrixReversedZ = k_ReverseZMatrix * _projectionMatrix;

--- a/src/Camera/DefaultWorldCameraModel.cpp
+++ b/src/Camera/DefaultWorldCameraModel.cpp
@@ -282,7 +282,6 @@ void DefaultWorldCameraModel::UpdateFocusPointInteractionParameters(glm::vec3 or
 	_averageIslandDistance += extra;
 }
 
-// This is a vanilla-style deprojection but with a few math errors
 glm::vec3 ScreenToWorld(const Camera& camera, glm::u16vec2 pixelCoord)
 {
 	const auto& window = Locator::windowing ::value();
@@ -294,10 +293,8 @@ glm::vec3 ScreenToWorld(const Camera& camera, glm::u16vec2 pixelCoord)
 	const auto screenCoord = static_cast<glm::vec2>(pixelCoord) / static_cast<glm::vec2>(screenSize);
 	const auto clipSpaceCoordinates = ((screenCoord - 0.5f) * 2.0f) * glm::vec2(1.0f, -1.0f);
 
-	// The multiplication by aspect within the tan is odd and wrong
-	const auto baseTanHalfFov = glm::tan(yFov / 2.0f * aspect);
-	// Using baseTanHalfFov directly to scale is also odd
-	const auto extents = glm::vec3(baseTanHalfFov, baseTanHalfFov / aspect, 1.0f);
+	const auto tanHalfFov = glm::tan(yFov / 2.0f);
+	const auto extents = glm::vec3(tanHalfFov * aspect, tanHalfFov, 1.0f);
 	const auto point = glm::vec4(glm::vec3(clipSpaceCoordinates, 1.0f) * extents, 1.0f);
 
 	return camera.GetRotationMatrix() * point;

--- a/test/camera/scenarios/TiltDownZoomOut.h
+++ b/test/camera/scenarios/TiltDownZoomOut.h
@@ -1862,7 +1862,7 @@ public:
 			}
 			assert(false); // Shouldn't be any unaccounted raycasts
 		}
-		else if (screenCoord == k_ScreenCentreLine[13])
+		else if (screenCoord == k_ScreenCentreLine[13] || (screenCoord + glm::u16vec2(0, 1)) == k_ScreenCentreLine[13])
 		{
 			switch (frameNumber)
 			{


### PR DESCRIPTION
The conversion function gets the ratio of depth to width of the right triangle that the view frustum traces (`tan(xFov / 2)`, applies the aspect ratio, to turn it to vertical (` / aspect`), turns that back to the angle for the right triangle (`atan`) and back to fov (`x 2`).

Our current implementation converts the angle to fov before applying `atan`.

This causes a bad angle to be fed to the perspective matrix function and it can be seen that something is wrong by resizing the game windows in the horizontal. At a small enough size, the image flips which indicates a negative FOV which shouldn not be possible while the width is positive.

With these changes, we have 1-to-1 correspondence with vanilla.

![image](https://github.com/user-attachments/assets/33092201-3e46-444d-bdc5-1a687d13def2)
![image](https://github.com/user-attachments/assets/d0de02a1-43b2-4b86-8174-33777e5c456d)
