### PR TITLE
Revert commits converting `LOCATOR_IMPLEMENTATIONS` warnings to messages

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -60,4 +60,5 @@ CheckOptions:
     value: _
   - key: readability-identifier-naming.ProtectedMemberPrefix
     value: _
-# WarningsAsErrors: '*'
+ExtraArgsBefore:
+  - -DLOCATOR_IMPLEMENTATIONS

--- a/.clangd
+++ b/.clangd
@@ -1,2 +1,2 @@
 CompileFlags:
-  Add: [-std:c++20]
+  Add: [-std:c++20, -DLOCATOR_IMPLEMENTATIONS ]

--- a/src/3D/Implementations/LandIsland.h
+++ b/src/3D/Implementations/LandIsland.h
@@ -18,7 +18,7 @@
 #include "3D/LandIslandInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
+#error "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack

--- a/src/3D/Implementations/LandIsland.h
+++ b/src/3D/Implementations/LandIsland.h
@@ -18,7 +18,7 @@
 #include "3D/LandIslandInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#pragma message("Locator interface implementations should only be included in Locator.cpp, use interface instead.")
+#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack

--- a/src/3D/Implementations/Ocean.h
+++ b/src/3D/Implementations/Ocean.h
@@ -16,7 +16,7 @@
 #include "3D/OceanInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#pragma message("Locator interface implementations should only be included in Locator.cpp, use interface instead.")
+#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack

--- a/src/3D/Implementations/Ocean.h
+++ b/src/3D/Implementations/Ocean.h
@@ -16,7 +16,7 @@
 #include "3D/OceanInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
+#error "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack

--- a/src/3D/Implementations/Sky.h
+++ b/src/3D/Implementations/Sky.h
@@ -18,7 +18,7 @@
 #include "Graphics/RenderPass.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
+#error "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack

--- a/src/3D/Implementations/Sky.h
+++ b/src/3D/Implementations/Sky.h
@@ -18,7 +18,7 @@
 #include "Graphics/RenderPass.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#pragma message("Locator interface implementations should only be included in Locator.cpp, use interface instead.")
+#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack

--- a/src/3D/Implementations/TempleInterior.h
+++ b/src/3D/Implementations/TempleInterior.h
@@ -16,7 +16,7 @@
 #include "3D/TempleInteriorInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#pragma message("Locator interface implementations should only be included in Locator.cpp, use interface instead.")
+#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack

--- a/src/3D/Implementations/TempleInterior.h
+++ b/src/3D/Implementations/TempleInterior.h
@@ -16,7 +16,7 @@
 #include "3D/TempleInteriorInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
+#error "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack

--- a/src/Audio/AudioManager.h
+++ b/src/Audio/AudioManager.h
@@ -24,7 +24,7 @@
 #include "SoundGroup.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#pragma message("Locator interface implementations should only be included in Locator.cpp, use interface instead.")
+#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack

--- a/src/Audio/AudioManager.h
+++ b/src/Audio/AudioManager.h
@@ -24,7 +24,7 @@
 #include "SoundGroup.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
+#error "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack

--- a/src/Audio/AudioManagerNoOp.h
+++ b/src/Audio/AudioManagerNoOp.h
@@ -12,7 +12,7 @@
 #include "AudioManagerInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#warning "Locator interface implementations should only be included in Locator.cpp", use interface instead.
+#error "Locator interface implementations should only be included in Locator.cpp", use interface instead.
 #endif
 
 namespace openblack::audio

--- a/src/Audio/AudioManagerNoOp.h
+++ b/src/Audio/AudioManagerNoOp.h
@@ -12,7 +12,7 @@
 #include "AudioManagerInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#pragma message("Locator interface implementations should only be included in Locator.cpp, use interface instead.")
+#warning "Locator interface implementations should only be included in Locator.cpp", use interface instead.
 #endif
 
 namespace openblack::audio

--- a/src/Common/RandomNumberManagerProduction.h
+++ b/src/Common/RandomNumberManagerProduction.h
@@ -15,7 +15,7 @@
 #include "RandomNumberManager.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#pragma message("Locator interface implementations should only be included in Locator.cpp, use interface instead.")
