### PR TITLE
clang-tidy: fix execution for MSVC

### DIFF
--- a/apps/anmtool/CMakeLists.txt
+++ b/apps/anmtool/CMakeLists.txt
@@ -8,8 +8,7 @@ target_compile_definitions(anmtool PRIVATE CXXOPTS_NO_EXCEPTIONS)
 target_link_libraries(anmtool PRIVATE cxxopts::cxxopts anm)
 
 if (OPENBLACK_CLANG_TIDY_CHECKS)
-  # FIXME(bwrsandman) MSVC is throwing false errors about exceptions being disabled
-  if (NOT MSVC AND CLANG_TIDY)
+  if (CLANG_TIDY)
     set_target_properties(anmtool PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
   else ()
     message("Clang-tidy checks requested but unavailable")

--- a/apps/glwtool/CMakeLists.txt
+++ b/apps/glwtool/CMakeLists.txt
@@ -8,8 +8,7 @@ target_compile_definitions(glwtool PRIVATE CXXOPTS_NO_EXCEPTIONS)
 target_link_libraries(glwtool PRIVATE cxxopts::cxxopts glw)
 
 if (OPENBLACK_CLANG_TIDY_CHECKS)
-  # FIXME(bwrsandman) MSVC is throwing false errors about exceptions being disabled
-  if (NOT MSVC AND CLANG_TIDY)
+  if (CLANG_TIDY)
     set_target_properties(glwtool PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
   else ()
     message("Clang-tidy checks requested but unavailable")

--- a/apps/l3dtool/CMakeLists.txt
+++ b/apps/l3dtool/CMakeLists.txt
@@ -8,8 +8,7 @@ target_compile_definitions(l3dtool PRIVATE CXXOPTS_NO_EXCEPTIONS)
 target_link_libraries(l3dtool PRIVATE cxxopts::cxxopts l3d)
 
 if (OPENBLACK_CLANG_TIDY_CHECKS)
-  # FIXME(bwrsandman) MSVC is throwing false errors about exceptions being disabled
-  if (NOT MSVC AND CLANG_TIDY)
+  if (CLANG_TIDY)
     set_target_properties(l3dtool PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
   else ()
     message("Clang-tidy checks requested but unavailable")

--- a/apps/lhvmtool/CMakeLists.txt
+++ b/apps/lhvmtool/CMakeLists.txt
@@ -8,8 +8,7 @@ target_compile_definitions(lhvmtool PRIVATE CXXOPTS_NO_EXCEPTIONS)
 target_link_libraries(lhvmtool PRIVATE cxxopts::cxxopts ScriptLibrary)
 
 if (OPENBLACK_CLANG_TIDY_CHECKS)
-  # FIXME(bwrsandman) MSVC is throwing false errors about exceptions being disabled
-  if (NOT MSVC AND CLANG_TIDY)
+  if (CLANG_TIDY)
     set_target_properties(lhvmtool PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
   else ()
     message("Clang-tidy checks requested but unavailable")

--- a/apps/lndtool/CMakeLists.txt
+++ b/apps/lndtool/CMakeLists.txt
@@ -8,8 +8,7 @@ target_compile_definitions(lndtool PRIVATE CXXOPTS_NO_EXCEPTIONS)
 target_link_libraries(lndtool PRIVATE cxxopts::cxxopts lnd)
 
 if (OPENBLACK_CLANG_TIDY_CHECKS)
-  # FIXME(bwrsandman) MSVC is throwing false errors about exceptions being disabled
-  if (NOT MSVC AND CLANG_TIDY)
+  if (CLANG_TIDY)
     set_target_properties(lndtool PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
   else ()
     message("Clang-tidy checks requested but unavailable")

--- a/apps/morphtool/CMakeLists.txt
+++ b/apps/morphtool/CMakeLists.txt
@@ -8,8 +8,7 @@ target_compile_definitions(morphtool PRIVATE CXXOPTS_NO_EXCEPTIONS)
 target_link_libraries(morphtool PRIVATE cxxopts::cxxopts morph)
 
 if (OPENBLACK_CLANG_TIDY_CHECKS)
-  # FIXME(bwrsandman) MSVC is throwing false errors about exceptions being disabled
-  if (NOT MSVC AND CLANG_TIDY)
+  if (CLANG_TIDY)
     set_target_properties(morphtool PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
   else ()
     message("Clang-tidy checks requested but unavailable")

--- a/apps/packtool/CMakeLists.txt
+++ b/apps/packtool/CMakeLists.txt
@@ -8,8 +8,7 @@ target_compile_definitions(packtool PRIVATE CXXOPTS_NO_EXCEPTIONS)
 target_link_libraries(packtool PRIVATE cxxopts::cxxopts pack)
 
 if (OPENBLACK_CLANG_TIDY_CHECKS)
-  # FIXME(bwrsandman) MSVC is throwing false errors about exceptions being disabled
-  if (NOT MSVC AND CLANG_TIDY)
+  if (CLANG_TIDY)
     set_target_properties(packtool PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
   else ()
     message("Clang-tidy checks requested but unavailable")

--- a/components/anm/CMakeLists.txt
+++ b/components/anm/CMakeLists.txt
@@ -9,8 +9,7 @@ target_include_directories(
 )
 
 if (OPENBLACK_CLANG_TIDY_CHECKS)
-  # FIXME(bwrsandman) MSVC is throwing false errors about exceptions being disabled
-  if (NOT MSVC AND CLANG_TIDY)
+  if (CLANG_TIDY)
     set_target_properties(anm PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
   else ()
     message("Clang-tidy checks requested but unavailable")

--- a/components/glw/CMakeLists.txt
+++ b/components/glw/CMakeLists.txt
@@ -9,8 +9,7 @@ target_include_directories(
 )
 
 if (OPENBLACK_CLANG_TIDY_CHECKS)
-  # FIXME(bwrsandman) MSVC is throwing false errors about exceptions being disabled
-  if (NOT MSVC AND CLANG_TIDY)
+  if (CLANG_TIDY)
     set_target_properties(glw PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
   else ()
     message("Clang-tidy checks requested but unavailable")

--- a/components/l3d/CMakeLists.txt
+++ b/components/l3d/CMakeLists.txt
@@ -9,8 +9,7 @@ target_include_directories(
 )
 
 if (OPENBLACK_CLANG_TIDY_CHECKS)
-  # FIXME(bwrsandman) MSVC is throwing false errors about exceptions being disabled
-  if (NOT MSVC AND CLANG_TIDY)
+  if (CLANG_TIDY)
     set_target_properties(l3d PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
   else ()
     message("Clang-tidy checks requested but unavailable")

--- a/components/lnd/CMakeLists.txt
+++ b/components/lnd/CMakeLists.txt
@@ -9,8 +9,7 @@ target_include_directories(
 )
 
 if (OPENBLACK_CLANG_TIDY_CHECKS)
-  # FIXME(bwrsandman) MSVC is throwing false errors about exceptions being disabled
-  if (NOT MSVC AND CLANG_TIDY)
+  if (CLANG_TIDY)
     set_target_properties(lnd PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
   else ()
     message("Clang-tidy checks requested but unavailable")

--- a/components/morph/CMakeLists.txt
+++ b/components/morph/CMakeLists.txt
@@ -9,8 +9,7 @@ target_include_directories(
 )
 
 if (OPENBLACK_CLANG_TIDY_CHECKS)
-  # FIXME(bwrsandman) MSVC is throwing false errors about exceptions being disabled
-  if (NOT MSVC AND CLANG_TIDY)
+  if (CLANG_TIDY)
     set_target_properties(morph PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
   else ()
     message("Clang-tidy checks requested but unavailable")

--- a/components/pack/CMakeLists.txt
+++ b/components/pack/CMakeLists.txt
@@ -9,8 +9,7 @@ target_include_directories(
 )
 
 if (OPENBLACK_CLANG_TIDY_CHECKS)
-  # FIXME(bwrsandman) MSVC is throwing false errors about exceptions being disabled
-  if (NOT MSVC AND CLANG_TIDY)
+  if (CLANG_TIDY)
     set_target_properties(pack PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
   else ()
     message("Clang-tidy checks requested but unavailable")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,9 +126,19 @@ target_link_libraries(
 )
 
 if (OPENBLACK_CLANG_TIDY_CHECKS)
-  # FIXME(bwrsandman) MSVC is throwing false errors about exceptions being disabled
-  if (NOT MSVC AND CLANG_TIDY)
-    set_target_properties(openblack_lib PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
+  if (CLANG_TIDY)
+    if (MSVC)
+      # as for now, /EHsc has to be passed manually to clang-tidy
+      # see https://gitlab.kitware.com/cmake/cmake/-/issues/20512
+      set_target_properties(
+        openblack_lib PROPERTIES CXX_CLANG_TIDY
+                                 "${CLANG_TIDY};--extra-arg=/EHsc"
+      )
+    else ()
+      set_target_properties(
+        openblack_lib PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY}
+      )
+    endif ()
   else ()
     message("Clang-tidy checks requested but unavailable")
   endif ()


### PR DESCRIPTION
~~In short, first 2 commits refactors boilerplate to functions, what enables 3rd commit: fix for running clang-tidy in msvc environment.~~

~~1st commit is just small fix for `clang-cl` warning I've encountered.~~

clang-tidy get reenabled for msvc for tools and components without any changes.
Only in case of `openblack_lib`, `/EHsc` has to be manually added to `clang-tidy` invocation, see commit description for details.

I've not looked if or how to enable `clang-tidy` for msvc in CI.

Now I can get back to https://github.com/openblack/openblack/pull/789 without having to run full CI for simple linting :)