### PR TITLE
Fix rendering of the ocean.

### DIFF
--- a/assets/shaders/fs_water.sc
+++ b/assets/shaders/fs_water.sc
@@ -15,10 +15,16 @@ void main()
 	float skyBightness = skyType / 2.0f;
 
 	vec3 diffuse_colour = mix(0.25f, 1.0f, skyBightness) * texture2D(s_diffuse, v_texcoord0.xy).rgb;
+	vec3 reflect_colour = texture2DProj(s_reflection, v_texcoord1).rgb;
+
 	// This was called alpha in vanilla because they rendered parts of the scene upside down in the
 	// main backbuffer, then alpha blended the ocean on top to simulate a render texture fetch.
-	float alpha = texture2D(s_alpha, v_texcoord0.xy).r;
-	vec3 reflect_colour = texture2DProj(s_reflection, v_texcoord1).rgb;
+	float reflection_alpha = texture2D(s_alpha, v_texcoord0.xy).r;
+
+	// The 3000 and formula is pretty much guessed but the results look very good.
+	float horizon_alpha = saturate(1.0f / float(v_texcoord0.z / 3000.0f));
+
+	float alpha = reflection_alpha * horizon_alpha;
 
 	gl_FragColor = vec4(mix(reflect_colour, diffuse_colour, alpha), 1.0f);
 }

--- a/assets/shaders/fs_water.sc
+++ b/assets/shaders/fs_water.sc
@@ -15,8 +15,10 @@ void main()
 	float skyBightness = skyType / 2.0f;
 
 	vec3 diffuse_colour = mix(0.25f, 1.0f, skyBightness) * texture2D(s_diffuse, v_texcoord0.xy).rgb;
+	// This was called alpha in vanilla because they rendered parts of the scene upside down in the
+	// main backbuffer, then alpha blended the ocean on top to simulate a render texture fetch.
 	float alpha = texture2D(s_alpha, v_texcoord0.xy).r;
 	vec3 reflect_colour = texture2DProj(s_reflection, v_texcoord1).rgb;
 
-	gl_FragColor = vec4(mix(reflect_colour, diffuse_colour, 0.8), alpha);
+	gl_FragColor = vec4(mix(reflect_colour, diffuse_colour, alpha), 1.0f);
 }

--- a/assets/shaders/vs_water.sc
+++ b/assets/shaders/vs_water.sc
@@ -16,9 +16,10 @@ vec4 ScreenSpacePosition(vec4 position)
 void main()
 {
 	vec4 vertex = vec4(vec3(a_position.x, 0.0, a_position.y), 1.0);
+	vec4 viewSpacePos = mul(u_view, vertex);
 	vec4 position = mul(u_viewProj, vertex);
 	gl_Position = position;
 
-	v_texcoord0 = vec4(vertex.x / 500.0f, vertex.z / 500.0f, 0.0f, 0.0f);
+	v_texcoord0 = vec4(vertex.x / 500.0f, vertex.z / 500.0f, viewSpacePos.z, 0.0f);
 	v_texcoord1 = ScreenSpacePosition(position);
 }

--- a/assets/shaders/vs_water.sc
+++ b/assets/shaders/vs_water.sc
@@ -19,6 +19,6 @@ void main()
 	vec4 position = mul(u_viewProj, vertex);
 	gl_Position = position;
 
-	v_texcoord0 = vec4(vertex.z / 200.0f, vertex.x / 200.0f, 0.0f, 0.0f);
+	v_texcoord0 = vec4(vertex.x / 500.0f, vertex.z / 500.0f, 0.0f, 0.0f);
 	v_texcoord1 = ScreenSpacePosition(position);
 }


### PR DESCRIPTION
Currently there are several problems with the ocean.
Mainly it just doesn't look like the right colour and there are many reasons for this.

1. In the screenshots, if you happen to have dark theme, the water will look darker because the image has alpha encoded in it.

Dark:
![image](https://github.com/user-attachments/assets/58449fac-f24e-4430-854e-fc17590e81f4)
Light
![image](https://github.com/user-attachments/assets/8ca501f8-f694-4f84-b54e-444aa161adaf)

2. The details of vanilla are of different scales and have different orientations as openblack. This can be see if you visualize the UVs.

Vanilla:
![image](https://github.com/user-attachments/assets/3ed0c1f7-caec-4694-892e-287c9c802928)

Our prior:
![image](https://github.com/user-attachments/assets/8f00d01c-0424-4422-be42-36a5b2eb6e81)

3. The "reflection map" was not being used properly. In vanilla, they rendered part of the scene (including the whole bottom hemisphere of the sky) upside how reflected about the horizon into the main render buffer. They simulated a render texture fetch by simply using alpha blending when they drew the water plane. We were misusing `Skya.raw`, the alpha blending texture.

Skya.raw:
![image](https://github.com/user-attachments/assets/8c751431-7f0b-449e-85ff-59adf0c3aeaa)

Vanilla before drawing the water plane:
![image](https://github.com/user-attachments/assets/0f7d7c06-b09b-457f-82c0-43b6b01544bd)

Vanilla after drawing the water plane:
![image](https://github.com/user-attachments/assets/47662da8-b988-4eea-a097-efdb15a68572)

Ours (new):
![image](https://github.com/user-attachments/assets/38c6508c-1d2f-4f76-900e-1a0ed2220f73)

4. The horizon is blended with the sky in vanilla and ours had an awkward cut from ocean to sky. The re implementation is mostly guessed but looks very close.