+#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack

--- a/src/Common/RandomNumberManagerProduction.h
+++ b/src/Common/RandomNumberManagerProduction.h
@@ -15,7 +15,7 @@
 #include "RandomNumberManager.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
+#error "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack

--- a/src/Common/RandomNumberManagerTesting.h
+++ b/src/Common/RandomNumberManagerTesting.h
@@ -15,7 +15,7 @@
 #include "RandomNumberManager.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#pragma message("Locator interface implementations should only be included in Locator.cpp, use interface instead.")
+#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack

--- a/src/Common/RandomNumberManagerTesting.h
+++ b/src/Common/RandomNumberManagerTesting.h
@@ -15,7 +15,7 @@
 #include "RandomNumberManager.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
+#error "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack

--- a/src/Debug/Gui.h
+++ b/src/Debug/Gui.h
@@ -23,7 +23,7 @@
 #include "DebugGuiInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#pragma message("Locator interface implementations should only be included in Locator.cpp, use interface instead.")
+#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack::debug::gui

--- a/src/Debug/Gui.h
+++ b/src/Debug/Gui.h
@@ -23,7 +23,7 @@
 #include "DebugGuiInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
+#error "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack::debug::gui

--- a/src/ECS/MapProduction.h
+++ b/src/ECS/MapProduction.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#pragma message("Locator interface implementations should only be included in Locator.cpp, use interface instead.")
+#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 #include "Map.h"

--- a/src/ECS/MapProduction.h
+++ b/src/ECS/MapProduction.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
+#error "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 #include "Map.h"

--- a/src/ECS/Systems/Implementations/CameraBookmarkSystem.h
+++ b/src/ECS/Systems/Implementations/CameraBookmarkSystem.h
@@ -16,7 +16,7 @@
 #include "ECS/Systems/CameraBookmarkSystemInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#pragma message("Locator interface implementations should only be included in Locator.cpp, use interface instead.")
+#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack::ecs::systems

--- a/src/ECS/Systems/Implementations/CameraBookmarkSystem.h
+++ b/src/ECS/Systems/Implementations/CameraBookmarkSystem.h
@@ -16,7 +16,7 @@
 #include "ECS/Systems/CameraBookmarkSystemInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
+#error "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack::ecs::systems

--- a/src/ECS/Systems/Implementations/DynamicsSystem.h
+++ b/src/ECS/Systems/Implementations/DynamicsSystem.h
@@ -14,7 +14,7 @@
 #include "ECS/Systems/DynamicsSystemInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#pragma message("Locator interface implementations should only be included in Locator.cpp, use interface instead.")
+#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 class btCollisionDispatcher;

--- a/src/ECS/Systems/Implementations/DynamicsSystem.h
+++ b/src/ECS/Systems/Implementations/DynamicsSystem.h
@@ -14,7 +14,7 @@
 #include "ECS/Systems/DynamicsSystemInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
+#error "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 class btCollisionDispatcher;

--- a/src/ECS/Systems/Implementations/HandSystem.h
+++ b/src/ECS/Systems/Implementations/HandSystem.h
@@ -12,7 +12,7 @@
 #include "ECS/Systems/HandSystemInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
+#error "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack::ecs::systems

--- a/src/ECS/Systems/Implementations/HandSystem.h
+++ b/src/ECS/Systems/Implementations/HandSystem.h
@@ -12,7 +12,7 @@
 #include "ECS/Systems/HandSystemInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#pragma message("Locator interface implementations should only be included in Locator.cpp, use interface instead.")
+#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack::ecs::systems

--- a/src/ECS/Systems/Implementations/LivingActionSystem.h
+++ b/src/ECS/Systems/Implementations/LivingActionSystem.h
@@ -13,7 +13,7 @@
 #include "ECS/Systems/LivingActionSystemInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
+#error "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack::ecs::systems

