### PR TITLE
Basic settings for clangd

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  Add: [-std:c++20]

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ openblack.log
 # executable generated files
 screenshot.png
 compile_commands.json
+.cache


### PR DESCRIPTION
This adds some basic settings to work with *clangd*.

When generating compile commands for *clangd*, the compiler specifies c++latest, which isn't recognized by clangd (see https://github.com/clangd/clangd/issues/527). A file *.clangd* is provided to force clangd to use c++20.

*Clangd* generates a folder named *.cache* which contains indexing informations. The *.cache* directory is added to *.gitignore*.