### PR TITLE
Add villager wandering around their home town, pathfinding fixes, and town assignment

### DIFF
--- a/src/ECS/Archetypes/VillagerArchetype.cpp
+++ b/src/ECS/Archetypes/VillagerArchetype.cpp
@@ -57,7 +57,7 @@ entt::entity VillagerArchetype::Create([[maybe_unused]] const glm::vec3& abodePo
 
 	registry.Assign<Villager>(entity, health, static_cast<uint32_t>(age), hunger, lifeStage, sex, info.tribeType,
 	                          info.villagerNumber, task, town, abode);
-	registry.Assign<WallHug>(entity, glm::vec2(), glm::vec2(), GetSpeedStateSpeed(info.speedGroup.speedDefault));
+	registry.Assign<WallHug>(entity, glm::vec2(), glm::vec2(), 0.0f, GetSpeedStateSpeed(info.speedGroup.speedDefault));
 	const auto resourceId = resources::HashIdentifier(info.highDetail);
 	registry.Assign<Mesh>(entity, resourceId, static_cast<int8_t>(0), static_cast<int8_t>(0));
 	auto turnsSinceStateChange = Locator::rng::value().NextValue<uint16_t>(1, 500);

--- a/src/ECS/Systems/Implementations/LivingActionSystem.cpp
+++ b/src/ECS/Systems/Implementations/LivingActionSystem.cpp
@@ -510,8 +510,7 @@ void LivingActionSystem::VillagerSetState(LivingAction& action, LivingAction::In
 	}
 
 	[[maybe_unused]] auto& registry = Locator::entitiesRegistry::value();
-	SPDLOG_LOGGER_TRACE(spdlog::get("ai"), "Villager #{}: Setting state {} -> {}",
-	                    static_cast<int>(registry.ToEntity(action)),
+	SPDLOG_LOGGER_TRACE(spdlog::get("ai"), "Villager #{}: Setting state {} -> {}", static_cast<int>(registry.ToEntity(action)),
 	                    k_VillagerStateStrings.at(static_cast<size_t>(previousState)),
 	                    k_VillagerStateStrings.at(static_cast<size_t>(state)));
 

--- a/src/ECS/Systems/Implementations/LivingActionSystem.cpp
+++ b/src/ECS/Systems/Implementations/LivingActionSystem.cpp
@@ -53,7 +53,7 @@ uint32_t VillagerCreated(LivingAction& action)
 	return 0;
 }
 
-// Proof-of-concept wander behaviour: how far (in world units) an idle villager may roam from
+// Wander behaviour: how far (in world units) an idle villager may roam from
 // its village centre when picking a destination.
 static constexpr float k_WanderRadius = 40.0f;
 // Idle pause (in turns) before an arrived/abandoned villager picks a new destination.
@@ -65,13 +65,13 @@ static constexpr float k_WanderWorldBoundMax = 5090.0f;
 
 namespace
 {
-// PoC: pick a random nearby point and hand it to the PathfindingSystem the same way the
+// Pick a random nearby point and hand it to the PathfindingSystem the same way the
 // debug "Move To Point" tool does (see Debug/PathFinding.cpp), then wait in MoveToPos.
 uint32_t VillagerDecideWhatToDo(LivingAction& action)
 {
 	if (action.turnsSinceStateChange < k_WanderCooldownTurns)
 	{
-		// TODO(WeaveCraft): play a "catch breath" idle animation here (lean forward, breathe) during the cooldown
+		// TODO(#863): play a "catch breath" idle animation here (lean forward, breathe) during the cooldown
 		// once villager animation playback exists. The transitionAnimation hook in k_VillagerStateTable
 		// is the intended home for it; the Mesh component has no animation state today.
 		return 0;
@@ -106,7 +106,7 @@ uint32_t VillagerDecideWhatToDo(LivingAction& action)
 	return 0;
 }
 
-// PoC: wait until the PathfindingSystem has walked us to the goal, then decide again.
+// Wait until the PathfindingSystem has walked us to the goal, then decide again.
 uint32_t VillagerMoveToPos(LivingAction& action)
 {
 	auto& registry = Locator::entitiesRegistry::value();

--- a/src/ECS/Systems/Implementations/LivingActionSystem.cpp
+++ b/src/ECS/Systems/Implementations/LivingActionSystem.cpp
@@ -11,10 +11,18 @@
 
 #include "LivingActionSystem.h"
 
+#include <glm/common.hpp>
+#include <glm/gtc/constants.hpp>
+#include <glm/gtx/vec_swizzle.hpp>
+#include <glm/trigonometric.hpp>
+#include <glm/vec2.hpp>
 #include <spdlog/spdlog.h>
 
+#include "Common/RandomNumberManager.h"
 #include "ECS/Components/LivingAction.h"
+#include "ECS/Components/Transform.h"
 #include "ECS/Components/Villager.h"
+#include "ECS/Components/WallHug.h"
 #include "ECS/Registry.h"
 #include "Enums.h"
 #include "Locator.h"
@@ -41,6 +49,76 @@ uint32_t VillagerCreated(LivingAction& action)
 	{
 		Locator::livingActionSystem::value().VillagerSetState(action, LivingAction::Index::Top, VillagerStates::DecideWhatToDo,
 		                                                      false);
+	}
+	return 0;
+}
+
+// Proof-of-concept wander behaviour: how far (in world units) an idle villager may roam from
+// its village centre when picking a destination.
+static constexpr float k_WanderRadius = 40.0f;
+// Idle pause (in turns) before an arrived/abandoned villager picks a new destination.
+static constexpr uint16_t k_WanderCooldownTurns = 20;
+// Keep goals clear of the map edges so the pathfinder's neighbouring-cell lookups stay in
+// bounds (the movement grid is MapInterface::k_GridSize cells, each 10 world units wide).
+static constexpr float k_WanderWorldBoundMin = 30.0f;
+static constexpr float k_WanderWorldBoundMax = 5090.0f;
+
+// PoC: pick a random nearby point and hand it to the PathfindingSystem the same way the
+// debug "Move To Point" tool does (see Debug/PathFinding.cpp), then wait in MoveToPos.
+uint32_t VillagerDecideWhatToDo(LivingAction& action)
+{
+	if (action.turnsSinceStateChange < k_WanderCooldownTurns)
+	{
+		// TODO: play a "catch breath" idle animation here (lean forward, breathe) during the cooldown
+		// once villager animation playback exists. The transitionAnimation hook in k_VillagerStateTable
+		// is the intended home for it; the Mesh component has no animation state today.
+		return 0;
+	}
+
+	auto& registry = Locator::entitiesRegistry::value();
+	const auto entity = registry.ToEntity(action);
+
+	const auto& transform = registry.Get<Transform>(entity);
+	auto& wallHug = registry.Get<WallHug>(entity);
+	auto& rng = Locator::rng::value();
+
+	const float angle = rng.NextValue(0.0f, glm::two_pi<float>());
+	const float distance = rng.NextValue(0.0f, k_WanderRadius);
+	const auto& villager = registry.Get<Villager>(entity);
+	auto origin = glm::xz(transform.position); // fallback if the villager has no valid town
+	if (villager.town != entt::null && registry.Valid(villager.town) && registry.AllOf<Transform>(villager.town))
+	{
+		origin = glm::xz(registry.Get<Transform>(villager.town).position);
+	}
+	auto goal = origin + glm::vec2(glm::cos(angle), glm::sin(angle)) * distance;
+	goal = glm::clamp(goal, glm::vec2(k_WanderWorldBoundMin), glm::vec2(k_WanderWorldBoundMax));
+
+	wallHug.goal = goal;
+	wallHug.step = glm::vec2(0.0f); // force a fresh step to be computed on the next pathfinding turn
+	registry.Remove<MoveStateLinearTag, MoveStateOrbitTag, MoveStateExitCircleTag, MoveStateStepThroughTag,
+	                MoveStateFinalStepTag, MoveStateArrivedTag>(entity);
+	registry.Remove<WallHugObjectReference>(entity);
+	registry.Assign<MoveStateLinearTag>(entity);
+
+	Locator::livingActionSystem::value().VillagerSetState(action, LivingAction::Index::Top, VillagerStates::MoveToPos, true);
+	return 0;
+}
+
+// PoC: wait until the PathfindingSystem has walked us to the goal, then decide again.
+uint32_t VillagerMoveToPos(LivingAction& action)
+{
+	auto& registry = Locator::entitiesRegistry::value();
+	const auto entity = registry.ToEntity(action);
+
+	// The PathfindingSystem removes the "in transit" move-state tags once the goal is reached
+	// (leaving only a FinalStep tag). When none of them remain, we've arrived.
+	const bool stillMoving =
+	    registry.AnyOf<MoveStateLinearTag, MoveStateOrbitTag, MoveStateExitCircleTag, MoveStateStepThroughTag>(entity);
+	if (!stillMoving)
+	{
+		registry.Remove<MoveStateFinalStepTag, MoveStateArrivedTag>(entity);
+		Locator::livingActionSystem::value().VillagerSetState(action, LivingAction::Index::Top,
+		                                                      VillagerStates::DecideWhatToDo, true);
 	}
 	return 0;
 }
@@ -126,7 +204,10 @@ const static std::array<VillagerStateTableEntry, static_cast<size_t>(VillagerSta
     /* INVALID_STATE */ VillagerStateTableEntry {
         .state = &VillagerInvalidState,
     },
-    /* MOVE_TO_POS */ k_TodoEntry,
+    /* MOVE_TO_POS */
+    VillagerStateTableEntry {
+        .state = &VillagerMoveToPos,
+    },
     /* MOVE_TO_OBJECT */ k_TodoEntry,
     /* MOVE_ON_STRUCTURE */ k_TodoEntry,
     /* IN_SCRIPT */ k_TodoEntry,
@@ -292,7 +373,10 @@ const static std::array<VillagerStateTableEntry, static_cast<size_t>(VillagerSta
     /* TURN_TO_FACE_CREATURE_REACTION */ k_TodoEntry,
     /* WATCH_FLYING_OBJECT_REACTION */ k_TodoEntry,
     /* POINT_AT_FLYING_OBJECT_REACTION */ k_TodoEntry,
-    /* DECIDE_WHAT_TO_DO */ k_TodoEntry,
+    /* DECIDE_WHAT_TO_DO */
+    VillagerStateTableEntry {
+        .state = &VillagerDecideWhatToDo,
+    },
     /* INTERACT_DECIDE_WHAT_TO_DO */ k_TodoEntry,
     /* EAT_OUTSIDE */ k_TodoEntry,
     /* RUN_AWAY_FROM_OBJECT_REACTION */ k_TodoEntry,
@@ -420,29 +504,35 @@ void LivingActionSystem::VillagerSetState(LivingAction& action, LivingAction::In
                                           bool skipTransition) const
 {
 	const auto previousState = static_cast<VillagerStates>(action.states.at(static_cast<size_t>(index)));
-	if (previousState != state)
+	if (previousState == state)
 	{
-		[[maybe_unused]] auto& registry = Locator::entitiesRegistry::value();
-		SPDLOG_LOGGER_TRACE(spdlog::get("ai"), "Villager #{}: Setting state {} -> {}",
-		                    static_cast<int>(registry.ToEntity(action)),
-		                    k_VillagerStateStrings.at(static_cast<size_t>(previousState)),
-		                    k_VillagerStateStrings.at(static_cast<size_t>(state)));
+		return;
+	}
 
-		if (index == LivingAction::Index::Top)
-		{
-			action.turnsSinceStateChange = 0;
-			if (skipTransition)
-			{
-				return;
-			}
+	[[maybe_unused]] auto& registry = Locator::entitiesRegistry::value();
+	SPDLOG_LOGGER_TRACE(spdlog::get("ai"), "Villager #{}: Setting state {} -> {}",
+	                    static_cast<int>(registry.ToEntity(action)),
+	                    k_VillagerStateStrings.at(static_cast<size_t>(previousState)),
+	                    k_VillagerStateStrings.at(static_cast<size_t>(state)));
 
-			if (VillagerCallExitState(action, index))
-			{
-				return;
-			}
+	const bool runTransition = index == LivingAction::Index::Top && !skipTransition;
 
-			VillagerCallEntryState(action, index, previousState, state);
-		}
+	// Exit the previous state before switching. A truthy return means it isn't ready to be
+	// left yet, so abort the transition without changing state.
+	if (runTransition && VillagerCallExitState(action, index))
+	{
+		return;
+	}
+
+	if (index == LivingAction::Index::Top)
+	{
+		action.turnsSinceStateChange = 0;
+	}
+	action.states.at(static_cast<size_t>(index)) = static_cast<uint8_t>(state);
+
+	if (runTransition)
+	{
+		VillagerCallEntryState(action, index, previousState, state);
 	}
 }
 

--- a/src/ECS/Systems/Implementations/LivingActionSystem.cpp
+++ b/src/ECS/Systems/Implementations/LivingActionSystem.cpp
@@ -63,13 +63,15 @@ static constexpr uint16_t k_WanderCooldownTurns = 20;
 static constexpr float k_WanderWorldBoundMin = 30.0f;
 static constexpr float k_WanderWorldBoundMax = 5090.0f;
 
+namespace
+{
 // PoC: pick a random nearby point and hand it to the PathfindingSystem the same way the
 // debug "Move To Point" tool does (see Debug/PathFinding.cpp), then wait in MoveToPos.
 uint32_t VillagerDecideWhatToDo(LivingAction& action)
 {
 	if (action.turnsSinceStateChange < k_WanderCooldownTurns)
 	{
-		// TODO: play a "catch breath" idle animation here (lean forward, breathe) during the cooldown
+		// TODO(WeaveCraft): play a "catch breath" idle animation here (lean forward, breathe) during the cooldown
 		// once villager animation playback exists. The transitionAnimation hook in k_VillagerStateTable
 		// is the intended home for it; the Mesh component has no animation state today.
 		return 0;
@@ -122,6 +124,7 @@ uint32_t VillagerMoveToPos(LivingAction& action)
 	}
 	return 0;
 }
+} // namespace
 
 struct VillagerStateTableEntry
 {

--- a/src/ECS/Systems/Implementations/LivingActionSystem.cpp
+++ b/src/ECS/Systems/Implementations/LivingActionSystem.cpp
@@ -117,8 +117,8 @@ uint32_t VillagerMoveToPos(LivingAction& action)
 	if (!stillMoving)
 	{
 		registry.Remove<MoveStateFinalStepTag, MoveStateArrivedTag>(entity);
-		Locator::livingActionSystem::value().VillagerSetState(action, LivingAction::Index::Top,
-		                                                      VillagerStates::DecideWhatToDo, true);
+		Locator::livingActionSystem::value().VillagerSetState(action, LivingAction::Index::Top, VillagerStates::DecideWhatToDo,
+		                                                      true);
 	}
 	return 0;
 }

--- a/src/ECS/Systems/Implementations/PathfindingSystem.cpp
+++ b/src/ECS/Systems/Implementations/PathfindingSystem.cpp
@@ -206,7 +206,7 @@ bool OrbitScanForObstacle(entt::entity entity, bool clockwise, Transform& transf
 		                         obstacleFixed.boundingRadius * obstacleFixed.boundingRadius;
 		if (closeEnough)
 		{
-			// TODO: CircleSquareSweep is unimplemented. Degrade gracefully for the wander PoC instead of
+			// TODO(WeaveCraft): CircleSquareSweep is unimplemented. Degrade gracefully for the wander PoC instead of
 			// crashing, returning out of this scope so the external following code does not run.
 			AbandonMove(registry, entity);
 			return false;

--- a/src/ECS/Systems/Implementations/PathfindingSystem.cpp
+++ b/src/ECS/Systems/Implementations/PathfindingSystem.cpp
@@ -71,8 +71,8 @@ void IterateStepAroundObstacle(Transform& transform, WallHug& wallHug, const Fix
 	InitializeStep(transform, wallHug, angle + angleStep * clockwiseModifier);
 }
 
-/// The wall-hug/orbit movement port has unfinished branches. For the villager-wander
-/// proof-of-concept we degrade gracefully instead of crashing: stop the villager where it is
+/// The wall-hug/orbit movement port has unfinished branches. To keep villager wandering
+/// working, we degrade gracefully instead of crashing: stop the villager where it is
 /// and drop all of its movement state. The LivingActionSystem's MoveToPos handler then sees no
 /// active move tags, treats the villager as "arrived", and picks a new destination.
 void AbandonMove(ecs::Registry& registry, entt::entity entity)
@@ -206,7 +206,7 @@ bool OrbitScanForObstacle(entt::entity entity, bool clockwise, Transform& transf
 		                         obstacleFixed.boundingRadius * obstacleFixed.boundingRadius;
 		if (closeEnough)
 		{
-			// TODO(WeaveCraft): CircleSquareSweep is unimplemented. Degrade gracefully for the wander PoC instead of
+			// TODO(#864): CircleSquareSweep is unimplemented. Degrade gracefully instead of
 			// crashing, returning out of this scope so the external following code does not run.
 			AbandonMove(registry, entity);
 			return false;
@@ -284,8 +284,8 @@ bool OrbitScanForObstacle(entt::entity entity, bool clockwise, Transform& transf
 
 					if (t < 0)
 					{
-						// Unfinished orbit geometry produced a negative step count. Degrade gracefully for
-						// the wander PoC (bail out of the scan) rather than asserting and crashing.
+						// Unfinished orbit geometry produced a negative step count. Degrade gracefully
+						// (bail out of the scan) rather than asserting and crashing.
 						AbandonMove(registry, entity);
 						return false;
 					}
@@ -420,7 +420,7 @@ void PathfindingSystem::Update()
 
 	// 3.  ORBIT_CW, ORBIT_CCW, EXIT_CIRCLE_CW, EXIT_CIRCLE_CCW:
 	//         Orbiting requires a recorded obstacle to hug. Handling a missing one is unimplemented
-	//         in the port; for the wander PoC, abandon those moves instead of crashing. Collect
+	//         in the port; abandon those moves instead of crashing. Collect
 	//         first, then remove, so we never mutate the pool being iterated for a non-current entity.
 	{
 		std::vector<entt::entity> missingObstacle;
@@ -489,7 +489,7 @@ void PathfindingSystem::Update()
 	registry.Each<const MoveStateOrbitTag>([&registry](entt::entity entity, [[maybe_unused]] const MoveStateOrbitTag& state) {
 		if (!registry.AnyOf<WallHugObjectReference>(entity))
 		{
-			// TODO: circle-to-circle transition is unimplemented. Degrade gracefully for the wander PoC.
+			// TODO(#865): circle-to-circle transition is unimplemented. Degrade gracefully.
 			AbandonMove(registry, entity);
 		}
 	});

--- a/src/ECS/Systems/Implementations/PathfindingSystem.cpp
+++ b/src/ECS/Systems/Implementations/PathfindingSystem.cpp
@@ -12,6 +12,7 @@
 #include "PathfindingSystem.h"
 
 #include <optional>
+#include <vector>
 
 #include <entt/entity/entity.hpp>
 #include <glm/gtx/euler_angles.hpp>
@@ -70,9 +71,16 @@ void IterateStepAroundObstacle(Transform& transform, WallHug& wallHug, const Fix
 	InitializeStep(transform, wallHug, angle + angleStep * clockwiseModifier);
 }
 
-void InCircleHugWithoutObject()
+/// The wall-hug/orbit movement port has unfinished branches. For the villager-wander
+/// proof-of-concept we degrade gracefully instead of crashing: stop the villager where it is
+/// and drop all of its movement state. The LivingActionSystem's MoveToPos handler then sees no
+/// active move tags, treats the villager as "arrived", and picks a new destination.
+void AbandonMove(ecs::Registry& registry, entt::entity entity)
 {
-	throw std::runtime_error("TODO: Handle case of orbiting without an object to orbit");
+	SPDLOG_LOGGER_WARN(spdlog::get("pathfinding"), "Villager #{}: unimplemented pathfinding case hit, abandoning move",
+	                   static_cast<uint32_t>(entity));
+	registry.Remove<MoveStateLinearTag, MoveStateOrbitTag, MoveStateExitCircleTag, MoveStateStepThroughTag,
+	                MoveStateFinalStepTag, MoveStateArrivedTag, WallHugObjectReference>(entity);
 }
 bool AreWeThere(const glm::vec2& pos, const glm::vec2& goal, float threshold)
 {
@@ -198,8 +206,10 @@ bool OrbitScanForObstacle(entt::entity entity, bool clockwise, Transform& transf
 		                         obstacleFixed.boundingRadius * obstacleFixed.boundingRadius;
 		if (closeEnough)
 		{
-			throw std::runtime_error("TODO: CircleSquareSweep");
-			// Needs to return out of this scope and not run the external following code
+			// TODO: CircleSquareSweep is unimplemented. Degrade gracefully for the wander PoC instead of
+			// crashing, returning out of this scope so the external following code does not run.
+			AbandonMove(registry, entity);
+			return false;
 		}
 
 		for (const auto& c : GetNeighboringCells(glm::xz(transform.position)))
@@ -272,7 +282,13 @@ bool OrbitScanForObstacle(entt::entity entity, bool clockwise, Transform& transf
 					const auto t1 = angle1 * 2.0f / 3.0f * r1 / wallHug.speed;
 					int t = static_cast<int>(glm::round(glm::min(t0, t1)));
 
-					assert(t >= 0);
+					if (t < 0)
+					{
+						// Unfinished orbit geometry produced a negative step count. Degrade gracefully for
+						// the wander PoC (bail out of the scan) rather than asserting and crashing.
+						AbandonMove(registry, entity);
+						return false;
+					}
 					if (t < 1)
 					{
 						// We're too close to second circle. Act like we're on the second circle and continue looking forward by
@@ -403,35 +419,31 @@ void PathfindingSystem::Update()
 	    entt::exclude<WallHugObjectReference>);
 
 	// 3.  ORBIT_CW, ORBIT_CCW, EXIT_CIRCLE_CW, EXIT_CIRCLE_CCW:
-	//         If there is no recorded obstacle (what we orbit), this is an unimplemented error
-	//         exclude from next parts
-	registry.Each<const MoveStateOrbitTag>([&registry](entt::entity entity, [[maybe_unused]] const MoveStateOrbitTag& state) {
-		if (!registry.AllOf<WallHugObjectReference>(entity))
+	//         Orbiting requires a recorded obstacle to hug. Handling a missing one is unimplemented
+	//         in the port; for the wander PoC, abandon those moves instead of crashing. Collect
+	//         first, then remove, so we never mutate the pool being iterated for a non-current entity.
+	{
+		std::vector<entt::entity> missingObstacle;
+		const auto collectIfNoObstacle = [&registry, &missingObstacle](entt::entity entity) {
+			if (!registry.AllOf<WallHugObjectReference>(entity) ||
+			    registry.Get<WallHugObjectReference>(entity).entity == entt::null)
+			{
+				missingObstacle.push_back(entity);
+			}
+		};
+		registry.Each<const MoveStateOrbitTag>(
+		    [&collectIfNoObstacle](entt::entity entity, [[maybe_unused]] const MoveStateOrbitTag& state) {
+			    collectIfNoObstacle(entity);
+		    });
+		registry.Each<const MoveStateExitCircleTag>(
+		    [&collectIfNoObstacle](entt::entity entity, [[maybe_unused]] const MoveStateExitCircleTag& state) {
+			    collectIfNoObstacle(entity);
+		    });
+		for (const auto entity : missingObstacle)
 		{
-			InCircleHugWithoutObject();
+			AbandonMove(registry, entity);
 		}
-	});
-	registry.Each<const MoveStateOrbitTag, const WallHugObjectReference>(
-	    []([[maybe_unused]] const MoveStateOrbitTag& state, const WallHugObjectReference& object) {
-		    if (object.entity == entt::null)
-		    {
-			    InCircleHugWithoutObject();
-		    }
-	    });
-	registry.Each<const MoveStateExitCircleTag>(
-	    [&registry](entt::entity entity, [[maybe_unused]] const MoveStateExitCircleTag& state) {
-		    if (!registry.AllOf<WallHugObjectReference>(entity))
-		    {
-			    InCircleHugWithoutObject();
-		    }
-	    });
-	registry.Each<const MoveStateExitCircleTag, const WallHugObjectReference>(
-	    []([[maybe_unused]] const MoveStateExitCircleTag& state, const WallHugObjectReference& object) {
-		    if (object.entity == entt::null)
-		    {
-			    InCircleHugWithoutObject();
-		    }
-	    });
+	}
 
 	// 4a. STEP_THROUGH, EXIT_CIRCLE_CW, EXIT_CIRCLE_CCW, LINEAR without obstacles:
 	//         Do StepForward and ApplyStepGoal for the step distance -> no change to state
@@ -477,7 +489,8 @@ void PathfindingSystem::Update()
 	registry.Each<const MoveStateOrbitTag>([&registry](entt::entity entity, [[maybe_unused]] const MoveStateOrbitTag& state) {
 		if (!registry.AnyOf<WallHugObjectReference>(entity))
 		{
-			throw std::runtime_error("TODO: probably transitioning to another circle, scan and select new reference");
+			// TODO: circle-to-circle transition is unimplemented. Degrade gracefully for the wander PoC.
+			AbandonMove(registry, entity);
 		}
 	});
 	ApplyStepGoal<MoveState::Orbit>(registry);

--- a/src/ECS/Systems/Implementations/TownSystem.cpp
+++ b/src/ECS/Systems/Implementations/TownSystem.cpp
@@ -53,7 +53,8 @@ entt::entity TownSystem::FindClosestTown(const glm::vec3& point) const
 
 	registry.Each<const Town, const Transform>(
 	    [&point, &result, &closest](entt::entity entity, [[maybe_unused]] auto& town, [[maybe_unused]] auto& transform) {
-		    float distance2 = glm::dot(point, transform.position);
+		    const auto delta = point - transform.position;
+		    const float distance2 = glm::dot(delta, delta);
 		    if (distance2 < closest)
 		    {
 			    closest = distance2;


### PR DESCRIPTION
Hey! I've been working on getting villagers to actually move around in the game. 

The main thing was that VillagerSetState never wrote the new state into action.states, so villagers were stuck in Created forever. Once that was fixed I added DecideWhatToDo and MoveToPos handlers so they actually wander around. They pick a random point within a radius of their village center and walk there, then pick a new one after a short cooldown.

Along the way I found that WallHug had a constructor argument mismatch where speed was landing in yAngle, so every villager had zero speed. 
Fixed FindClosestTown which was using dot(point, position) instead of dot(delta, delta) for distance calculation, causing villagers to run to the wrong town.

The PathfindingSystem had a few throw std::runtime_error("TODO") and an assert(t >= 0) that would crash the game when villagers hit unfinished pathfinding cases. Replaced those with a graceful AbandonMove that just stops the villager and lets them pick a new destination instead of crashing.

Tested on Land 1 and Land 2 with different tribes.