--- a/src/ECS/Systems/Implementations/LivingActionSystem.h
+++ b/src/ECS/Systems/Implementations/LivingActionSystem.h
@@ -13,7 +13,7 @@
 #include "ECS/Systems/LivingActionSystemInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#pragma message("Locator interface implementations should only be included in Locator.cpp, use interface instead.")
+#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack::ecs::systems

--- a/src/ECS/Systems/Implementations/PathfindingSystem.h
+++ b/src/ECS/Systems/Implementations/PathfindingSystem.h
@@ -12,7 +12,7 @@
 #include "ECS/Systems/PathfindingSystemInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#pragma message("Locator interface implementations should only be included in Locator.cpp, use interface instead.")
+#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack::ecs::systems

--- a/src/ECS/Systems/Implementations/PathfindingSystem.h
+++ b/src/ECS/Systems/Implementations/PathfindingSystem.h
@@ -12,7 +12,7 @@
 #include "ECS/Systems/PathfindingSystemInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
+#error "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack::ecs::systems

--- a/src/ECS/Systems/Implementations/PlayerSystem.h
+++ b/src/ECS/Systems/Implementations/PlayerSystem.h
@@ -15,7 +15,7 @@
 #include "ECS/Systems/PlayerSystemInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#warning "ECS System implementations should only be included in Locator.cpp"
+#error "ECS System implementations should only be included in Locator.cpp"
 #endif
 
 namespace openblack::ecs::systems

--- a/src/ECS/Systems/Implementations/PlayerSystem.h
+++ b/src/ECS/Systems/Implementations/PlayerSystem.h
@@ -15,7 +15,7 @@
 #include "ECS/Systems/PlayerSystemInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#pragma message("ECS System implementations should only be included in Locator.cpp, use interface instead.")
+#warning "ECS System implementations should only be included in Locator.cpp"
 #endif
 
 namespace openblack::ecs::systems

--- a/src/ECS/Systems/Implementations/RenderingSystem.h
+++ b/src/ECS/Systems/Implementations/RenderingSystem.h
@@ -19,7 +19,7 @@
 #include "RenderingSystemCommon.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#pragma message("Locator interface implementations should only be included in Locator.cpp, use interface instead.")
+#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack::ecs::systems

--- a/src/ECS/Systems/Implementations/RenderingSystem.h
+++ b/src/ECS/Systems/Implementations/RenderingSystem.h
@@ -19,7 +19,7 @@
 #include "RenderingSystemCommon.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
+#error "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack::ecs::systems

--- a/src/ECS/Systems/Implementations/RenderingSystemCommon.h
+++ b/src/ECS/Systems/Implementations/RenderingSystemCommon.h
@@ -19,7 +19,7 @@
 #include "ECS/Systems/RenderingSystemInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
+#error "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack::ecs::systems

--- a/src/ECS/Systems/Implementations/RenderingSystemCommon.h
+++ b/src/ECS/Systems/Implementations/RenderingSystemCommon.h
@@ -19,7 +19,7 @@
 #include "ECS/Systems/RenderingSystemInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#pragma message("Locator interface implementations should only be included in Locator.cpp, use interface instead.")
+#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack::ecs::systems

--- a/src/ECS/Systems/Implementations/RenderingSystemTemple.h
+++ b/src/ECS/Systems/Implementations/RenderingSystemTemple.h
@@ -20,7 +20,7 @@
 #include "RenderingSystemCommon.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
+#error "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack::ecs::systems

--- a/src/ECS/Systems/Implementations/RenderingSystemTemple.h
+++ b/src/ECS/Systems/Implementations/RenderingSystemTemple.h
@@ -20,7 +20,7 @@
 #include "RenderingSystemCommon.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#pragma message("Locator interface implementations should only be included in Locator.cpp, use interface instead.")
+#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack::ecs::systems

--- a/src/ECS/Systems/Implementations/TownSystem.h
+++ b/src/ECS/Systems/Implementations/TownSystem.h
@@ -12,7 +12,7 @@
 #include "ECS/Systems/TownSystemInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
+#error "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack::ecs::systems

