### PR TITLE
feat(chl): implement SET_FOCUS object facing

### DIFF
--- a/src/CHLApi.cpp
+++ b/src/CHLApi.cpp
@@ -20,6 +20,10 @@
 #include <LHVMTypes.h>
 #include <entt/entity/entity.hpp>
 #include <entt/entity/fwd.hpp>
+#include <glm/geometric.hpp>
+#include <glm/gtc/constants.hpp>
+#include <glm/gtx/euler_angles.hpp>
+#include <glm/vec2.hpp>
 #include <glm/vec3.hpp>
 #include <spdlog/spdlog.h>
 
@@ -475,10 +479,29 @@ void MoveGameThing() // 033 MOVE_GAME_THING
 
 void SetFocus() // 034 SET_FOCUS
 {
-	// const auto position = PopVec();
-	// const auto object = Pop().uintVal;
-	// TODO(Daniels118): implement this
-	SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "CHLApi Function {}() not implemented.", __func__);
+	const auto position = PopVec();
+	const auto object = Pop().uintVal;
+
+	if (object == 0)
+	{
+		return;
+	}
+
+	auto& registry = Locator::entitiesRegistry::value();
+	auto* transform = registry.TryGet<Transform>(static_cast<entt::entity>(object));
+	if (transform == nullptr)
+	{
+		return;
+	}
+
+	const glm::vec2 direction(position.x - transform->position.x, position.z - transform->position.z);
+	if (glm::dot(direction, direction) == 0.0f)
+	{
+		return;
+	}
+
+	const auto angle = std::atan2(direction.y, direction.x);
+	transform->rotation = glm::eulerAngleY(-angle - glm::half_pi<float>());
 }
 
 void HasCameraArrived() // 035 HAS_CAMERA_ARRIVED

--- a/src/CHLApi.cpp
+++ b/src/CHLApi.cpp
@@ -31,7 +31,10 @@
 #include "3D/TempleInteriorInterface.h"
 #include "Camera/Camera.h"
 #include "ECS/Archetypes/MobileStaticArchetype.h"
+#include "ECS/Components/Creature.h"
+#include "ECS/Components/Town.h"
 #include "ECS/Components/Transform.h"
+#include "ECS/Components/WallHug.h"
 #include "ECS/Registry.h"
 #include "ECS/Systems/HandSystemInterface.h"
 #include "Enums.h"
@@ -45,7 +48,10 @@ using namespace openblack::ecs::archetypes;
 
 using openblack::Locator;
 using openblack::MobileStaticInfo;
+using openblack::ecs::components::Creature;
+using openblack::ecs::components::Town;
 using openblack::ecs::components::Transform;
+using openblack::ecs::components::WallHug;
 using openblack::ecs::systems::HandSystemInterface;
 using openblack::lhvm::DataType;
 using openblack::lhvm::VMValue;
@@ -484,24 +490,48 @@ void SetFocus() // 034 SET_FOCUS
 
 	if (object == 0)
 	{
+		SPDLOG_LOGGER_WARN(spdlog::get("scripting"), "CHLApi Function {}(): Thing no longer valid", __func__);
 		return;
 	}
 
+	const auto entity = static_cast<entt::entity>(object);
 	auto& registry = Locator::entitiesRegistry::value();
-	auto* transform = registry.TryGet<Transform>(static_cast<entt::entity>(object));
+	auto* transform = registry.TryGet<Transform>(entity);
+	// Vanilla rejects anything that is not an Object; without an Object class, a missing Transform is the nearest check
 	if (transform == nullptr)
 	{
+		SPDLOG_LOGGER_ERROR(spdlog::get("scripting"), "CHLApi Function {}(): Thing must be living to face position!", __func__);
 		return;
 	}
 
-	const glm::vec2 direction(position.x - transform->position.x, position.z - transform->position.z);
-	if (glm::dot(direction, direction) == 0.0f)
+	// Vanilla applies SetFocus to every member of a script container (Town/Flock/Dance) instead of the container itself
+	if (registry.AllOf<Town>(entity))
 	{
+		SPDLOG_LOGGER_WARN(spdlog::get("scripting"), "CHLApi Function {}(): script container focus not implemented", __func__);
 		return;
 	}
 
+	// Vanilla dispatches creatures to Creature::SetFocus (BW1W120 0x004f6760), which does not turn them on the spot.
+	// That override is not decompiled yet, so apply nothing rather than the generic rotation
+	if (registry.AllOf<Creature>(entity))
+	{
+		SPDLOG_LOGGER_WARN(spdlog::get("scripting"), "CHLApi Function {}(): creature focus not implemented", __func__);
+		return;
+	}
+
+	// Object::SetFocus: yaw from the horizontal offset with no zero-distance guard, atan2(0, 0) == 0
+	const glm::vec2 direction(position.x - transform->position.x, position.z - transform->position.z);
 	const auto angle = std::atan2(direction.y, direction.x);
+	// Same angle-to-rotation mapping as PathfindingSystem's InitializeStep, so facing a point matches walking towards it
 	transform->rotation = glm::eulerAngleY(-angle - glm::half_pi<float>());
+
+	// Vanilla's virtual SetYAngle lets MobileWallHug keep its own angle in sync. Only the angle is mirrored: that override
+	// is not decompiled and step is the pathfinder's per-tick movement, not orientation
+	auto* wallHug = registry.TryGet<WallHug>(entity);
+	if (wallHug != nullptr)
+	{
+		wallHug->yAngle = angle;
+	}
 }
 
 void HasCameraArrived() // 035 HAS_CAMERA_ARRIVED

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,6 +44,8 @@ openblack_setup_and_add_test(test_load_scene test_load_scene.cpp)
 openblack_setup_and_add_test(test_fixed test_fixed.cpp)
 openblack_setup_and_add_test(test_interpolator test_interpolator.cpp)
 openblack_setup_and_add_test(test_set_camera_pos camera/test_set_camera_pos.cpp)
+openblack_setup_and_add_test(test_chlapi_set_focus chlapi/test_set_focus.cpp)
+target_link_libraries(test_chlapi_set_focus PRIVATE ScriptLibrary)
 openblack_setup_and_add_json_test(
   test_mobile_wall_hug mobile_wall_hug/test_mobile_wall_hug.cpp
 )