--- a/src/ECS/Systems/Implementations/TownSystem.h
+++ b/src/ECS/Systems/Implementations/TownSystem.h
@@ -12,7 +12,7 @@
 #include "ECS/Systems/TownSystemInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#pragma message("Locator interface implementations should only be included in Locator.cpp, use interface instead.")
+#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack::ecs::systems

--- a/src/FileSystem/DefaultFileSystem.h
+++ b/src/FileSystem/DefaultFileSystem.h
@@ -15,7 +15,7 @@
 #include "FileSystemInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#warning "Locator interface implementations should only be included in Locator.cpp"
+#error "Locator interface implementations should only be included in Locator.cpp"
 #endif
 
 namespace openblack::filesystem

--- a/src/FileSystem/DefaultFileSystem.h
+++ b/src/FileSystem/DefaultFileSystem.h
@@ -15,7 +15,7 @@
 #include "FileSystemInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#pragma message("Locator interface implementations should only be included in Locator.cpp")
+#warning "Locator interface implementations should only be included in Locator.cpp"
 #endif
 
 namespace openblack::filesystem

--- a/src/Graphics/Renderer.h
+++ b/src/Graphics/Renderer.h
@@ -27,7 +27,7 @@
 #include "Graphics/RendererInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#pragma message("Locator interface implementations should only be included in Locator.cpp, use interface instead.")
+#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack

--- a/src/Graphics/Renderer.h
+++ b/src/Graphics/Renderer.h
@@ -27,7 +27,7 @@
 #include "Graphics/RendererInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
+#error "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack

--- a/src/Input/GameActionMap.h
+++ b/src/Input/GameActionMap.h
@@ -20,7 +20,7 @@
 #include "GameActionMapInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#pragma message("Locator interface implementations should only be included in Locator.cpp")
+#warning "Locator interface implementations should only be included in Locator.cpp"
 #endif
 
 namespace openblack::input

--- a/src/Input/GameActionMap.h
+++ b/src/Input/GameActionMap.h
@@ -20,7 +20,7 @@
 #include "GameActionMapInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#warning "Locator interface implementations should only be included in Locator.cpp"
+#error "Locator interface implementations should only be included in Locator.cpp"
 #endif
 
 namespace openblack::input

--- a/src/Resources/Resources.h
+++ b/src/Resources/Resources.h
@@ -12,7 +12,7 @@
 #include "ResourcesInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#pragma message("Locator interface implementations should only be included in Locator.cpp, use interface instead.")
+#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack::resources

--- a/src/Resources/Resources.h
+++ b/src/Resources/Resources.h
@@ -12,7 +12,7 @@
 #include "ResourcesInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#warning "Locator interface implementations should only be included in Locator.cpp, use interface instead."
+#error "Locator interface implementations should only be included in Locator.cpp, use interface instead."
 #endif
 
 namespace openblack::resources

--- a/src/Windowing/Sdl2WindowingSystem.h
+++ b/src/Windowing/Sdl2WindowingSystem.h
@@ -21,7 +21,7 @@
 #include "WindowingInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#warning "Locator interface implementations should only be included in Locator.cpp"
+#error "Locator interface implementations should only be included in Locator.cpp"
 #endif
 
 struct SDL_Window;

--- a/src/Windowing/Sdl2WindowingSystem.h
+++ b/src/Windowing/Sdl2WindowingSystem.h
@@ -21,7 +21,7 @@
 #include "WindowingInterface.h"
 
 #if !defined(LOCATOR_IMPLEMENTATIONS)
-#pragma message("Locator interface implementations should only be included in Locator.cpp")
+#warning "Locator interface implementations should only be included in Locator.cpp"
 #endif
 
 struct SDL_Window;


### PR DESCRIPTION
The `LOCATOR_IMPLEMENTATIONS` warnings were converted from warnings to `#pragma message`.
This is a potential risk to future development because the CI treats warnings as errors to prevent the accumulation of valid warnings without preventing local development from being able to see warnings and continue working.
In the case of `LOCATOR_IMPLEMENTATIONS`, it is imperative that the warning is not raised in the upstream branches because it would indicate illegal use of the services implementations instead of the abstract base classses.