--- a/test/chlapi/test_set_focus.cpp
+++ b/test/chlapi/test_set_focus.cpp
@@ -38,7 +38,7 @@ constexpr size_t k_SetFocusFunctionId = 34;
 
 void ExpectMatrixNear(const glm::mat3& actual, const glm::mat3& expected)
 {
-	for (glm::length_t column = 0; column < actual.length(); ++column)
+	for (glm::length_t column = 0; column < glm::mat3::length(); ++column)
 	{
 		for (glm::length_t row = 0; row < actual[column].length(); ++row)
 		{

--- a/test/chlapi/test_set_focus.cpp
+++ b/test/chlapi/test_set_focus.cpp
@@ -16,8 +16,12 @@
 #include <utility>
 
 #include <CHLApi.h>
+#include <ECS/Components/Creature.h>
+#include <ECS/Components/Town.h>
 #include <ECS/Components/Transform.h>
+#include <ECS/Components/WallHug.h>
 #include <ECS/Registry.h>
+#include <Enums.h>
 #include <Game.h>
 #include <LHVM.h>
 #include <Locator.h>
@@ -25,6 +29,7 @@
 #include <glm/gtc/constants.hpp>
 #include <glm/gtx/euler_angles.hpp>
 #include <glm/mat3x3.hpp>
+#include <glm/vec2.hpp>
 #include <glm/vec3.hpp>
 #include <gtest/gtest.h>
 
@@ -106,12 +111,70 @@ TEST_F(CHLApiSetFocusTest, TurnsObjectTowardsPositionOnHorizontalPlane)
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables): external macro
-TEST_F(CHLApiSetFocusTest, KeepsRotationWhenFocusHasSameHorizontalPosition)
+TEST_F(CHLApiSetFocusTest, TurnsObjectTowardsDiagonalPosition)
 {
-	const auto initialRotation = glm::mat3(glm::eulerAngleY(0.75f));
-	const auto entity = CreateObject(glm::vec3(10.0f, 2.0f, 20.0f), initialRotation);
+	// Direction (10, 10) gives atan2 == pi / 4, so this pins the sign of the angle in the rotation
+	const auto entity = CreateObject(glm::vec3(10.0f, 0.0f, 20.0f), glm::mat3(1.0f));
+
+	InvokeSetFocus(entity, glm::vec3(20.0f, 0.0f, 30.0f));
+
+	const auto& transform = Locator::entitiesRegistry::value().Get<const Transform>(entity);
+	ExpectMatrixNear(transform.rotation, glm::mat3(glm::eulerAngleY(-glm::quarter_pi<float>() - glm::half_pi<float>())));
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables): external macro
+TEST_F(CHLApiSetFocusTest, FacesAngleZeroWhenFocusHasSameHorizontalPosition)
+{
+	// Mirrors vanilla Object::SetFocus, which has no zero-distance guard: atan2(0, 0) == 0
+	const auto entity = CreateObject(glm::vec3(10.0f, 2.0f, 20.0f), glm::mat3(glm::eulerAngleY(0.75f)));
 
 	InvokeSetFocus(entity, glm::vec3(10.0f, 100.0f, 20.0f));
+
+	const auto& transform = Locator::entitiesRegistry::value().Get<const Transform>(entity);
+	ExpectMatrixNear(transform.rotation, glm::mat3(glm::eulerAngleY(-glm::half_pi<float>())));
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables): external macro
+TEST_F(CHLApiSetFocusTest, DoesNotRotateCreature)
+{
+	// Vanilla dispatches creatures to Creature::SetFocus, which does not turn them on the spot
+	const auto initialRotation = glm::mat3(glm::eulerAngleY(0.75f));
+	const auto entity = CreateObject(glm::vec3(10.0f, 0.0f, 20.0f), initialRotation);
+	Locator::entitiesRegistry::value().Assign<Creature>(entity, PlayerNames::PLAYER_ONE, CreatureType::Cow, entt::id_type {0});
+
+	InvokeSetFocus(entity, glm::vec3(20.0f, 0.0f, 30.0f));
+
+	const auto& transform = Locator::entitiesRegistry::value().Get<const Transform>(entity);
+	ExpectMatrixNear(transform.rotation, initialRotation);
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables): external macro
+TEST_F(CHLApiSetFocusTest, UpdatesWallHugAngle)
+{
+	const auto entity = CreateObject(glm::vec3(10.0f, 0.0f, 20.0f), glm::mat3(1.0f));
+	Locator::entitiesRegistry::value().Assign<WallHug>(entity, glm::vec2(), glm::vec2(), 0.0f, 1.0f);
+
+	InvokeSetFocus(entity, glm::vec3(20.0f, 0.0f, 30.0f));
+
+	const auto& registry = Locator::entitiesRegistry::value();
+	const auto& transform = registry.Get<const Transform>(entity);
+	const auto& wallHug = registry.Get<const WallHug>(entity);
+	EXPECT_FLOAT_EQ(wallHug.yAngle, glm::quarter_pi<float>());
+	// step is the pathfinder's per-tick movement and is not touched by SET_FOCUS
+	EXPECT_FLOAT_EQ(wallHug.step.x, 0.0f);
+	EXPECT_FLOAT_EQ(wallHug.step.y, 0.0f);
+	ExpectMatrixNear(transform.rotation, glm::mat3(glm::eulerAngleY(-glm::quarter_pi<float>() - glm::half_pi<float>())));
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables): external macro
+TEST_F(CHLApiSetFocusTest, DoesNotRotateScriptContainer)
+{
+	// Vanilla applies SetFocus to a town's members, never to the town itself
+	const auto initialRotation = glm::mat3(glm::eulerAngleY(0.75f));
+	const auto entity = CreateObject(glm::vec3(10.0f, 0.0f, 20.0f), initialRotation);
+	Locator::entitiesRegistry::value().Assign<Town>(entity, 0u);
+
+	InvokeSetFocus(entity, glm::vec3(20.0f, 0.0f, 30.0f));
 
 	const auto& transform = Locator::entitiesRegistry::value().Get<const Transform>(entity);
 	ExpectMatrixNear(transform.rotation, initialRotation);

--- a/test/chlapi/test_set_focus.cpp
+++ b/test/chlapi/test_set_focus.cpp
@@ -1,0 +1,132 @@
+/******************************************************************************
+ * Copyright (c) 2018-2026 openblack developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/openblack/openblack
+ *
+ * openblack is licensed under the GNU General Public License version 3.
+ *******************************************************************************/
+
+#include <cstddef>
+#include <cstdint>
+
+#include <algorithm>
+#include <filesystem>
+#include <memory>
+#include <utility>
+
+#include <CHLApi.h>
+#include <ECS/Components/Transform.h>
+#include <ECS/Registry.h>
+#include <Game.h>
+#include <LHVM.h>
+#include <Locator.h>
+#include <entt/entity/entity.hpp>
+#include <glm/gtc/constants.hpp>
+#include <glm/gtx/euler_angles.hpp>
+#include <glm/mat3x3.hpp>
+#include <glm/vec3.hpp>
+#include <gtest/gtest.h>
+
+using namespace openblack;
+using namespace openblack::ecs::components;
+
+namespace
+{
+
+constexpr size_t k_SetFocusFunctionId = 34;
+
+void ExpectMatrixNear(const glm::mat3& actual, const glm::mat3& expected)
+{
+	for (glm::length_t column = 0; column < actual.length(); ++column)
+	{
+		for (glm::length_t row = 0; row < actual[column].length(); ++row)
+		{
+			EXPECT_NEAR(actual[column][row], expected[column][row], 0.0001f);
+		}
+	}
+}
+
+class CHLApiSetFocusTest: public ::testing::Test
+{
+protected:
+	void SetUp() override
+	{
+		static const auto mockGamePath = std::filesystem::path(TEST_BINARY_DIR) / "mock";
+		auto args = Arguments {
+		    .graphicsBackend = GraphicsBackend::Noop,
+		    .gamePath = mockGamePath.string(),
+		    .numFramesToSimulate = 0,
+		    .logFile = "stdout",
+		};
+		std::fill_n(args.logLevels.begin(), args.logLevels.size(), spdlog::level::warn);
+		_game = std::make_unique<Game>(std::move(args));
+		ASSERT_TRUE(_game->Initialize());
+
+		const auto& function = Locator::chlapi::value().GetFunctionsTable().at(k_SetFocusFunctionId);
+		ASSERT_EQ(function.name, "SET_FOCUS");
+	}
+
+	void TearDown() override { _game.reset(); }
+
+	static entt::entity CreateObject(const glm::vec3& position, const glm::mat3& rotation)
+	{
+		auto& registry = Locator::entitiesRegistry::value();
+		auto entity = registry.Create();
+		if (entity == static_cast<entt::entity>(0))
+		{
+			entity = registry.Create();
+		}
+		registry.Assign<Transform>(entity, position, rotation, glm::vec3(1.0f));
+		return entity;
+	}
+
+	static void InvokeSetFocus(entt::entity entity, const glm::vec3& position)
+	{
+		auto& vm = Locator::vm::value();
+		vm.Pusho(static_cast<uint32_t>(entity));
+		vm.Pushv(position.x);
+		vm.Pushv(position.y);
+		vm.Pushv(position.z);
+		Locator::chlapi::value().GetFunctionsTable().at(k_SetFocusFunctionId).impl();
+	}
+
+	std::unique_ptr<Game> _game;
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables): external macro
+TEST_F(CHLApiSetFocusTest, TurnsObjectTowardsPositionOnHorizontalPlane)
+{
+	const auto entity = CreateObject(glm::vec3(10.0f, 2.0f, 20.0f), glm::mat3(1.0f));
+
+	InvokeSetFocus(entity, glm::vec3(20.0f, 100.0f, 20.0f));
+
+	const auto& transform = Locator::entitiesRegistry::value().Get<const Transform>(entity);
+	ExpectMatrixNear(transform.rotation, glm::mat3(glm::eulerAngleY(-glm::half_pi<float>())));
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables): external macro
+TEST_F(CHLApiSetFocusTest, KeepsRotationWhenFocusHasSameHorizontalPosition)
+{
+	const auto initialRotation = glm::mat3(glm::eulerAngleY(0.75f));
+	const auto entity = CreateObject(glm::vec3(10.0f, 2.0f, 20.0f), initialRotation);
+
+	InvokeSetFocus(entity, glm::vec3(10.0f, 100.0f, 20.0f));
+
+	const auto& transform = Locator::entitiesRegistry::value().Get<const Transform>(entity);
+	ExpectMatrixNear(transform.rotation, initialRotation);
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables): external macro
+TEST_F(CHLApiSetFocusTest, IgnoresMissingObject)
+{
+	InvokeSetFocus(static_cast<entt::entity>(123456), glm::vec3(20.0f, 2.0f, 20.0f));
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables): external macro
+TEST_F(CHLApiSetFocusTest, IgnoresNullObject)
+{
+	InvokeSetFocus(static_cast<entt::entity>(0), glm::vec3(20.0f, 2.0f, 20.0f));
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

Implement the missing CHL `SET_FOCUS` native by turning the target object toward a supplied horizontal world coordinate.

The original native metadata identifies function 34 as an object-and-coordinate operation, separate from the camera-focus natives. A Four Gods runtime audit encountered the missing function 46 times in 600 unpaused frames.

## Changes

- Pop the target coordinate and object from the VM stack.
- Follow `GScript::SetFocus` from bw1-decomp: warn on a null thing, error on a thing that cannot face a position, and leave script containers and creatures alone.
- Rotate other entities towards the target's horizontal position using openblack's pathfinding orientation convention, with no zero-distance guard, as in `Object::SetFocus`.
- Keep a wall-hugging entity's `WallHug::yAngle` in step with its transform.
- Coverage: native-table wiring, horizontal and diagonal facing (the latter pins the rotation sign), the unguarded zero-distance case, and creature, town and wall-hug entities.

## Scope

`Creature::SetFocus` (`BW1W120 0x004f6760`) is not decompiled yet and vanilla does not turn a creature on the spot, so creatures are logged and skipped rather than rotated. The Town/Flock/Dance member fan-out has no openblack equivalent yet. Camera behaviour is unchanged.

## Validation

- `clang-format-19` dry-run: passed.
- `git diff --check`: passed.
- Debug build: passed.
- CTest: 8/8 passed.
- Four Gods real-asset run: 600 unpaused frames, exit 0, with no remaining `SET_FOCUS` unimplemented errors.
- Interactive Land 1 real-asset run: exited 0 with no fatal or assertion errors.

## References

- [CHL native-function metadata](https://github.com/Daniels118/blackandwhite/blob/main/chlasm/src/it/ld/bw/chl/model/NativeFunction.java)
- [Object `SetFocus` declaration in bw1-decomp](https://github.com/openblack/bw1-decomp/blob/main/src/Black/Object.h)

## Collaboration disclosure

This change was developed collaboratively by Jack Hollister and OpenAI Codex (GPT-5.6) for the initial revision, and Claude Opus 5 (Claude Code) for the September 2026 revision.
